### PR TITLE
feat: support deleting tutorials from CLI and webapp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,14 @@ The boundary is strict: **skills generate content; the CLI owns durable state.**
 main.go                           cobra entrypoint
 cmd/
   root.go                         rootCmd ("lathe")
-  list.go, open.go, serve.go, store.go    one subcommand per file
+  list.go, open.go, rm.go, serve.go, store.go    one subcommand per file
 internal/
   config/                         TutorialsDir() → ~/.lathe/tutorials
   store/
     metadata.go                   Tutorial struct, Status enum, Read/WriteMetadata
-    store.go                      Store(), copyDir/copyFile, detectParts, SlugToTitle
+    store.go                      Store(), Delete(), copyDir/copyFile, detectParts, SlugToTitle
   serve/
-    server.go                     net/http handlers (list, tutorial, part)
+    server.go                     net/http handlers (list, tutorial, part, delete)
     renderer.go                   goldmark + chroma markdown rendering
     layout.html, list.html        embed.FS templates
   verify/
@@ -61,7 +61,7 @@ There is no top-level test runner script — tests are plain `go test`. The `/la
 ## Things to avoid
 
 - Don't add a `lathe verify` or `lathe status` command — verification is intentionally always automatic via `--verify` (see "Out of Scope" in the design spec).
-- Don't add tutorial deletion, editing, or sharing commands without checking with the user — the v1 scope is deliberately narrow.
+- Don't add tutorial editing or sharing commands without checking with the user — the v1 scope is deliberately narrow. (Deletion is supported via `lathe rm <slug>` and the `×` button on the web list page; both go through `store.Delete` / `safeTutorialPath`.)
 - Don't have the verify skill modify the tutorial source markdown — it's read-only with respect to the tutorial directory, and only writes `verify-result.json` and the `status` field of `metadata.json`.
 - Don't add OS-level sandboxing (sandbox-exec, Docker) for verification unless explicitly asked — soft isolation via `--project-dir` is the chosen tradeoff.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ lathe list               # show all stored tutorials with status badges
 lathe open <slug>        # open a specific tutorial (requires lathe serve)
 lathe store <path>       # save a tutorial directory manually
 lathe store <path> --verify   # save and run background verification
+lathe rm <slug>          # delete a stored tutorial (prompts unless --force)
 ```
+
+You can also delete tutorials from the web UI — each row on the list page has a `×` button that removes the tutorial after a confirmation.
 
 Default port is `4242`; override with `--port`.
 
