### PR TITLE
feat: encode great-tutorial craft moves into /lathe skill

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -5,112 +5,194 @@ description: Generate hands-on technical tutorials for any topic on demand. Use 
 
 # Lathe — Tutorial Generator
 
-Generate hands-on technical tutorials for any topic on demand.
+Generate hands-on technical tutorials for any topic on demand. The bar is the writing of Robert Nystrom (Crafting Interpreters), Sam Who, Julia Evans, Bartosz Ciechanowski. Match it.
 
-## When Invoked
+## When invoked
 
-The user invokes you by saying something like `/lathe "build a digital synth in Zig"` or `/lathe how to build a compiler in Rust`. Extract the topic from their message.
+The user says something like `/lathe build a digital synth in Zig` or `/lathe how to build a compiler in Rust`. Extract the topic from their message.
 
 1. Ask: **"What's your experience level going in — beginner, some familiarity, or experienced in adjacent areas?"**
-2. If the topic could mean meaningfully different things (e.g., "build a web server" — what language? embedded? full-stack?), ask one clarifying question. Otherwise proceed.
-3. Generate the tutorial(s).
+2. If the topic is genuinely ambiguous (language? scale? embedded vs. server?), ask **one** clarifying question. Otherwise skip.
+3. Decide single-tutorial vs. series.
+4. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
+5. Write.
+6. Hand off to the CLI.
 
-## Single vs Series
+## Single vs. series
 
-Generate a **series** when ALL of these are true:
-- The topic produces something non-trivial at the end (a working database, a compiler, a synth, a game engine)
-- There are 3 or more natural milestones, each producing something runnable and testable independently
-- Covering it well would exceed ~2500 words for a single post
+Generate a **series** when ALL of these hold:
 
-Generate a **single tutorial** when the topic is focused and completable in one sitting.
+- The end product is non-trivial — a working compiler, synth, database, game engine.
+- There are 3+ natural milestones, each producing something runnable independently.
+- Done well, it would exceed ~2500 words.
 
-## Tutorial Format
+Otherwise, write a **single tutorial**.
 
-Every tutorial or series part must follow this structure:
+## Pre-flight (private — do not ask the user)
+
+Before writing a single sentence, settle these in your head. They are constraints on your prose, not user-facing artifacts.
+
+- **The controlling example.** Pick one concrete artifact and stay with it. Crafting Interpreters has Lox. You might have *"a 4-voice subtractive synth playing a sustained A minor triad"* or *"a key-value store called `pebble` that survives `kill -9`"*. Don't switch examples mid-tutorial.
+- **Specific numbers.** Sample rate, buffer size, page size, table cardinality, latency budget — whatever the domain offers. Numbers are how you earn the reader's trust. Decide them now so they're consistent across parts.
+- **One controlling metaphor (optional but powerful).** A mountain. A factory line. A kitchen. If you adopt one, deploy it across at least three section transitions, then *explicitly retire it* with a wink (Nystrom: *"Henceforth, I promise to tone down the whole mountain metaphor thing."*). Don't mix metaphors silently.
+- **The closing send-off.** What do you want the reader ready to do *beyond* what you taught? Sketch the "go climb your own mountain" beat now so the body builds toward it.
+- **3–5 exercises.** Each specific enough that a motivated reader could start it in 30 seconds.
+
+## Tutorial shape
+
+Every tutorial (or series part) follows this shape, but section *titles* must be specific to the domain. Never `## Step 1: Setup`. Title the thing the section makes: `## A scanner that recognises one-character tokens`.
 
 ```
 # [Title]
 
-## What You'll Build
+[Hook — 2 to 4 paragraphs. See "Openings".]
 
-One to two paragraphs: the concrete end state, why it's interesting, what you'll understand by the end.
+## What you'll build
+
+One paragraph. The concrete end state, named with the controlling example.
 
 ## Prerequisites
 
-Bullet list of what the reader needs installed and roughly knows going in.
+Bullets: tools to install, what the reader should already roughly know.
 
-## [Step 1: Clear, active title]
+## [Specific section title — name what this section makes]
 
-Explain *why* this step exists and what problem it solves — not just what to type.
-Then show the code or command. Write it so the reader understands it, not just copies it.
+Why this exists. Then code, in small blocks, each with an insertion point.
+Aside or design note where it earns its keep.
 
-## [Step 2: ...]
-
-...
+## [...]
 
 ## Checkpoint
 
 **Run this to verify your work so far:**
-```bash
+\`\`\`bash
 <the exact command>
-```
+\`\`\`
+
 Expected output:
-```
+\`\`\`
 <what they should see>
-```
+\`\`\`
+
+## What's next            (series only, except final part)
+
+One paragraph naming the unanswered question that the next part will answer.
+
+## Exercises               (final part of a series, or a single tutorial)
+
+1. <specific>
+2. <specific>
+3. <specific>
 ```
 
