### PR TITLE
feat: streaming Q&A chat on tutorial pages

### DIFF
--- a/internal/serve/ask.go
+++ b/internal/serve/ask.go
@@ -1,0 +1,291 @@
+package serve
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+// maxQuestionBytes caps the JSON request body for /-/ask. Questions are
+// expected to be short prose; anything bigger is almost certainly abuse.
+const maxQuestionBytes = 8 << 10 // 8 KiB
+
+// handleAsk streams an answer to a question about the part the user is
+// currently reading. It spawns a tightly-scoped read-only `claude` subprocess
+// (via exec.CommandContext bound to r.Context() so disconnect kills it) and
+// re-streams the assistant text deltas to the browser as Server-Sent Events.
+//
+// SSE wire format:
+//
+//	data: <chunk>\n\n             — answer text chunks
+//	event: done\ndata: {}\n\n     — clean completion
+//	event: error\ndata: <msg>\n\n — subprocess or stream error
+func (s *Server) handleAsk(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	part := r.PathValue("part")
+
+	// Defense in depth: only .md files are valid parts.
+	if !strings.HasSuffix(part, ".md") {
+		http.NotFound(w, r)
+		return
+	}
+
+	tutDir, ok := s.safeTutorialPath(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	partPath, ok := s.safeTutorialPath(slug, part)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	articleBody, err := os.ReadFile(partPath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Cap the request body. http.MaxBytesReader returns an error from Read once
+	// the limit is exceeded; the json decoder surfaces that as a decode error.
+	r.Body = http.MaxBytesReader(w, r.Body, maxQuestionBytes)
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "request body too large", http.StatusBadRequest)
+		return
+	}
+	if len(raw) == 0 {
+		http.Error(w, "empty request body", http.StatusBadRequest)
+		return
+	}
+	var payload struct {
+		Question string `json:"question"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	question := strings.TrimSpace(payload.Question)
+	if question == "" {
+		http.Error(w, "question is required", http.StatusBadRequest)
+		return
+	}
+
+	system, user := buildAskPrompt(tut, part, string(articleBody), question)
+
+	// Build the subprocess. Bind to the request context so client disconnect
+	// kills the subprocess for free — no goroutines needed.
+	cmd := exec.CommandContext(r.Context(), "claude",
+		"--bare",
+		"-p",
+		"--output-format", "stream-json",
+		"--include-partial-messages",
+		"--project-dir", tutDir,
+		"--allowedTools", "Read,Glob,Grep",
+		"--dangerously-skip-permissions",
+		"--system-prompt", system,
+		user,
+	)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		http.Error(w, "stream init failed", http.StatusInternalServerError)
+		return
+	}
+	// Drop stderr — without this, a chatty subprocess can fill the OS pipe
+	// buffer and deadlock the handler waiting on Wait().
+	cmd.Stderr = io.Discard
+
+	// SSE headers must go out before any frame is written. After the first
+	// write, we cannot change status — errors after this must be SSE-framed.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		writeSSEError(w, flusher, "subprocess start failed")
+		return
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	// Partial-message JSON events from claude can exceed the default 64KB
+	// scanner buffer when they contain large code blocks; bump to 1MB.
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var obj any
+		if err := json.Unmarshal(line, &obj); err != nil {
+			// Non-JSON output (logs, banners) is harmless to skip.
+			continue
+		}
+		text := extractTextDelta(obj)
+		if text == "" {
+			continue
+		}
+		writeSSEData(w, flusher, text)
+	}
+
+	// Drain stdout fully before Wait returns; reading the err afterward.
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		writeSSEError(w, flusher, "subprocess error")
+		return
+	}
+	fmt.Fprint(w, "event: done\ndata: {}\n\n")
+	flusher.Flush()
+}
+
+// writeSSEData emits a `data:` SSE frame. The SSE spec requires that newlines
+// in the payload be sent as separate `data:` lines; we honor that so that
+// multi-line model output renders correctly on the client.
+func writeSSEData(w io.Writer, flusher http.Flusher, text string) {
+	for _, line := range strings.Split(text, "\n") {
+		fmt.Fprintf(w, "data: %s\n", line)
+	}
+	fmt.Fprint(w, "\n")
+	flusher.Flush()
+}
+
+// writeSSEError emits an `error` SSE event. The message is intentionally short
+// — we don't pipe stderr here, since it could be large and may leak details.
+func writeSSEError(w io.Writer, flusher http.Flusher, msg string) {
+	fmt.Fprintf(w, "event: error\ndata: %s\n\n", msg)
+	flusher.Flush()
+}
+
+// extractTextDelta walks the JSON envelope of a claude --output-format
+// stream-json line and returns any assistant text it carries. It handles the
+// two common shapes:
+//
+//  1. content_block_delta with a text_delta:
+//     {"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}
+//     (optionally wrapped in {"type":"stream_event","event":{...}})
+//  2. assistant message with content blocks:
+//     {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+//
+// Anything else (tool_use, tool_result, message_start/stop, ping, system
+// banners) returns "" and is skipped by the caller.
+func extractTextDelta(v any) string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	// Unwrap stream_event envelope.
+	if t, _ := m["type"].(string); t == "stream_event" {
+		if inner, ok := m["event"].(map[string]any); ok {
+			return extractTextDelta(inner)
+		}
+	}
+
+	// Shape 1: content_block_delta with text_delta.
+	if t, _ := m["type"].(string); t == "content_block_delta" {
+		if delta, ok := m["delta"].(map[string]any); ok {
+			if dt, _ := delta["type"].(string); dt == "text_delta" {
+				if s, ok := delta["text"].(string); ok {
+					return s
+				}
+			}
+		}
+		return ""
+	}
+
+	// Shape 2: full assistant message.
+	if t, _ := m["type"].(string); t == "assistant" {
+		if msg, ok := m["message"].(map[string]any); ok {
+			if content, ok := msg["content"].([]any); ok {
+				var b strings.Builder
+				for _, block := range content {
+					bm, ok := block.(map[string]any)
+					if !ok {
+						continue
+					}
+					if bt, _ := bm["type"].(string); bt == "text" {
+						if s, ok := bm["text"].(string); ok {
+							b.WriteString(s)
+						}
+					}
+				}
+				return b.String()
+			}
+		}
+	}
+
+	return ""
+}
+
+// buildAskPrompt produces the (system, user) prompt pair sent to the claude
+// subprocess. The system prompt embeds the full text of the part the user is
+// currently reading, plus — for series — a list of sibling parts the model
+// can consult via Read/Glob/Grep. The user prompt is the question verbatim.
+func buildAskPrompt(tut *store.Tutorial, part, articleBody, question string) (system, user string) {
+	var b strings.Builder
+
+	title := ""
+	if tut != nil {
+		title = tut.Title
+	}
+
+	b.WriteString("You are a helpful assistant answering questions about a hands-on technical tutorial.\n\n")
+	fmt.Fprintf(&b, "The tutorial is titled %q.\n", title)
+	fmt.Fprintf(&b, "The user is currently reading the part %q.\n\n", part)
+	fmt.Fprintf(&b, "The full text of %q is included below.\n\n", part)
+
+	if tut != nil && tut.Series && len(tut.Parts) > 1 {
+		// Build the list of *other* parts so the model knows what it can
+		// consult via Read/Glob/Grep.
+		var siblings []string
+		for _, p := range tut.Parts {
+			if p == part {
+				continue
+			}
+			siblings = append(siblings, p)
+		}
+		if len(siblings) > 0 {
+			b.WriteString("This tutorial is a series. Other parts are also available in the same directory and you have read-only Read/Glob/Grep access if you need to consult them:\n")
+			for _, p := range siblings {
+				fmt.Fprintf(&b, "  - %s\n", p)
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("Answer the user's question concisely and accurately, citing specific parts of the tutorial when relevant. Do not write or modify any files.\n\n")
+	fmt.Fprintf(&b, "--- BEGIN %s ---\n", part)
+	b.WriteString(articleBody)
+	if !strings.HasSuffix(articleBody, "\n") {
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "--- END %s ---\n", part)
+
+	return b.String(), question
+}

--- a/internal/serve/ask_test.go
+++ b/internal/serve/ask_test.go
@@ -1,0 +1,210 @@
+package serve
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+// makeTutFixture builds a small tutorial fixture and returns the tutorial dir.
+// Kept inline (rather than relying on serve_test.go's helper) because this
+// test file is in package serve while server_test.go is in package serve_test.
+func makeTutFixture(t *testing.T, dir, slug string, series bool) string {
+	t.Helper()
+	tutDir := filepath.Join(dir, slug)
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    slug,
+		Title:   "Test Tutorial",
+		Status:  store.StatusVerified,
+		Series:  series,
+		Created: time.Now(),
+	}
+	if series {
+		tut.Parts = []string{"part-01.md", "part-02.md"}
+		for _, p := range tut.Parts {
+			if err := os.WriteFile(filepath.Join(tutDir, p), []byte("# "+p), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	} else {
+		if err := os.WriteFile(filepath.Join(tutDir, "index.md"), []byte("# Index"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	return tutDir
+}
+
+func TestBuildAskPrompt(t *testing.T) {
+	t.Run("non-series", func(t *testing.T) {
+		tut := &store.Tutorial{Title: "Single", Series: false}
+		system, user := buildAskPrompt(tut, "index.md", "Hello world", "What is X?")
+
+		if !strings.Contains(system, "Single") {
+			t.Errorf("system prompt missing tutorial title %q:\n%s", "Single", system)
+		}
+		if !strings.Contains(system, "index.md") {
+			t.Errorf("system prompt missing current part %q:\n%s", "index.md", system)
+		}
+		if !strings.Contains(system, "Hello world") {
+			t.Errorf("system prompt missing article body:\n%s", system)
+		}
+		// Non-series should not have the series block listing other parts.
+		if strings.Contains(system, "Other parts are also available") {
+			t.Errorf("non-series system prompt unexpectedly mentions other parts:\n%s", system)
+		}
+		if user != "What is X?" {
+			t.Errorf("user prompt = %q, want %q", user, "What is X?")
+		}
+	})
+
+	t.Run("series", func(t *testing.T) {
+		tut := &store.Tutorial{
+			Title:  "Series",
+			Series: true,
+			Parts:  []string{"part-01.md", "part-02.md", "part-03.md"},
+		}
+		system, user := buildAskPrompt(tut, "part-02.md", "Body of part 2", "Why?")
+
+		if !strings.Contains(system, "Body of part 2") {
+			t.Errorf("system prompt missing article body:\n%s", system)
+		}
+		if !strings.Contains(system, "part-01.md") {
+			t.Errorf("system prompt missing sibling part-01.md in series block:\n%s", system)
+		}
+		if !strings.Contains(system, "part-03.md") {
+			t.Errorf("system prompt missing sibling part-03.md in series block:\n%s", system)
+		}
+		// The current part should NOT be listed as another available part.
+		// It will appear elsewhere (e.g. "currently reading"), so we look for
+		// a bullet-line containing it specifically.
+		if strings.Contains(system, "- part-02.md") {
+			t.Errorf("series block unexpectedly lists current part as a sibling:\n%s", system)
+		}
+		if user != "Why?" {
+			t.Errorf("user prompt = %q, want %q", user, "Why?")
+		}
+	})
+
+	t.Run("series with single part omits sibling block", func(t *testing.T) {
+		tut := &store.Tutorial{
+			Title:  "Solo",
+			Series: true,
+			Parts:  []string{"part-01.md"},
+		}
+		system, _ := buildAskPrompt(tut, "part-01.md", "Body", "Q?")
+		if strings.Contains(system, "Other parts are also available") {
+			t.Errorf("solo series should not include the sibling-parts block:\n%s", system)
+		}
+	})
+
+	t.Run("nil tutorial does not panic", func(t *testing.T) {
+		// buildAskPrompt should be defensive against a nil tut. The handler
+		// reads metadata first, but we don't want a NPE inside the helper.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("buildAskPrompt panicked on nil tut: %v", r)
+			}
+		}()
+		_, _ = buildAskPrompt(nil, "index.md", "Body", "Q?")
+	})
+}
+
+func postAsk(t *testing.T, srv *Server, slug, part string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/-/ask/"+slug+"/"+part, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestAskHandlerValidation(t *testing.T) {
+	dir := t.TempDir()
+	makeTutFixture(t, dir, "tut", false)
+	makeTutFixture(t, dir, "series", true)
+	srv := NewServer(dir)
+
+	t.Run("unknown slug returns 404", func(t *testing.T) {
+		w := postAsk(t, srv, "nope", "index.md", []byte(`{"question":"hi"}`))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("unknown slug = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("known slug, unknown part returns 404", func(t *testing.T) {
+		w := postAsk(t, srv, "tut", "missing.md", []byte(`{"question":"hi"}`))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("unknown part = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("non-md part returns 404", func(t *testing.T) {
+		w := postAsk(t, srv, "tut", "index.txt", []byte(`{"question":"hi"}`))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("non-md part = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("slug with leading dot returns 404", func(t *testing.T) {
+		// ServeMux path-cleans `..` segments before matching, so a literal
+		// `..` slug never reaches the handler. A slug like `.hidden` does
+		// reach us though, and should still 404 because no metadata exists.
+		w := postAsk(t, srv, ".hidden", "index.md", []byte(`{"question":"hi"}`))
+		if w.Code != http.StatusNotFound {
+			t.Errorf(".hidden slug = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("empty body returns 400", func(t *testing.T) {
+		w := postAsk(t, srv, "tut", "index.md", []byte(``))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("empty body = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("bad json returns 400", func(t *testing.T) {
+		w := postAsk(t, srv, "tut", "index.md", []byte(`{not json`))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("bad json = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("blank question returns 400", func(t *testing.T) {
+		w := postAsk(t, srv, "tut", "index.md", []byte(`{"question":"   "}`))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("blank question = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("oversize body returns 400", func(t *testing.T) {
+		// 10KB question -> oversize since the cap is 8KB.
+		big := strings.Repeat("a", 10*1024)
+		body := []byte(`{"question":"` + big + `"}`)
+		w := postAsk(t, srv, "tut", "index.md", body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("oversize body = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("GET on ask route is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/-/ask/tut/index.md", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code == http.StatusOK {
+			t.Errorf("GET /-/ask = %d, want non-200 (method not allowed)", w.Code)
+		}
+	})
+}

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -84,6 +84,32 @@
     .mermaid{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem;margin:1.25rem 0;text-align:center;overflow-x:auto}
     .mermaid:not([data-processed]){font-family:'JetBrains Mono','Fira Code',monospace;font-size:.8rem;text-align:left;white-space:pre;color:var(--text-faint)}
     .mermaid svg{max-width:100%;height:auto}
+    #askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:50;background:var(--active-bg);color:var(--active-text);border:1px solid var(--border);font:inherit;font-weight:600;font-size:.9rem;padding:.65rem 1.1rem;border-radius:9999px;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.15);transition:transform 150ms ease-out,box-shadow 150ms ease-out}
+    #askButton:hover{transform:translateY(-2px);box-shadow:0 4px 10px rgba(0,0,0,0.2)}
+    #askButton:focus-visible{outline:2px solid var(--active-text);outline-offset:2px}
+    #askDrawer{position:fixed;top:0;right:0;bottom:0;width:min(420px,100vw);background:var(--surface);border-left:1px solid var(--border);transform:translateX(100%);transition:transform 200ms ease-out;z-index:60;display:flex;flex-direction:column}
+    #askDrawer.open{transform:translateX(0)}
+    #askDrawer header{display:flex;align-items:center;justify-content:space-between;gap:.5rem;padding:1rem 1.25rem;border-bottom:1px solid var(--border)}
+    #askDrawer header h3{font-size:1rem;font-weight:600;color:var(--text);margin:0;line-height:1.3;overflow:hidden;text-overflow:ellipsis}
+    #askClose{background:transparent;border:none;color:var(--text-subtle);font-size:1.5rem;line-height:1;cursor:pointer;padding:.25rem .5rem;border-radius:4px}
+    #askClose:hover{background:var(--hover-bg);color:var(--text)}
+    #askBackdrop{position:fixed;inset:0;background:rgba(0,0,0,0.25);z-index:55}
+    [data-theme="dark"] #askBackdrop{background:rgba(0,0,0,0.55)}
+    #askLog{flex:1;overflow-y:auto;padding:1rem;display:flex;flex-direction:column;gap:.75rem}
+    .ask-bubble{border-radius:8px;padding:.6rem .8rem;max-width:92%;white-space:pre-wrap;word-wrap:break-word;color:var(--text);font-size:.9rem;line-height:1.5}
+    .ask-question{align-self:flex-end;background:var(--active-bg);color:var(--active-text)}
+    .ask-answer{align-self:flex-start;background:var(--hover-bg)}
+    #askForm{display:flex;flex-direction:column;gap:.6rem;padding:1rem;border-top:1px solid var(--border)}
+    #askInput{width:100%;resize:vertical;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:.55rem .7rem;font:inherit;font-size:.9rem;line-height:1.4}
+    #askInput:focus{outline:2px solid var(--active-text);outline-offset:1px}
+    .ask-controls{display:flex;gap:.5rem;justify-content:flex-end}
+    #askSubmit,#askStop{font:inherit;font-size:.85rem;font-weight:500;padding:.45rem .9rem;border-radius:6px;border:1px solid var(--border);cursor:pointer}
+    #askSubmit{background:var(--active-bg);color:var(--active-text)}
+    #askSubmit:hover:not(:disabled){background:var(--hover-bg)}
+    #askStop{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
+    #askStop:hover{filter:brightness(0.95)}
+    #askSubmit:disabled,#askStop:disabled{opacity:.5;cursor:not-allowed}
+    @media (max-width:600px){#askDrawer{width:100vw}}
   </style>
 </head>
 <body>
@@ -108,6 +134,22 @@
   </nav>
   <main>{{.Content}}</main>
 </div>
+<button type="button" id="askButton" aria-label="Ask a question about this tutorial">Ask</button>
+<aside id="askDrawer" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" aria-hidden="true">
+  <header>
+    <h3>Ask about "{{.Tutorial.Title}}"</h3>
+    <button type="button" id="askClose" aria-label="Close">×</button>
+  </header>
+  <div id="askLog" role="log" aria-live="polite"></div>
+  <form id="askForm">
+    <textarea id="askInput" placeholder="Ask a question…" rows="2" required></textarea>
+    <div class="ask-controls">
+      <button type="submit" id="askSubmit">Send</button>
+      <button type="button" id="askStop" hidden>Stop</button>
+    </div>
+  </form>
+</aside>
+<div id="askBackdrop" hidden></div>
 <script>
   (function(){
     var btn = document.getElementById('themeToggle');
@@ -157,6 +199,188 @@
     };
     s.onerror = function(){ console.warn('mermaid bundle failed to load'); };
     document.body.appendChild(s);
+  })();
+</script>
+<script>
+  (function(){
+    var drawer = document.getElementById('askDrawer');
+    var openBtn = document.getElementById('askButton');
+    var closeBtn = document.getElementById('askClose');
+    var backdrop = document.getElementById('askBackdrop');
+    var log = document.getElementById('askLog');
+    var form = document.getElementById('askForm');
+    var input = document.getElementById('askInput');
+    var submit = document.getElementById('askSubmit');
+    var stop = document.getElementById('askStop');
+    if (!drawer || !openBtn || !form) return;
+
+    var slug = drawer.getAttribute('data-slug') || '';
+    var part = drawer.getAttribute('data-part') || '';
+    var controller = null;
+
+    function openDrawer(){
+      drawer.classList.add('open');
+      drawer.setAttribute('aria-hidden', 'false');
+      backdrop.hidden = false;
+      setTimeout(function(){ try { input.focus(); } catch(e){} }, 50);
+    }
+    function closeDrawer(){
+      drawer.classList.remove('open');
+      drawer.setAttribute('aria-hidden', 'true');
+      backdrop.hidden = true;
+      if (controller) {
+        try { controller.abort(); } catch(e){}
+      }
+    }
+
+    openBtn.addEventListener('click', openDrawer);
+    closeBtn.addEventListener('click', closeDrawer);
+    backdrop.addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', function(ev){
+      if (ev.key === 'Escape' && drawer.classList.contains('open')) {
+        closeDrawer();
+      }
+    });
+
+    function nearBottom(){
+      return (log.scrollHeight - log.scrollTop - log.clientHeight) < 50;
+    }
+    function pinBottom(){
+      log.scrollTop = log.scrollHeight;
+    }
+    function appendBubble(cls, text){
+      var was = nearBottom();
+      var el = document.createElement('div');
+      el.className = 'ask-bubble ' + cls;
+      el.textContent = text || '';
+      log.appendChild(el);
+      if (was) pinBottom();
+      return el;
+    }
+
+    function setSending(sending){
+      submit.disabled = sending;
+      stop.hidden = !sending;
+      input.disabled = sending;
+    }
+
+    input.addEventListener('keydown', function(ev){
+      if (ev.key === 'Enter' && !ev.shiftKey) {
+        ev.preventDefault();
+        form.requestSubmit();
+      }
+    });
+
+    stop.addEventListener('click', function(){
+      if (controller) {
+        try { controller.abort(); } catch(e){}
+      }
+    });
+
+    function parseSseFrame(frame){
+      var event = 'message';
+      var dataLines = [];
+      var lines = frame.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        if (!line) continue;
+        if (line.charAt(0) === ':') continue;
+        var idx = line.indexOf(':');
+        var field, value;
+        if (idx === -1) { field = line; value = ''; }
+        else {
+          field = line.substring(0, idx);
+          value = line.substring(idx + 1);
+          if (value.charAt(0) === ' ') value = value.substring(1);
+        }
+        if (field === 'event') event = value;
+        else if (field === 'data') dataLines.push(value);
+      }
+      return { event: event, data: dataLines.join('\n') };
+    }
+
+    form.addEventListener('submit', function(ev){
+      ev.preventDefault();
+      var question = (input.value || '').trim();
+      if (!question) return;
+
+      appendBubble('ask-question', question);
+      var answer = appendBubble('ask-answer', '');
+
+      input.value = '';
+      setSending(true);
+      pinBottom();
+
+      controller = new AbortController();
+      var url = '/-/ask/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part);
+
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: question }),
+        signal: controller.signal
+      }).then(function(response){
+        if (!response.ok || !response.body) {
+          throw new Error('HTTP ' + response.status);
+        }
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder();
+        var buffer = '';
+        var done = false;
+
+        function appendAnswer(text){
+          var was = nearBottom();
+          answer.textContent = answer.textContent + text;
+          if (was) pinBottom();
+        }
+
+        function processBuffer(){
+          var idx;
+          while ((idx = buffer.indexOf('\n\n')) !== -1) {
+            var frame = buffer.substring(0, idx);
+            buffer = buffer.substring(idx + 2);
+            if (!frame) continue;
+            var parsed = parseSseFrame(frame);
+            if (parsed.event === 'done') {
+              done = true;
+              return;
+            } else if (parsed.event === 'error') {
+              appendAnswer('\n\n[error: ' + parsed.data + ']');
+            } else {
+              appendAnswer(parsed.data);
+            }
+          }
+        }
+
+        function pump(){
+          return reader.read().then(function(result){
+            if (result.value) {
+              buffer += decoder.decode(result.value, { stream: true });
+              processBuffer();
+            }
+            if (done || result.done) {
+              if (!done && buffer) {
+                buffer += '\n\n';
+                processBuffer();
+              }
+              try { reader.cancel(); } catch(e){}
+              return;
+            }
+            return pump();
+          });
+        }
+        return pump();
+      }).catch(function(err){
+        if (err && err.name === 'AbortError') return;
+        var was = nearBottom();
+        answer.textContent = answer.textContent + '\n\n[error: ' + (err && err.message ? err.message : 'request failed') + ']';
+        if (was) pinBottom();
+      }).then(function(){
+        setSending(false);
+        controller = null;
+        try { input.focus(); } catch(e){}
+      });
+    });
   })();
 </script>
 </body>

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -46,6 +46,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{slug}/", s.handleTutorial)
 	mux.HandleFunc("GET /{slug}/{part}", s.handlePart)
 	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
+	mux.HandleFunc("POST /-/ask/{slug}/{part}", s.handleAsk)
 	return mux
 }
 


### PR DESCRIPTION
## Summary

- Add a floating "Ask" button + slide-in side drawer to every tutorial page (`internal/serve/layout.html`).
- Add a `POST /-/ask/{slug}/{part}` endpoint that spawns a read-only `claude` subprocess with the current part inlined and streams the answer back as Server-Sent Events (`internal/serve/ask.go`).
- Subprocess is whitelisted to `Read,Glob,Grep` only and bound to `r.Context()` via `exec.CommandContext`, so client disconnect (Stop button → `controller.abort()`) kills it for free.
- Pure `buildAskPrompt` helper for testability; full validation suite (`internal/serve/ask_test.go`).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- [ ] `./lathe serve` against a non-series tutorial → click Ask → send a question → confirm streaming and answer references the article.
- [ ] Same for a multi-part series, asking about a sibling part → confirm Claude uses Read to consult the other part file.
- [ ] Mid-stream Stop → partial answer freezes, `pgrep -f 'claude --bare'` shows subprocess gone within ~1s.
- [ ] Path traversal `curl -X POST .../-/ask/..%2F..%2Fetc/index.md` → 404.
- [ ] Empty question → 400. 10 KB question → 400.
- [ ] Reload page → drawer Q&A history cleared.
- [ ] Toggle dark mode while drawer is open → styles flip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)