@@ -121,7 +124,7 @@ Verification runs with `--dangerously-skip-permissions` and is sandboxed only by
 ## Repository layout
 
 ```
-cmd/                CLI entry points (root, list, open, serve, store)
+cmd/                CLI entry points (root, list, open, rm, serve, store)
 internal/config/    ~/.lathe/tutorials path resolution
 internal/store/     copy + metadata read/write, slug detection
 internal/serve/     HTTP server, markdown renderer, embedded HTML templates

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var rmForce bool
+
+var rmCmd = &cobra.Command{
+	Use:   "rm <slug>",
+	Short: "Delete a stored tutorial",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		if !rmForce {
+			fmt.Fprintf(cmd.OutOrStdout(), "Delete tutorial %q? [y/N]: ", slug)
+			reader := bufio.NewReader(cmd.InOrStdin())
+			line, _ := reader.ReadString('\n')
+			if strings.ToLower(strings.TrimSpace(line)) != "y" {
+				fmt.Fprintln(cmd.OutOrStdout(), "aborted")
+				return nil
+			}
+		}
+		if err := store.Delete(slug); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s\n", slug)
+		return nil
+	},
+}
+
+func init() {
+	rmCmd.Flags().BoolVarP(&rmForce, "force", "f", false, "skip confirmation prompt")
+	rootCmd.AddCommand(rmCmd)
+}

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -31,10 +31,14 @@
     .header{display:flex;justify-content:space-between;align-items:flex-start;gap:1rem}
     h1{font-size:1.75rem;margin-bottom:.4rem}
     .subtitle{color:var(--text-faint);margin-bottom:2rem;font-size:.95rem}
-    .tutorial{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1.1rem 1.5rem;margin:.75rem 0;display:flex;justify-content:space-between;align-items:center}
+    .tutorial{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1.1rem 1.5rem;margin:.75rem 0;display:flex;justify-content:space-between;align-items:center;gap:1rem}
     .tutorial a{text-decoration:none;color:var(--link);font-weight:500;font-size:1rem}
     .tutorial a:hover{text-decoration:underline}
     .meta{font-size:.8rem;color:var(--text-empty);margin-top:.2rem}
+    .tutorial-actions{display:flex;align-items:center;gap:.6rem;flex-shrink:0}
+    .delete-form{margin:0}
+    .delete-btn{background:transparent;border:1px solid var(--border);color:var(--text-empty);font:inherit;font-size:1rem;line-height:1;padding:.15rem .55rem;border-radius:5px;cursor:pointer}
+    .delete-btn:hover{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
     .badge{font-size:.7rem;padding:.2rem .5rem;border-radius:4px}
     .badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
     .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
@@ -66,10 +70,15 @@
     <a href="/{{.Slug}}/">{{.Title}}</a>
     <div class="meta">{{if .Series}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}</div>
   </div>
-  {{if eq .Status "verified"}}<span class="badge verified">✅ Verified</span>
-  {{else if eq .Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
-  {{else if eq .Status "failed"}}<span class="badge failed">❌ Failed</span>
-  {{end}}
+  <div class="tutorial-actions">
+    {{if eq .Status "verified"}}<span class="badge verified">✅ Verified</span>
+    {{else if eq .Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
+    {{else if eq .Status "failed"}}<span class="badge failed">❌ Failed</span>
+    {{end}}
+    <form method="POST" action="/-/delete/{{.Slug}}" class="delete-form" data-tutorial-title="{{.Title}}">
+      <button type="submit" class="delete-btn" aria-label="Delete tutorial" title="Delete tutorial">×</button>
+    </form>
+  </div>
 </div>
 {{end}}
 {{else}}
@@ -91,6 +100,16 @@
       document.documentElement.setAttribute('data-theme', next);
       try { localStorage.setItem('lathe-theme', next); } catch (e) {}
       refresh();
+    });
+  })();
+  (function(){
+    document.querySelectorAll('.delete-form').forEach(function(form){
+      form.addEventListener('submit', function(e){
+        var title = form.dataset.tutorialTitle || 'this tutorial';
+        if (!confirm('Delete "' + title + '"? This cannot be undone.')) {
+          e.preventDefault();
+        }
+      });
     });
   })();
 </script>

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -45,6 +45,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{$}", s.handleList)
 	mux.HandleFunc("GET /{slug}/", s.handleTutorial)
 	mux.HandleFunc("GET /{slug}/{part}", s.handlePart)
+	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
 	return mux
 }
 
@@ -143,6 +144,25 @@ func (s *Server) handlePart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.renderPart(w, tut, tutDir, part)
+}
+
+func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	tutDir, ok := s.safeTutorialPath(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	info, err := os.Stat(tutDir)
+	if err != nil || !info.IsDir() {
+		http.NotFound(w, r)
+		return
+	}
+	if err := os.RemoveAll(tutDir); err != nil {
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
 func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, part string) {

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -157,6 +157,55 @@ func TestStaticAssetWhitelist(t *testing.T) {
 	}
 }
 
+func TestDeleteEndpointRemovesTutorial(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "doomed", false)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/delete/doomed", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("POST /-/delete/doomed = %d, want %d", w.Code, http.StatusSeeOther)
+	}
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Errorf("redirect Location = %q, want %q", loc, "/")
+	}
+	if _, err := os.Stat(tutDir); !os.IsNotExist(err) {
+		t.Errorf("tutorial dir still exists after delete: stat err = %v", err)
+	}
+}
+
+func TestDeleteEndpointRejectsGet(t *testing.T) {
+	dir := t.TempDir()
+	makeTestTutorial(t, dir, "stay", false)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/-/delete/stay", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusSeeOther || w.Code == http.StatusOK {
+		t.Errorf("GET /-/delete/stay = %d, want method not allowed", w.Code)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "stay")); err != nil {
+		t.Errorf("tutorial removed via GET: %v", err)
+	}
+}
+
+func TestDeleteEndpointMissingSlug(t *testing.T) {
+	dir := t.TempDir()
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/delete/nonexistent", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("POST /-/delete/nonexistent = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
 func TestPathTraversalBlocked(t *testing.T) {
 	dir := t.TempDir()
 	makeTestTutorial(t, dir, "test-tutorial", false)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -107,6 +107,31 @@ func detectParts(dir string) ([]string, bool) {
 	return parts, len(parts) > 0
 }
 
+func Delete(slug string) error {
+	if slug == "" || slug == "." || slug == ".." || strings.ContainsAny(slug, `/\`) {
+		return fmt.Errorf("invalid slug: %q", slug)
+	}
+	tutorialsDir, err := config.TutorialsDir()
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(tutorialsDir, slug)
+	if !strings.HasPrefix(target, tutorialsDir+string(filepath.Separator)) {
+		return fmt.Errorf("invalid slug: %q", slug)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("tutorial %q not found", slug)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a tutorial directory: %q", slug)
+	}
+	return os.RemoveAll(target)
+}
+
 func SlugToTitle(slug string) string {
 	words := strings.Split(slug, "-")
 	for i, w := range words {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -91,6 +91,57 @@ func TestStoreWithVerifyStatus(t *testing.T) {
 	}
 }
 
+func TestDeleteRemovesTutorial(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	tut, err := store.Store(src, false)
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", tut.Slug)
+	if _, err := os.Stat(tutDir); err != nil {
+		t.Fatalf("tutorial dir not created: %v", err)
+	}
+
+	if err := store.Delete(tut.Slug); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := os.Stat(tutDir); !os.IsNotExist(err) {
+		t.Errorf("tutorial dir still exists after Delete: stat err = %v", err)
+	}
+}
+
+func TestDeleteMissingSlug(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := store.Delete("does-not-exist"); err == nil {
+		t.Error("Delete() of missing slug should error")
+	}
+}
+
+func TestDeleteRejectsBadSlugs(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	sentinel := filepath.Join(homeDir, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("don't touch"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, slug := range []string{"", ".", "..", "../sentinel", "foo/bar", `foo\bar`} {
+		if err := store.Delete(slug); err == nil {
+			t.Errorf("Delete(%q) should reject as invalid", slug)
+		}
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("sentinel file disturbed by bad-slug delete: %v", err)
+	}
+}
+
 func TestSlugToTitle(t *testing.T) {
 	cases := []struct {
 		slug  string


### PR DESCRIPTION
Adds `lathe rm <slug>` (with -f/--force) and a `×` button on each row
of the web list page. The webapp posts to `/-/delete/{slug}` which
reuses `safeTutorialPath` for traversal protection and redirects back
to `/`. The CLI prompts for y/N confirmation by default.

https://claude.ai/code/session_0167V421uXNsDQptW6BKkLpP