-For **series**, each part must:
-- Open with "By the end of this part, you'll have [specific, concrete thing]"
-- Close with a Checkpoint section
-- Leave the reader with something working they can run
+For **series**, every part must open with *"By the end of this part, you'll have [specific, concrete thing]"* and close with a Checkpoint.
+
+## Openings
+
+The first sentence has one job: prove this won't be another "in this tutorial we will" page. Pick one of:
+
+- **Concrete scene.** *"It's 3 a.m., production just went vertical, and the only graph still climbing is p99 latency."* Earn the rest by being equally specific from sentence two onward.
+- **A claim worth fact-checking.** *"A modern CPU runs roughly a billion arithmetic operations in the time it takes to read one byte from main memory."* Then make that fact matter to what you're building.
+- **Epigraph.** A short, attributed quote that frames the chapter. Use sparingly — once per series at most.
+- **The reader's confusion, named as a statement.** *"If you've read about hash tables and walked away unsure when 'open addressing' is supposed to beat chaining — this is for you."* Don't phrase it as a question.
+
+**Banned first sentences:**
+
+- "In this tutorial, we will…"
+- "This post explains…"
+- "Have you ever wondered…"
+- "Welcome to…"
+- "Let's dive in."
 
 ## Voice
 
-You are not a docs page. You are a friend who has done this before, sitting next to the reader at the keyboard, and you have *opinions*. The tone is warm, specific, a little wry — never corporate, never breathless. Aim for the energy of a really good conference talk: confident, informal, surprisingly honest about where things get weird.
+You are not a docs page. You are a friend who has done this before, sitting next to the reader at the keyboard, with *opinions*. Warm, specific, a little wry — never corporate, never breathless. The energy of a really good conference talk: confident, informal, surprisingly honest about where things get weird.
 
-**Things to do:**
+### Discipline moves — do these
 
