### PR TITLE
feat: add dark mode toggle to serve webapp

### DIFF
--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -4,32 +4,58 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{.Title}} — Lathe</title>
+  <script>
+    (function(){
+      try {
+        var saved = localStorage.getItem('lathe-theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) {}
+    })();
+  </script>
   <style>
+    :root{
+      --bg:#f9fafb;--surface:#fff;--border:#e5e7eb;--text:#111827;--text-muted:#374151;--text-subtle:#4b5563;--text-faint:#6b7280;
+      --hover-bg:#f3f4f6;--active-bg:#eff6ff;--active-text:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;--blockquote-border:#d1d5db;
+      --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
+      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;
+    }
+    [data-theme="dark"]{
+      --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-muted:#cbd5e1;--text-subtle:#9ca3af;--text-faint:#9ca3af;
+      --hover-bg:#222632;--active-bg:#1e2a44;--active-text:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;--blockquote-border:#374151;
+      --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
+      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;
+    }
     *{box-sizing:border-box;margin:0;padding:0}
-    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f9fafb;color:#111827;line-height:1.6}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
     .layout{display:flex;min-height:100vh}
-    nav{width:260px;background:#fff;border-right:1px solid #e5e7eb;padding:1.5rem;position:sticky;top:0;height:100vh;overflow-y:auto;flex-shrink:0}
-    nav h2{font-size:.9rem;font-weight:600;color:#374151;margin-bottom:.5rem;line-height:1.4}
+    nav{width:260px;background:var(--surface);border-right:1px solid var(--border);padding:1.5rem;position:sticky;top:0;height:100vh;overflow-y:auto;flex-shrink:0;display:flex;flex-direction:column}
+    nav h2{font-size:.9rem;font-weight:600;color:var(--text-muted);margin-bottom:.5rem;line-height:1.4}
     .badge{display:inline-block;font-size:.7rem;padding:.2rem .5rem;border-radius:4px;margin-bottom:1.25rem}
-    .badge.verified{background:#d1fae5;color:#065f46}
-    .badge.verifying{background:#fef3c7;color:#92400e}
-    .badge.failed{background:#fee2e2;color:#991b1b}
+    .badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
+    .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
+    .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
     nav ul{list-style:none}
     nav li{margin:.2rem 0}
-    nav a{display:block;font-size:.85rem;color:#4b5563;text-decoration:none;padding:.35rem .6rem;border-radius:5px}
-    nav a:hover{background:#f3f4f6;color:#111827}
-    nav a.active{background:#eff6ff;color:#1d4ed8;font-weight:500}
+    nav a{display:block;font-size:.85rem;color:var(--text-subtle);text-decoration:none;padding:.35rem .6rem;border-radius:5px}
+    nav a:hover{background:var(--hover-bg);color:var(--text)}
+    nav a.active{background:var(--active-bg);color:var(--active-text);font-weight:500}
+    .theme-toggle{margin-top:auto;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;font-size:.8rem;padding:.4rem .6rem;border-radius:5px;cursor:pointer;display:flex;align-items:center;gap:.4rem;width:100%}
+    .theme-toggle:hover{background:var(--hover-bg);color:var(--text)}
+    .theme-toggle .icon{font-size:.95rem;line-height:1}
+    [data-theme="dark"] .theme-toggle .icon-light,[data-theme="light"] .theme-toggle .icon-dark,:root:not([data-theme]) .theme-toggle .icon-dark{display:none}
     main{flex:1;max-width:760px;padding:3rem 2.5rem}
-    h1{font-size:1.9rem;margin-bottom:1.5rem;color:#111827}
-    h2{font-size:1.4rem;margin:2rem 0 .75rem;color:#1f2937}
-    h3{font-size:1.15rem;margin:1.75rem 0 .6rem;color:#374151}
-    p{margin-bottom:1rem;color:#374151}
-    code{font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em;background:#f3f4f6;padding:.1rem .35rem;border-radius:3px;color:#1f2937}
-    pre{border-radius:8px;margin:1.25rem 0;overflow-x:auto}
+    h1{font-size:1.9rem;margin-bottom:1.5rem;color:var(--text)}
+    h2{font-size:1.4rem;margin:2rem 0 .75rem;color:var(--text)}
+    h3{font-size:1.15rem;margin:1.75rem 0 .6rem;color:var(--text-muted)}
+    p{margin-bottom:1rem;color:var(--text-muted)}
+    code{font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em;background:var(--code-bg);padding:.1rem .35rem;border-radius:3px;color:var(--code-text)}
+    pre{border-radius:8px;margin:1.25rem 0;overflow-x:auto;border:1px solid var(--border)}
     pre code{background:none;padding:0;color:inherit;font-size:.875rem}
-    ul,ol{margin:.75rem 0 .75rem 1.5rem;color:#374151}
+    ul,ol{margin:.75rem 0 .75rem 1.5rem;color:var(--text-muted)}
     li{margin:.25rem 0}
-    blockquote{border-left:3px solid #d1d5db;padding:.5rem 1rem;margin:1rem 0;color:#6b7280}
+    blockquote{border-left:3px solid var(--blockquote-border);padding:.5rem 1rem;margin:1rem 0;color:var(--text-faint)}
   </style>
 </head>
 <body>
@@ -47,8 +73,31 @@
       {{end}}
     </ul>
     {{end}}
+    <button type="button" class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+      <span class="icon icon-light">☀</span><span class="icon icon-dark">☾</span>
+      <span class="label"></span>
+    </button>
   </nav>
   <main>{{.Content}}</main>
 </div>
+<script>
+  (function(){
+    var btn = document.getElementById('themeToggle');
+    if (!btn) return;
+    var label = btn.querySelector('.label');
+    function refresh(){
+      var t = document.documentElement.getAttribute('data-theme') || 'light';
+      if (label) label.textContent = t === 'dark' ? 'Light mode' : 'Dark mode';
+    }
+    refresh();
+    btn.addEventListener('click', function(){
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      try { localStorage.setItem('lathe-theme', next); } catch (e) {}
+      refresh();
+    });
+  })();
+</script>
 </body>
 </html>

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -51,8 +51,9 @@
     h3{font-size:1.15rem;margin:1.75rem 0 .6rem;color:var(--text-muted)}
     p{margin-bottom:1rem;color:var(--text-muted)}
     code{font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em;background:var(--code-bg);padding:.1rem .35rem;border-radius:3px;color:var(--code-text)}
-    pre{border-radius:8px;margin:1.25rem 0;overflow-x:auto;border:1px solid var(--border)}
-    pre code{background:none;padding:0;color:inherit;font-size:.875rem}
+    pre.chroma{border-radius:8px;margin:1.25rem 0;padding:.9rem 1rem;overflow-x:auto;border:1px solid var(--border);font-size:.875rem}
+    pre.chroma code{background:none;padding:0;color:inherit;font-size:1em}
+    {{.HighlightCSS}}
     ul,ol{margin:.75rem 0 .75rem 1.5rem;color:var(--text-muted)}
     li{margin:.25rem 0}
     blockquote{border-left:3px solid var(--blockquote-border);padding:.5rem 1rem;margin:1rem 0;color:var(--text-faint)}

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -51,8 +51,8 @@
     h3{font-size:1.15rem;margin:1.75rem 0 .6rem;color:var(--text-muted)}
     p{margin-bottom:1rem;color:var(--text-muted)}
     code{font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em;background:var(--code-bg);padding:.1rem .35rem;border-radius:3px;color:var(--code-text)}
-    pre.chroma{border-radius:8px;margin:1.25rem 0;padding:.9rem 1rem;overflow-x:auto;border:1px solid var(--border);font-size:.875rem}
-    pre.chroma code{background:none;padding:0;color:inherit;font-size:1em}
+    pre{border-radius:8px;margin:1.25rem 0;padding:.9rem 1rem;overflow-x:auto;border:1px solid var(--border);background:var(--code-bg);color:var(--code-text);font-size:.875rem}
+    pre code{background:none;padding:0;color:inherit;font-size:1em}
     {{.HighlightCSS}}
     ul,ol{margin:.75rem 0 .75rem 1.5rem;color:var(--text-muted)}
     li{margin:.25rem 0}

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -3,25 +3,61 @@
 <head>
   <meta charset="UTF-8">
   <title>Lathe — Tutorials</title>
+  <script>
+    (function(){
+      try {
+        var saved = localStorage.getItem('lathe-theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) {}
+    })();
+  </script>
   <style>
+    :root{
+      --bg:#f9fafb;--surface:#fff;--border:#e5e7eb;--text:#111827;--text-faint:#6b7280;--text-empty:#9ca3af;
+      --link:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;
+      --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
+      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;
+    }
+    [data-theme="dark"]{
+      --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-faint:#9ca3af;--text-empty:#6b7280;
+      --link:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;
+      --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
+      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;
+    }
     *{box-sizing:border-box;margin:0;padding:0}
-    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f9fafb;color:#111827;max-width:700px;margin:3rem auto;padding:0 1.5rem}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--text);max-width:700px;margin:3rem auto;padding:0 1.5rem}
+    .header{display:flex;justify-content:space-between;align-items:flex-start;gap:1rem}
     h1{font-size:1.75rem;margin-bottom:.4rem}
-    .subtitle{color:#6b7280;margin-bottom:2rem;font-size:.95rem}
-    .tutorial{background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:1.1rem 1.5rem;margin:.75rem 0;display:flex;justify-content:space-between;align-items:center}
-    .tutorial a{text-decoration:none;color:#1d4ed8;font-weight:500;font-size:1rem}
+    .subtitle{color:var(--text-faint);margin-bottom:2rem;font-size:.95rem}
+    .tutorial{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1.1rem 1.5rem;margin:.75rem 0;display:flex;justify-content:space-between;align-items:center}
+    .tutorial a{text-decoration:none;color:var(--link);font-weight:500;font-size:1rem}
     .tutorial a:hover{text-decoration:underline}
-    .meta{font-size:.8rem;color:#9ca3af;margin-top:.2rem}
+    .meta{font-size:.8rem;color:var(--text-empty);margin-top:.2rem}
     .badge{font-size:.7rem;padding:.2rem .5rem;border-radius:4px}
-    .badge.verified{background:#d1fae5;color:#065f46}
-    .badge.verifying{background:#fef3c7;color:#92400e}
-    .badge.failed{background:#fee2e2;color:#991b1b}
-    .empty{color:#9ca3af;text-align:center;padding:3rem;font-size:.95rem}
+    .badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
+    .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
+    .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
+    .empty{color:var(--text-empty);text-align:center;padding:3rem;font-size:.95rem}
+    .empty code{background:var(--code-bg);color:var(--code-text);padding:.1rem .35rem;border-radius:3px;font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em}
+    .theme-toggle{background:transparent;border:1px solid var(--border);color:var(--text-faint);font:inherit;font-size:.8rem;padding:.4rem .6rem;border-radius:5px;cursor:pointer;display:inline-flex;align-items:center;gap:.4rem;flex-shrink:0}
+    .theme-toggle:hover{color:var(--text)}
+    .theme-toggle .icon{font-size:.95rem;line-height:1}
+    [data-theme="dark"] .theme-toggle .icon-light,[data-theme="light"] .theme-toggle .icon-dark,:root:not([data-theme]) .theme-toggle .icon-dark{display:none}
   </style>
 </head>
 <body>
-<h1>Lathe</h1>
-<p class="subtitle">Your generated tutorials</p>
+<div class="header">
+  <div>
+    <h1>Lathe</h1>
+    <p class="subtitle">Your generated tutorials</p>
+  </div>
+  <button type="button" class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+    <span class="icon icon-light">☀</span><span class="icon icon-dark">☾</span>
+    <span class="label"></span>
+  </button>
+</div>
 {{if .Tutorials}}
 {{range .Tutorials}}
 <div class="tutorial">
@@ -38,5 +74,24 @@
 {{else}}
 <div class="empty">No tutorials yet. Run <code>/lathe</code> in Claude Code to generate one.</div>
 {{end}}
+<script>
+  (function(){
+    var btn = document.getElementById('themeToggle');
+    if (!btn) return;
+    var label = btn.querySelector('.label');
+    function refresh(){
+      var t = document.documentElement.getAttribute('data-theme') || 'light';
+      if (label) label.textContent = t === 'dark' ? 'Light mode' : 'Dark mode';
+    }
+    refresh();
+    btn.addEventListener('click', function(){
+      var current = document.documentElement.getAttribute('data-theme') || 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      try { localStorage.setItem('lathe-theme', next); } catch (e) {}
+      refresh();
+    });
+  })();
+</script>
 </body>
 </html>

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -45,6 +45,7 @@
     .theme-toggle:hover{color:var(--text)}
     .theme-toggle .icon{font-size:.95rem;line-height:1}
     [data-theme="dark"] .theme-toggle .icon-light,[data-theme="light"] .theme-toggle .icon-dark,:root:not([data-theme]) .theme-toggle .icon-dark{display:none}
+    {{.HighlightCSS}}
   </style>
 </head>
 <body>

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -2,16 +2,29 @@ package serve
 
 import (
 	"bytes"
+	"fmt"
+	"html/template"
+	"strings"
 
-	highlighting "github.com/yuin/goldmark-highlighting/v2"
+	"github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/yuin/goldmark"
+	highlighting "github.com/yuin/goldmark-highlighting/v2"
+)
+
+const (
+	lightStyle = "github"
+	darkStyle  = "monokai"
 )
 
 func RenderMarkdown(src []byte) ([]byte, error) {
 	md := goldmark.New(
 		goldmark.WithExtensions(
 			highlighting.NewHighlighting(
-				highlighting.WithStyle("github"),
+				highlighting.WithStyle(lightStyle),
+				highlighting.WithFormatOptions(
+					html.WithClasses(true),
+				),
 			),
 		),
 	)
@@ -20,4 +33,54 @@ func RenderMarkdown(src []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func HighlightCSS() (template.CSS, error) {
+	formatter := html.New(html.WithClasses(true))
+	var out bytes.Buffer
+
+	light := styles.Get(lightStyle)
+	if light == nil {
+		return "", fmt.Errorf("chroma style %q not found", lightStyle)
+	}
+	if err := formatter.WriteCSS(&out, light); err != nil {
+		return "", err
+	}
+
+	var darkBuf bytes.Buffer
+	dark := styles.Get(darkStyle)
+	if dark == nil {
+		return "", fmt.Errorf("chroma style %q not found", darkStyle)
+	}
+	if err := formatter.WriteCSS(&darkBuf, dark); err != nil {
+		return "", err
+	}
+	out.WriteString(scopeCSS(darkBuf.String(), `[data-theme="dark"]`))
+
+	return template.CSS(out.String()), nil
+}
+
+// scopeCSS prefixes every CSS rule in src with the given selector. It assumes
+// the chroma WriteCSS layout: one rule per line, each starting with a
+// "/* ... */" comment followed by selector and declaration block.
+func scopeCSS(src, prefix string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if line == "" {
+			b.WriteByte('\n')
+			continue
+		}
+		end := strings.LastIndex(line, "*/")
+		if end == -1 {
+			b.WriteString(line)
+			b.WriteByte('\n')
+			continue
+		}
+		b.WriteString(line[:end+2])
+		b.WriteByte(' ')
+		b.WriteString(prefix)
+		b.WriteString(line[end+2:])
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -28,4 +28,36 @@ func TestRenderMarkdown(t *testing.T) {
 	if !strings.Contains(html, "Println") {
 		t.Errorf("RenderMarkdown() code block content missing from output, got:\n%s", html)
 	}
+	if !strings.Contains(html, `class="chroma"`) {
+		t.Errorf("RenderMarkdown() should emit chroma classes (WithClasses=true), got:\n%s", html)
+	}
+}
+
+func TestHighlightCSS(t *testing.T) {
+	css, err := serve.HighlightCSS()
+	if err != nil {
+		t.Fatalf("HighlightCSS() error = %v", err)
+	}
+	s := string(css)
+	if !strings.Contains(s, ".chroma") {
+		t.Error("HighlightCSS() missing .chroma rules")
+	}
+	if !strings.Contains(s, `[data-theme="dark"] .chroma`) {
+		t.Error("HighlightCSS() missing dark-scoped rules")
+	}
+	// Light rules must not be scoped under [data-theme="dark"].
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, ".chroma") && !strings.Contains(line, `[data-theme="dark"]`) {
+			// A light rule — fine.
+			continue
+		}
+	}
+	// Spot-check that both palettes appear: github (light) uses #fff for bg,
+	// monokai (dark) uses #f8f8f2 for default fg.
+	if !strings.Contains(strings.ToLower(s), "#fff") {
+		t.Error("HighlightCSS() missing expected light-theme color")
+	}
+	if !strings.Contains(strings.ToLower(s), "#f8f8f2") {
+		t.Error("HighlightCSS() missing expected dark-theme color")
+	}
 }

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	tutorialsDir string
 	layoutTmpl   *template.Template
 	listTmpl     *template.Template
+	highlightCSS template.CSS
 }
 
 func NewServer(tutorialsDir string) *Server {
@@ -28,7 +29,11 @@ func NewServer(tutorialsDir string) *Server {
 	}
 	layoutTmpl := template.Must(template.New("layout.html").Funcs(funcMap).ParseFS(templateFS, "layout.html"))
 	listTmpl := template.Must(template.New("list.html").ParseFS(templateFS, "list.html"))
-	return &Server{tutorialsDir: tutorialsDir, layoutTmpl: layoutTmpl, listTmpl: listTmpl}
+	css, err := HighlightCSS()
+	if err != nil {
+		panic(fmt.Sprintf("lathe: failed to build syntax-highlight CSS: %v", err))
+	}
+	return &Server{tutorialsDir: tutorialsDir, layoutTmpl: layoutTmpl, listTmpl: listTmpl, highlightCSS: css}
 }
 
 func (s *Server) Handler() http.Handler {
@@ -57,7 +62,10 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		tutorials = append(tutorials, tut)
 	}
 	var buf bytes.Buffer
-	if err := s.listTmpl.Execute(&buf, map[string]any{"Tutorials": tutorials}); err != nil {
+	if err := s.listTmpl.Execute(&buf, map[string]any{
+		"Tutorials":    tutorials,
+		"HighlightCSS": s.highlightCSS,
+	}); err != nil {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return
 	}
@@ -121,10 +129,11 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 	}
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
-		"Title":       tut.Title,
-		"Tutorial":    tut,
-		"CurrentPart": part,
-		"Content":     template.HTML(content),
+		"Title":        tut.Title,
+		"Tutorial":     tut,
+		"CurrentPart":  part,
+		"Content":      template.HTML(content),
+		"HighlightCSS": s.highlightCSS,
 	}); err != nil {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Persists choice in localStorage under 'lathe-theme' and falls back
to the OS-level prefers-color-scheme. Theme is applied via an
inline script in <head> before paint to avoid a flash of light
content.