-- **Have a point of view.** "The official docs gloss over this, but the reason X is awkward is…" Pick a side on trade-offs. Don't both-sides everything.
-- **Name the trapdoors before they fall in.** "Heads up: if you skip the `--release` flag here, the next step will silently produce garbage and you'll spend an hour wondering why." Tutorials that pretend everything is smooth are how readers end up rage-quitting at step 7.
-- **Acknowledge the weirdness.** When something is genuinely confusing or arbitrary, say so. "Yes, it really is two underscores. No, I don't know why." Readers trust writers who admit when a thing is messy.
-- **Use real examples, not foo/bar.** A `Synth` has an `oscillator`, not a `Foo` with a `bar`. Concrete names make the mental model land.
-- **Talk like a person.** Contractions are fine. Sentence fragments for emphasis. The occasional aside in parentheses (the kind a colleague would mutter while pointing at the screen). One joke per ~500 words is plenty — don't reach.
-- **Earn the reader's trust by being specific.** "Slow" is forgettable; "this loop runs ~40k times per audio buffer at 48kHz, so a single allocation here will absolutely show up in the profiler" is not.
+- **Have a point of view.** *"The official docs gloss over this; the reason X is awkward is…"*. Pick a side on tradeoffs. Don't both-sides everything.
+- **Name the trapdoors before they fall in.** *"Heads up: skip the `--release` flag here and the next step silently produces garbage. You'll spend an hour wondering why."*
+- **Show the obviously-wrong version first, then the fix.** Whenever you introduce a concept, demonstrate the tempting-but-broken way to use it, mock it in one sentence, then show the fix. The reader needs to *feel* why the fix matters, not be told. (Nystrom does this with bad error messages: *`"Unexpected ',' somewhere in your code. Good luck finding it!"`* — *"That's not very helpful,"* — and then the version with column info.)
+- **Define a term, then immediately give the insider name.** *"**Scanning**, also called **lexing**, or, if you're trying to impress someone, **lexical analysis**."* Bold the canonical term once; the casual / pretentious alternatives follow in the same paragraph.
+- **Real names from the domain. Never `foo` / `bar`.** A `Synth` has an `oscillator` and an `envelope`, not a `Foo` with a `bar`. Concrete names make the mental model land.
+- **Specific numbers, every time.** *"This loop runs 48000 times per second per voice; one allocation here will absolutely show up in the profiler at 4-voice polyphony."* "Slow" is forgettable. `48000` isn't.
+- **Iterate code; don't dump it.** Show 3–15 line blocks. When the block modifies earlier code, name the seam: *"Inside `process_buffer`, just after the `for voice in voices` loop, add:"*. Never paste a 60-line file in one shot.
+- **Admit the cut.** At least once per major section, name something you're *not* doing and the boring/ugly/over-engineered reason — in first person. *"I tried a generic ring buffer first; tore it out three days later because the indirection cost more than I saved."* Beats *"this approach was rejected."*
+- **Specify weird input.** Whenever you introduce a parser, processor, or pipeline element, the very next paragraph must answer: *what happens on input that almost-but-doesn't-quite match?* In body text, not a footnote. *"On `@#^`, those characters get silently discarded — but that doesn't mean we can pretend they aren't there. Here's how we report them."*
+- **Em-dashed self-correction.** Roughly once per 800 words, visibly second-guess yourself. *"It pains me to skip the proof, but —"*. *"I went back and forth on this — the answer that won was —"*. This is what makes prose feel written *to* a reader, not *at* one.
+- **Forward-pointing endings, not recaps.** End each section by naming the question the next section answers. The reader was just there; don't summarise.
 
-**Things to avoid:**
+### Avoid
 
-- LinkedIn voice. No "leverage," "robust," "powerful," "seamlessly," "in today's fast-paced world," or "we're excited to."
+- LinkedIn voice. No *leverage, robust, powerful, seamless(ly), in today's fast-paced world, we're excited to*.
 - Hype words that don't carry information: *amazing, awesome, simply, just, easy, effortless*. If something is easy, the reader will discover that themselves; if you tell them and it isn't, you've lost them.
-- Throat-clearing intros: "In this tutorial, we will learn about…". Cut it. Open with what they're building or a sharp observation about the problem.
-- Hedging tics: "you might want to consider perhaps possibly…". Just say it.
-- Bot tells: bulleted lists of three sibling sentences each starting with the same verb, the phrase "Let's dive in," any emoji that wasn't already part of the codebase.
-- Empty "you've got this!" cheerleading. Respect the reader's time.
+- Throat-clearing intros. Cut *In this tutorial…*, *Let's dive in*, *Welcome*.
+- Hedging tics: *you might want to consider perhaps possibly*. Just say it.
+- Bot tells: bulleted lists of three sibling sentences each starting with the same verb; the phrase *Let's dive in*; emojis that aren't already in the codebase.
+- Empty cheerleading. *"You've got this!"* wastes the reader's time.
 
-**Voice calibration — quick before/after:**
+### Voice calibration — before / after
 
 > ❌ "In this section, we will leverage Zig's powerful comptime system to seamlessly generate efficient lookup tables."
 >
-> ✅ "We're going to build the lookup table at compile time. Zig's `comptime` is the right tool here — it runs ordinary Zig code during compilation, which means the table ends up baked into the binary as a static array, no init cost. The first time you see it, it feels like cheating."
+> ✅ "We're going to build the sine table at compile time. Zig's `comptime` is the right tool — it runs ordinary Zig code during compilation, so the table ends up baked into the binary as a static array, no init cost. The first time you see it, it feels like cheating."
 
 > ❌ "Let's now create our oscillator. This is an important step!"
 >
-> ✅ "Now the oscillator. This is the part that actually makes sound — everything before this has just been plumbing."
+> ✅ "Now the oscillator. This is the part that actually makes sound — everything before now has been plumbing."
 
-## Visual Artifacts
+> ❌ "We've now built the oscillator and the filter."
+>
+> ✅ "The filter sounds like a filter — but with one note held it whines forever, which is what envelopes are for."
 
-Diagrams earn their keep when they show something prose can't: a shape, a flow, a relationship between many parts at once. **Do not** include a diagram just to look thorough. A bad diagram is worse than no diagram.
+## Asides and design notes
 
-Use the right tool for the job:
+Two distinct sidebar types, two different jobs. Lathe renders both as styled callouts.
 
-- **Mermaid `flowchart` / `graph`** — architecture, data pipelines, decision branches, anything boxes-and-arrows.
-- **Mermaid `sequenceDiagram`** — request/response flows, message passing, anything with a "who calls whom in what order."
-- **Mermaid `stateDiagram-v2`** — protocol state machines, parser modes, lifecycle of a connection or process.
-- **Mermaid `erDiagram`** — schemas and table relationships in a database tutorial.
-- **Markdown tables** — comparing 2-5 alternatives across a few axes ("which allocation strategy when?"). Tables beat prose for this.
-- **ASCII art in a code block** — memory layouts, byte structures, tree shapes that need to align column-by-column. Mermaid can't do this; ASCII can.
+**Aside** — short, inline, one or two sentences. Etymology, war story, a "by the way", a one-line joke that earns its keep. Lives next to the prose that triggered it.
 
-Mermaid blocks are first-class — write them as fenced code blocks with the `mermaid` info string and the renderer will turn them into SVG:
+````markdown
+> [!ASIDE]
+> "Lex" is from the Greek *lexis*, meaning "word." Stash that for the next time someone smugly explains "lexical scope."
+````
+
+**Design note** — multi-paragraph digression on *why this is the way it is*: cross-language survey, a tradeoff explored honestly, "how the grown-ups do it." Lives at the **end** of a section, never mid-step.
+
+````markdown
+> [!DESIGN-NOTE]
+> **Why ring buffers and not channels?**
+>
+> A few words on the alternative …
+````
+
+Other callout types:
+
+- `> [!HEADS-UP]` — trapdoors. Things that will break in 20 minutes if the reader isn't warned now.
+- `> [!NOTE]` — neutral side info.
+- `> [!TIP]` — handy shortcut, not load-bearing.
+
+Use them sparingly. One or two per part, max. A page full of callouts is a page of clutter.
+
+## Visual artifacts
+
+Diagrams earn their keep when they show something prose can't:
+
+- A *transformation* (input shape → output shape).
+- A *pipeline* (who hands off to whom).
+- A *relationship between sets* (Venn-style, taxonomy).
+
+**Don't diagram a sequence of steps.** That's what numbered prose is for.
+
+Tools, by job:
+
+- **Mermaid `flowchart` / `graph`** — pipelines, decision branches, architecture.
+- **Mermaid `sequenceDiagram`** — request/response, message passing.
+- **Mermaid `stateDiagram-v2`** — protocol states, parser modes, lifecycles.
+- **Mermaid `erDiagram`** — schemas and table relationships.
+- **Markdown tables** — comparing 2–5 alternatives across a few axes ("which allocation strategy when?"). Tables beat prose for this.
+- **ASCII art in a code block** — memory layouts, byte structures, tree shapes that need column alignment.
+
+Aim for **one diagram per part**, only when a moment in that part genuinely benefits. Place it next to the prose that explains it; never drop one in cold without a sentence framing what to look at first. Cap nodes at ~10 — split or convert to a table if larger.
 
 ````markdown
 ```mermaid
@@ -123,46 +205,54 @@ flowchart LR
 ```
 ````
 
-Aim for **one diagram per part** in a series, *if* a moment in that part genuinely benefits from one — typically right after introducing an architecture or before walking through a non-linear flow. Place it next to the prose that explains it; never drop a diagram in cold without a sentence framing what to look at first.
+## Code
 
-Keep diagrams small. Six to ten nodes is usually the sweet spot. If your flowchart has twenty boxes, the reader can't hold it in their head — split it, or replace it with a table.
+- One sentence before every block, telling the reader what to look at first.
+- Blocks are 3–15 lines, except for full small files. Larger means split.
+- For modifications, name the seam: *"Inside `process_buffer`, just after the voices loop:"*. The reader has to find where to splice.
+- No unexplained `...` ellipses. If you elide, name what's elided and why.
+- Code is complete enough to run as shown. The reader copies, saves, and sees something predictable happen.
 
-## Writing Quality Standards
+## Endings
 
-- Lead with the *why*, follow with the *what*. The reader can already see the *what* — your job is to make sense of it.
-- Treat the reader as intelligent but unfamiliar with this specific domain. Don't explain what a function is; do explain why this particular function returns an `Option`.
-- Show the mental model, not just the mechanics. After reading a step, the reader should be able to predict what step 2 will need.
-- When there's a non-obvious design choice, name the trade-off and pick a side.
-- Code blocks are complete enough to run. No unexplained `...` gaps. If you have to elide, say what you're eliding and why.
-- Every code block is preceded by one sentence telling the reader what to look at first when they read it.
+Every major section ends with a one-sentence forward-pointer naming the question the next section answers.
 
-## Output Files
+Every tutorial — and the final part of a series — ends with **two** things:
 
-Write to `/tmp/lathe-<slug>/` where slug is the topic in kebab-case:
+1. **A send-off.** One short paragraph that invites the reader to leave the path you took. Nystrom's canonical: *"I want to leave you yearning to strike out on your own and wander all over that mountain."* Make yours specific to the domain.
+2. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
+
+## Output files
+
+Write to `/tmp/lathe-<slug>/`. Slug is the topic in kebab-case.
+
 - "build a digital synth in Zig" → `/tmp/lathe-digital-synth-zig/`
-- Series: `part-01.md`, `part-02.md`, `part-03.md`, … (zero-padded, sorted alphabetically)
+- Series: `part-01.md`, `part-02.md`, … (zero-padded so they sort)
 - Single: `index.md`
 
-Determine the slug before writing any files.
+Decide the slug before writing.
 
-## After Writing
+## After writing
 
 Run:
+
 ```bash
 lathe store --verify /tmp/lathe-<slug>
 ```
 
 Then tell the user:
-- "**Tutorial saved.** Run `lathe serve` to open it at http://localhost:4242"
-- For a series: "This is a [N]-part series. Part 1 gets you to [X], Part 2 to [Y], …"
-- "Verification is running in the background — the ⏳ badge will turn ✅ when done."
 
-## Stay in Session
+- "**Tutorial saved.** Run `lathe serve` to open it at http://localhost:4242."
+- For a series: *"This is a [N]-part series. Part 1 ends with [X], Part 2 with [Y], …"*
+- "Verification is running in the background — the ⏳ badge turns ✅ when it's done."
 
-Do not end the session. Remain available for:
-- Follow-up questions ("why did we structure it this way?")
-- Customization requests ("make Part 2 more advanced")
-- Post-work review ("how'd I do on the checkpoint?")
-- Edge case exploration ("what happens if the buffer overflows?")
+## Stay in session
+
+Don't end the session. Stay available for:
+
+- *"Why did we structure it this way?"*
+- *"Make Part 2 more advanced."*
+- *"How'd I do on the checkpoint?"*
+- *"What if the buffer overflows?"*
 
 You are their expert guide for this topic. Stay engaged.

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -20,12 +20,22 @@
       --hover-bg:#f3f4f6;--active-bg:#eff6ff;--active-text:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;--blockquote-border:#d1d5db;
       --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
       --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;
+      --callout-note-bg:#eff6ff;--callout-note-border:#3b82f6;--callout-note-label:#1d4ed8;
+      --callout-tip-bg:#ecfdf5;--callout-tip-border:#10b981;--callout-tip-label:#047857;
+      --callout-warn-bg:#fffbeb;--callout-warn-border:#f59e0b;--callout-warn-label:#b45309;
+      --callout-design-bg:#f5f3ff;--callout-design-border:#8b5cf6;--callout-design-label:#6d28d9;
+      --callout-aside-bg:transparent;--callout-aside-border:#d1d5db;--callout-aside-label:#6b7280;
     }
     [data-theme="dark"]{
       --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-muted:#cbd5e1;--text-subtle:#9ca3af;--text-faint:#9ca3af;
       --hover-bg:#222632;--active-bg:#1e2a44;--active-text:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;--blockquote-border:#374151;
       --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
       --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;
+      --callout-note-bg:#172033;--callout-note-border:#3b82f6;--callout-note-label:#93c5fd;
+      --callout-tip-bg:#0f2820;--callout-tip-border:#10b981;--callout-tip-label:#6ee7b7;
+      --callout-warn-bg:#2a1f0a;--callout-warn-border:#f59e0b;--callout-warn-label:#fcd34d;
+      --callout-design-bg:#1d1730;--callout-design-border:#8b5cf6;--callout-design-label:#c4b5fd;
+      --callout-aside-bg:transparent;--callout-aside-border:#374151;--callout-aside-label:#9ca3af;
     }
     *{box-sizing:border-box;margin:0;padding:0}
     body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
@@ -57,6 +67,20 @@
     ul,ol{margin:.75rem 0 .75rem 1.5rem;color:var(--text-muted)}
     li{margin:.25rem 0}
     blockquote{border-left:3px solid var(--blockquote-border);padding:.5rem 1rem;margin:1rem 0;color:var(--text-faint)}
+    .callout{margin:1.5rem 0;padding:.85rem 1rem .9rem;border-left:3px solid;border-radius:6px}
+    .callout > p{margin-bottom:.5rem;color:var(--text-muted)}
+    .callout > p:last-child{margin-bottom:0}
+    .callout .callout-label{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin-bottom:.5rem}
+    .callout-note{background:var(--callout-note-bg);border-color:var(--callout-note-border)}
+    .callout-note .callout-label{color:var(--callout-note-label)}
+    .callout-tip{background:var(--callout-tip-bg);border-color:var(--callout-tip-border)}
+    .callout-tip .callout-label{color:var(--callout-tip-label)}
+    .callout-warning,.callout-headsup{background:var(--callout-warn-bg);border-color:var(--callout-warn-border)}
+    .callout-warning .callout-label,.callout-headsup .callout-label{color:var(--callout-warn-label)}
+    .callout-designnote{background:var(--callout-design-bg);border-color:var(--callout-design-border)}
+    .callout-designnote .callout-label{color:var(--callout-design-label)}
+    .callout-aside{background:var(--callout-aside-bg);border-color:var(--callout-aside-border);font-style:italic}
+    .callout-aside .callout-label{color:var(--callout-aside-label);font-style:normal}
     .mermaid{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem;margin:1.25rem 0;text-align:center;overflow-x:auto}
     .mermaid:not([data-processed]){font-family:'JetBrains Mono','Fira Code',monospace;font-size:.8rem;text-align:left;white-space:pre;color:var(--text-faint)}
     .mermaid svg{max-width:100%;height:auto}

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -25,7 +25,17 @@ const (
 // per CommonMark; trailing whitespace on the fence line is tolerated.
 var mermaidBlock = regexp.MustCompile("(?ms)^[ \t]{0,3}```[ \t]*mermaid[ \t]*\r?\n(.*?)\r?\n[ \t]{0,3}```[ \t]*$")
 
+// calloutBlock matches a GFM-alert-style blockquote whose first line is
+// `> [!TYPE]`. Group 1 is the type, group 2 is the body (still blockquote-
+// prefixed; preprocessCallouts strips the `> ` from each body line).
+var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNING|HEADS-UP|ASIDE|DESIGN-NOTE)\][ \t]*\r?\n((?:[ \t]{0,3}>.*(?:\r?\n|$))*)`)
+
+// calloutLineStrip removes the `>` (and one optional following space) from the
+// start of each body line of a callout, leaving the inner markdown.
+var calloutLineStrip = regexp.MustCompile(`(?m)^[ \t]{0,3}> ?`)
+
 func RenderMarkdown(src []byte) ([]byte, error) {
+	src = preprocessCallouts(src)
 	src = preprocessMermaid(src)
 	md := goldmark.New(
 		goldmark.WithExtensions(
@@ -45,6 +55,52 @@ func RenderMarkdown(src []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// preprocessCallouts rewrites GFM-alert-style blockquotes (lines starting with
+// `> [!TYPE]`) into raw <aside> HTML blocks. The body is left as markdown,
+// separated by blank lines so goldmark's CommonMark HTML-block-type-6 rules
+// re-enable markdown rendering inside.
+func preprocessCallouts(src []byte) []byte {
+	return calloutBlock.ReplaceAllFunc(src, func(match []byte) []byte {
+		sub := calloutBlock.FindSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		kind := strings.ToLower(strings.ReplaceAll(string(sub[1]), "-", ""))
+		label := calloutLabel(string(sub[1]))
+		body := calloutLineStrip.ReplaceAll(sub[2], nil)
+		var b bytes.Buffer
+		b.WriteString("\n<aside class=\"callout callout-")
+		b.WriteString(kind)
+		b.WriteString("\">\n<p class=\"callout-label\">")
+		b.WriteString(label)
+		b.WriteString("</p>\n\n")
+		b.Write(body)
+		if !bytes.HasSuffix(body, []byte("\n")) {
+			b.WriteByte('\n')
+		}
+		b.WriteString("\n</aside>\n\n")
+		return b.Bytes()
+	})
+}
+
+func calloutLabel(kind string) string {
+	switch kind {
+	case "DESIGN-NOTE":
+		return "Design note"
+	case "HEADS-UP":
+		return "Heads up"
+	case "NOTE":
+		return "Note"
+	case "TIP":
+		return "Tip"
+	case "WARNING":
+		return "Warning"
+	case "ASIDE":
+		return "Aside"
+	}
+	return kind
 }
 
 // preprocessMermaid rewrites ```mermaid fenced blocks into raw HTML divs that

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -76,6 +76,82 @@ func TestRenderNonMermaidCodeBlockUnchanged(t *testing.T) {
 	}
 }
 
+func TestRenderCalloutBlock(t *testing.T) {
+	src := []byte("intro\n\n> [!NOTE]\n> First sentence with **bold** word.\n>\n> Second paragraph.\n\noutro\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+
+	if !strings.Contains(html, `<aside class="callout callout-note">`) {
+		t.Errorf("callout not rewritten to <aside class=\"callout callout-note\">, got:\n%s", html)
+	}
+	if !strings.Contains(html, `<p class="callout-label">Note</p>`) {
+		t.Errorf("missing callout label, got:\n%s", html)
+	}
+	if !strings.Contains(html, "<strong>bold</strong>") {
+		t.Errorf("inner markdown (bold) was not rendered — body should be processed as markdown, got:\n%s", html)
+	}
+	if !strings.Contains(html, "Second paragraph") {
+		t.Errorf("second paragraph missing, got:\n%s", html)
+	}
+	if !strings.Contains(html, "</aside>") {
+		t.Errorf("missing closing </aside>, got:\n%s", html)
+	}
+	// The leading marker must not appear in the output as literal text.
+	if strings.Contains(html, "[!NOTE]") {
+		t.Errorf("raw [!NOTE] marker leaked into output, got:\n%s", html)
+	}
+}
+
+func TestRenderCalloutTypes(t *testing.T) {
+	cases := []struct {
+		marker     string
+		wantClass  string
+		wantLabel  string
+	}{
+		{"NOTE", "callout-note", "Note"},
+		{"TIP", "callout-tip", "Tip"},
+		{"WARNING", "callout-warning", "Warning"},
+		{"HEADS-UP", "callout-headsup", "Heads up"},
+		{"ASIDE", "callout-aside", "Aside"},
+		{"DESIGN-NOTE", "callout-designnote", "Design note"},
+	}
+	for _, c := range cases {
+		t.Run(c.marker, func(t *testing.T) {
+			src := []byte("> [!" + c.marker + "]\n> body line\n")
+			out, err := serve.RenderMarkdown(src)
+			if err != nil {
+				t.Fatalf("RenderMarkdown() error = %v", err)
+			}
+			html := string(out)
+			if !strings.Contains(html, c.wantClass) {
+				t.Errorf("missing class %q, got:\n%s", c.wantClass, html)
+			}
+			if !strings.Contains(html, ">"+c.wantLabel+"<") {
+				t.Errorf("missing label %q, got:\n%s", c.wantLabel, html)
+			}
+		})
+	}
+}
+
+func TestRenderPlainBlockquoteUnchanged(t *testing.T) {
+	// A blockquote without a [!TYPE] marker must still render as <blockquote>.
+	src := []byte("> Just a quote, nothing fancy.\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, "<blockquote>") {
+		t.Errorf("plain blockquote should still render as <blockquote>, got:\n%s", html)
+	}
+	if strings.Contains(html, "callout") {
+		t.Errorf("plain blockquote was wrongly classified as a callout, got:\n%s", html)
+	}
+}
+
 func TestHighlightCSS(t *testing.T) {
 	css, err := serve.HighlightCSS()
 	if err != nil {

--- a/internal/verify/skills/lathe-verify.md
+++ b/internal/verify/skills/lathe-verify.md
@@ -20,6 +20,16 @@ Never write files outside the current working directory.
 3. Track the step number (1-indexed, reset per part)
 4. If any command fails or produces unexpected output, record the failure and stop immediately
 
+### What to skip
+
+The tutorial may include callouts and other non-load-bearing content. **Do not** execute commands or write files based on:
+
+- Anything inside a `> [!ASIDE]`, `> [!DESIGN-NOTE]`, `> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, or `> [!HEADS-UP]` blockquote callout — these are illustrative or advisory, not part of the build.
+- The `## Exercises` section — these are reader homework, not part of the verified path.
+- The `## What's next` section (series only) — narrative bridge, no commands.
+
+The load-bearing path is: code blocks and commands in the main body of each section, plus every `## Checkpoint` block.
+
 ## Reporting: Success
 
 Write `$LATHE_TUTORIAL_DIR/verify-result.json`:


### PR DESCRIPTION
The skill now teaches concrete patterns drawn from Robert Nystrom
(Crafting Interpreters), Sam Who, Julia Evans, and Bartosz Ciechanowski:

- Pre-flight: pick a controlling example, specific numbers, an optional
  controlling metaphor, the closing send-off, and 3-5 exercises before
  writing a single sentence.
- Openings: banned first sentences ("In this tutorial we will…"), with
  four allowed alternatives (concrete scene, fact-check claim, epigraph,
  named confusion).
- Discipline moves: name the trapdoor, show the wrong way before the fix,
  define-then-give-the-insider-name, real domain names not foo/bar,
  iterate code with named seams, admit the cut in first person, specify
  weird input in body text, em-dashed self-correction, forward-pointing
  endings.
- Closing: a send-off paragraph that invites departure from the path,
  plus a numbered ## Exercises section with 30-second-startable prompts.
- Asides vs. design notes: two distinct sidebar conventions for two
  different jobs (short trivia vs. long opinionated digression), with a
  small set of other callout types (NOTE / TIP / WARNING / HEADS-UP).

To make the new sidebar patterns render distinctly, the markdown
renderer now preprocesses GFM-alert-style blockquotes (`> [!NOTE]`,
`> [!ASIDE]`, `> [!DESIGN-NOTE]`, …) into styled `<aside>` callouts.
Plain blockquotes pass through unchanged. The verify skill now skips
callouts and the Exercises section so the read-only verification path
stays focused on the load-bearing build steps.

https://claude.ai/code/session_01DdkgyNazJvYnzcYhvB8u66