### PR TITLE
fix subprocess flag + rework sidebar as in-page TOC

### DIFF
--- a/internal/serve/ask.go
+++ b/internal/serve/ask.go
@@ -98,7 +98,7 @@ func (s *Server) handleAsk(w http.ResponseWriter, r *http.Request) {
 		"-p",
 		"--output-format", "stream-json",
 		"--include-partial-messages",
-		"--project-dir", tutDir,
+		"--add-dir", tutDir,
 		"--allowedTools", "Read,Glob,Grep",
 		"--dangerously-skip-permissions",
 		"--system-prompt", system,

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -70,6 +70,15 @@
     nav a{display:block;font-size:.85rem;color:var(--text-subtle);text-decoration:none;padding:.35rem .6rem;border-radius:5px}
     nav a:hover{background:var(--hover-bg);color:var(--text)}
     nav a.active{background:var(--active-bg);color:var(--active-text);font-weight:500}
+    .back-link{display:inline-flex;align-items:center;gap:.3rem;font-size:.78rem;color:var(--text-faint);text-decoration:none;padding:.2rem .25rem;margin:-.2rem 0 .85rem;border-radius:4px}
+    .back-link:hover{color:var(--active-text);background:transparent}
+    nav .toc-label{font-size:.7rem;font-weight:600;color:var(--text-faint);text-transform:uppercase;letter-spacing:.06em;margin:.85rem .4rem .35rem;line-height:1.3}
+    nav ul.toc{list-style:none;margin:0;padding:0}
+    nav ul.toc li{margin:.1rem 0}
+    nav ul.toc a{font-size:.82rem;line-height:1.4;padding:.32rem .6rem;color:var(--text-subtle)}
+    nav ul.toc a:hover{background:var(--hover-bg);color:var(--text)}
+    /* Anchor offset so headings aren't flush to the top when jumped to. */
+    h2[id],h3[id]{scroll-margin-top:1rem}
     .theme-toggle{margin-top:auto;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;font-size:.8rem;padding:.4rem .6rem;border-radius:5px;cursor:pointer;display:flex;align-items:center;gap:.4rem;width:100%}
     .theme-toggle:hover{background:var(--hover-bg);color:var(--text)}
     .theme-toggle .icon{font-size:.95rem;line-height:1}
@@ -122,8 +131,19 @@
     .mermaid:not([data-processed]){font-family:'JetBrains Mono','Fira Code',monospace;font-size:.8rem;text-align:left;white-space:pre;color:var(--text-faint)}
     .mermaid svg{max-width:100%;height:auto}
 
+    /* Series TOC at bottom of part */
+    .series-toc{margin-top:3rem;padding-top:1.5rem;border-top:1px solid var(--border)}
+    .series-toc > h2{font-size:.95rem;font-weight:600;margin:0 0 .7rem;color:var(--text-muted);line-height:1.3;letter-spacing:.01em}
+    .series-toc ol{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:.4rem}
+    .series-toc li{margin:0}
+    .series-toc a,.series-toc .current-row{display:flex;gap:.65rem;align-items:baseline;padding:.6rem .85rem;border:1px solid var(--border);border-radius:7px;background:var(--surface);color:var(--text-subtle);text-decoration:none;font-size:.92rem;line-height:1.3}
+    .series-toc a:hover{color:var(--active-text);border-color:var(--active-text);background:var(--hover-bg)}
+    .series-toc .current-row{color:var(--active-text);border-color:var(--active-text);background:var(--active-bg);font-weight:500}
+    .series-toc .part-num{font-size:.7rem;font-weight:600;letter-spacing:.04em;color:var(--text-faint);text-transform:uppercase;flex-shrink:0;min-width:3.4rem}
+    .series-toc .current-row .part-num{color:var(--active-text)}
+
     /* Inline prev/next part navigation */
-    .part-nav{display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:3rem;padding-top:1.5rem;border-top:1px solid var(--border)}
+    .part-nav{display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:1.5rem;padding-top:1.5rem;border-top:1px solid var(--border)}
     .part-nav a{min-width:0;text-decoration:none;color:var(--text-subtle);background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.65rem .9rem;display:flex;flex-direction:column;gap:.2rem;transition:color 120ms,border-color 120ms,background 120ms}
     .part-nav a:hover{color:var(--active-text);border-color:var(--active-text);background:var(--hover-bg)}
     .part-nav .label{font-size:.72rem;font-weight:600;letter-spacing:.03em;color:var(--text-faint)}
@@ -195,16 +215,16 @@
 </header>
 <div class="layout">
   <nav id="sidebar">
+    <a href="/" class="back-link">← All tutorials</a>
     <h2>{{.Tutorial.Title}}</h2>
     {{if eq .Tutorial.Status "verified"}}<span class="badge verified">✅ Verified</span>
     {{else if eq .Tutorial.Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
     {{else if eq .Tutorial.Status "failed"}}<span class="badge failed">❌ Failed</span>
     {{end}}
-    {{if .Tutorial.Series}}
-    <ul>
-      {{range $i, $part := .Tutorial.Parts}}
-      <li><a href="/{{$.Tutorial.Slug}}/{{$part}}"{{if eq $part $.CurrentPart}} class="active"{{end}}>Part {{add $i 1}}</a></li>
-      {{end}}
+    {{if .TOC}}
+    <h3 class="toc-label">On this page</h3>
+    <ul class="toc">
+      {{range .TOC}}<li><a href="#{{.ID}}">{{.Text}}</a></li>{{end}}
     </ul>
     {{end}}
     <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle dark mode">
@@ -214,6 +234,22 @@
   </nav>
   <main>
     {{.Content}}
+    {{if and .Tutorial.Series (gt (len .Tutorial.Parts) 1)}}
+    <section class="series-toc" aria-label="In this series">
+      <h2>In this series</h2>
+      <ol>
+        {{range .SeriesTOC}}
+        <li>
+          {{if .Current}}
+          <span class="current-row" aria-current="page"><span class="part-num">Part {{.Number}}</span><span class="title">{{.Title}}</span></span>
+          {{else}}
+          <a href="/{{$.Tutorial.Slug}}/{{.Slug}}"><span class="part-num">Part {{.Number}}</span><span class="title">{{.Title}}</span></a>
+          {{end}}
+        </li>
+        {{end}}
+      </ol>
+    </section>
+    {{end}}
     {{if .Tutorial.Series}}
     <nav class="part-nav" aria-label="Part navigation">
       {{if .PrevPart}}

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -12,8 +12,19 @@ import (
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
 	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
 )
+
+// TOCEntry is a single h2 heading collected for the in-page table of contents
+// rendered in the sidebar. ID matches the auto-heading-id slug, so anchor links
+// (#first-section) jump directly to the heading.
+type TOCEntry struct {
+	ID   string
+	Text string
+}
 
 const (
 	lightStyle = "github"
@@ -35,6 +46,14 @@ var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNIN
 var calloutLineStrip = regexp.MustCompile(`(?m)^[ \t]{0,3}> ?`)
 
 func RenderMarkdown(src []byte) ([]byte, error) {
+	out, _, err := RenderMarkdownWithTOC(src)
+	return out, err
+}
+
+// RenderMarkdownWithTOC renders markdown to HTML and returns a list of h2
+// headings for the in-page TOC. parser.WithAutoHeadingID assigns each heading
+// a stable id slug; the same slug is captured here for anchor links.
+func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 	src = preprocessCallouts(src)
 	src = preprocessMermaid(src)
 	md := goldmark.New(
@@ -46,15 +65,66 @@ func RenderMarkdown(src []byte) ([]byte, error) {
 				),
 			),
 		),
+		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 		goldmark.WithRendererOptions(
 			goldmarkhtml.WithUnsafe(),
 		),
 	)
+	doc := md.Parser().Parse(text.NewReader(src))
+	toc := collectH2TOC(doc, src)
 	var buf bytes.Buffer
-	if err := md.Convert(src, &buf); err != nil {
-		return nil, err
+	if err := md.Renderer().Render(&buf, src, doc); err != nil {
+		return nil, nil, err
 	}
-	return buf.Bytes(), nil
+	return buf.Bytes(), toc, nil
+}
+
+// collectH2TOC walks the parsed AST and returns one TOCEntry per <h2>. h1, h3,
+// and deeper levels are skipped — h1 is the page title, h3+ would clutter the
+// sidebar. Heading text is the concatenation of inline ast.Text segments, so
+// formatting like `code` or *emphasis* contributes plain text only.
+func collectH2TOC(doc ast.Node, src []byte) []TOCEntry {
+	var toc []TOCEntry
+	ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok || h.Level != 2 {
+			return ast.WalkContinue, nil
+		}
+		// AutoHeadingID assigns an id to every non-empty heading; a missing id
+		// means the heading text was empty (`##` with no content). Skip — there
+		// is nothing to label the entry with anyway.
+		idAttr, ok := h.AttributeString("id")
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		idBytes, _ := idAttr.([]byte)
+		toc = append(toc, TOCEntry{
+			ID:   string(idBytes),
+			Text: extractInlineText(h, src),
+		})
+		return ast.WalkSkipChildren, nil
+	})
+	return toc
+}
+
+// extractInlineText concatenates the inline text of all ast.Text descendants of
+// n, in document order. Code spans and emphasis nodes contain ast.Text children
+// so this captures their visible text without HTML markup.
+func extractInlineText(n ast.Node, src []byte) string {
+	var b strings.Builder
+	ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := c.(*ast.Text); ok {
+			b.Write(t.Segment.Value(src))
+		}
+		return ast.WalkContinue, nil
+	})
+	return b.String()
 }
 
 // preprocessCallouts rewrites GFM-alert-style blockquotes (lines starting with

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -16,8 +16,8 @@ func TestRenderMarkdown(t *testing.T) {
 	}
 
 	html := string(out)
-	if !strings.Contains(html, "<h1>Hello World</h1>") {
-		t.Errorf("RenderMarkdown() missing <h1>, got:\n%s", html)
+	if !strings.Contains(html, `<h1 id="hello-world">Hello World</h1>`) {
+		t.Errorf("RenderMarkdown() missing <h1> with auto-id, got:\n%s", html)
 	}
 	if !strings.Contains(html, "<code>test</code>") {
 		t.Errorf("RenderMarkdown() missing inline <code>, got:\n%s", html)
@@ -149,6 +149,51 @@ func TestRenderPlainBlockquoteUnchanged(t *testing.T) {
 	}
 	if strings.Contains(html, "callout") {
 		t.Errorf("plain blockquote was wrongly classified as a callout, got:\n%s", html)
+	}
+}
+
+func TestRenderMarkdownWithTOC(t *testing.T) {
+	src := []byte("# Title\n\n## First Section\n\nIntro.\n\n### Subsection of first\n\nBody.\n\n## Second Section\n\nMore body.\n\n### Subsection of second\n\nDone.\n")
+
+	out, toc, err := serve.RenderMarkdownWithTOC(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdownWithTOC() error = %v", err)
+	}
+
+	html := string(out)
+	if !strings.Contains(html, `id="first-section"`) {
+		t.Errorf("rendered HTML missing first heading id, got:\n%s", html)
+	}
+	if !strings.Contains(html, `id="second-section"`) {
+		t.Errorf("rendered HTML missing second heading id, got:\n%s", html)
+	}
+
+	if len(toc) != 2 {
+		t.Fatalf("TOC length = %d, want 2 (h2s only); got entries: %#v", len(toc), toc)
+	}
+	if toc[0].ID != "first-section" || toc[0].Text != "First Section" {
+		t.Errorf("toc[0] = %+v, want {ID: first-section, Text: First Section}", toc[0])
+	}
+	if toc[1].ID != "second-section" || toc[1].Text != "Second Section" {
+		t.Errorf("toc[1] = %+v, want {ID: second-section, Text: Second Section}", toc[1])
+	}
+
+	// h3 entries should not be in the TOC.
+	for _, e := range toc {
+		if strings.HasPrefix(e.ID, "subsection-of") {
+			t.Errorf("h3 leaked into TOC: %+v", e)
+		}
+	}
+}
+
+func TestRenderMarkdownWithTOCEmpty(t *testing.T) {
+	src := []byte("just a paragraph, no headings here.\n")
+	_, toc, err := serve.RenderMarkdownWithTOC(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdownWithTOC() error = %v", err)
+	}
+	if len(toc) != 0 {
+		t.Errorf("expected empty TOC, got %#v", toc)
 	}
 }
 

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -166,13 +166,23 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
+// SeriesEntry is a row in the "In this series" list rendered at the bottom of
+// each series part. Title is precomputed from the part filename so the template
+// doesn't need to call into the store package.
+type SeriesEntry struct {
+	Slug    string
+	Title   string
+	Number  int
+	Current bool
+}
+
 func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, part string) {
 	src, err := os.ReadFile(filepath.Join(tutDir, part))
 	if err != nil {
 		http.Error(w, "part not found", http.StatusNotFound)
 		return
 	}
-	content, err := RenderMarkdown(src)
+	content, toc, err := RenderMarkdownWithTOC(src)
 	if err != nil {
 		http.Error(w, "render error", http.StatusInternalServerError)
 		return
@@ -180,8 +190,16 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 
 	var prevPart, nextPart, prevTitle, nextTitle string
 	var prevNumber, nextNumber, currentNumber int
+	var seriesTOC []SeriesEntry
 	if tut.Series {
+		seriesTOC = make([]SeriesEntry, 0, len(tut.Parts))
 		for i, p := range tut.Parts {
+			seriesTOC = append(seriesTOC, SeriesEntry{
+				Slug:    p,
+				Title:   store.SlugToTitle(strings.TrimSuffix(p, ".md")),
+				Number:  i + 1,
+				Current: p == part,
+			})
 			if p == part {
 				currentNumber = i + 1
 				if i > 0 {
@@ -194,7 +212,6 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 					nextTitle = store.SlugToTitle(strings.TrimSuffix(nextPart, ".md"))
 					nextNumber = i + 2
 				}
-				break
 			}
 		}
 	}
@@ -213,6 +230,8 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"NextTitle":         nextTitle,
 		"PrevNumber":        prevNumber,
 		"NextNumber":        nextNumber,
+		"TOC":               toc,
+		"SeriesTOC":         seriesTOC,
 	}); err != nil {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -184,6 +184,100 @@ func TestSeriesPartPrevNext(t *testing.T) {
 	}
 }
 
+func TestSeriesSidebarAndBottomList(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-series")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "test-series",
+		Title:   "Test Series",
+		Status:  store.StatusVerified,
+		Series:  true,
+		Parts:   []string{"part-01.md", "part-02.md"},
+		Created: time.Now(),
+	}
+	// Part 1 has two h2 sections so we can assert TOC links exist.
+	body1 := "# Part One\n\n## Setup\n\nFoo.\n\n## Wire it up\n\nBar.\n"
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte(body1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-02.md"), []byte("# Part Two\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-series/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-series/part-01.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+
+	// Sidebar should contain the back-link and the on-page TOC (no parts list).
+	if !strings.Contains(body, `class="back-link"`) || !strings.Contains(body, "All tutorials") {
+		t.Error("sidebar missing back-link to /")
+	}
+	if !strings.Contains(body, "On this page") {
+		t.Error("sidebar missing 'On this page' label")
+	}
+	if !strings.Contains(body, `href="#setup"`) {
+		t.Errorf("sidebar TOC missing anchor to first h2; body excerpt:\n%s", body)
+	}
+	if !strings.Contains(body, `href="#wire-it-up"`) {
+		t.Error("sidebar TOC missing anchor to second h2")
+	}
+
+	// The old in-sidebar parts list pattern (an <a class="active"> inside the
+	// sidebar pointing to the current part's URL) should no longer appear.
+	oldPattern := `<a href="/test-series/part-01.md" class="active"`
+	if strings.Contains(body, oldPattern) {
+		t.Errorf("sidebar still renders old parts-list pattern: %s", oldPattern)
+	}
+
+	// Bottom of main should contain the new "In this series" section listing
+	// all parts, with the current part marked.
+	if !strings.Contains(body, `class="series-toc"`) {
+		t.Error("main missing .series-toc section")
+	}
+	if !strings.Contains(body, "In this series") {
+		t.Error("main missing 'In this series' label")
+	}
+	if !strings.Contains(body, `class="current-row"`) {
+		t.Error("series-toc missing current-row marker for current part")
+	}
+	// Non-current parts must be real links.
+	if !strings.Contains(body, `href="/test-series/part-02.md"`) {
+		t.Error("series-toc missing link to non-current part")
+	}
+}
+
+func TestNonSeriesNoSeriesTOC(t *testing.T) {
+	dir := t.TempDir()
+	makeTestTutorial(t, dir, "single", false)
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/single/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /single/ = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, `class="series-toc"`) {
+		t.Error("non-series tutorial should not render .series-toc block")
+	}
+	if strings.Contains(body, "In this series") {
+		t.Error("non-series tutorial should not render 'In this series' label")
+	}
+}
+
 func TestNonSeriesNoPartNav(t *testing.T) {
 	dir := t.TempDir()
 	makeTestTutorial(t, dir, "single", false)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -36,7 +36,7 @@ func SpawnVerifier(slug, tutorialDir string) error {
 	)
 
 	cmd := exec.Command("claude",
-		"--project-dir", tempDir,
+		"--add-dir", tempDir,
 		"--dangerously-skip-permissions",
 		"-p", prompt,
 	)


### PR DESCRIPTION
## Summary

Two user-reported issues, both small enough to ship together:

- **Chat + verifier subprocess fix.** The `claude` CLI no longer accepts `--project-dir`; replacement is `--add-dir`. Both call sites (`internal/serve/ask.go`, `internal/verify/verify.go`) were exiting immediately, surfacing as `[error: subprocess error]` in the chat UI and a stuck `verifying` status on tutorials.
- **Sidebar UX rework.** The sidebar now serves in-page navigation instead of duplicating series part-jumping:
  - Sidebar: `← All tutorials` → title → status → "On this page" h2 TOC → theme toggle.
  - Series part-jumping moves to a new "In this series" block at the bottom of each part, above the existing prev/next nav.
  - Non-series tutorials get neither bottom block.
  - Renderer now enables goldmark `parser.WithAutoHeadingID()` so headings have stable anchor targets; new `RenderMarkdownWithTOC` walks the AST for h2-only TOC entries (h1 is the page title, h3+ would clutter the sidebar).

Two commits inside: `fix:` for the flag swap, `feat:` for the sidebar rework.

## Test plan

- [x] `go vet ./... && go build -o lathe && go test ./...` all green
- [x] New automated coverage: `TestRenderMarkdownWithTOC`, `TestRenderMarkdownWithTOCEmpty`, `TestSeriesSidebarAndBottomList`, `TestNonSeriesNoSeriesTOC`
- [ ] Manual: `./lathe serve` → open a series tutorial → verify sidebar shows back-link / title / status / "On this page" / theme toggle (no parts list)
- [ ] Manual: click a TOC entry → page scrolls to the corresponding `<h2>`
- [ ] Manual: scroll to bottom → "In this series" list with current part marked, then prev/next
- [ ] Manual: open a non-series tutorial → no series block, no prev/next
- [ ] Manual: narrow viewport → sidebar still works as off-canvas drawer with the same content
- [ ] Manual: toggle dark mode → TOC and series-list colors look correct in both themes
- [ ] Manual: open Ask drawer → answer streams (no `[error: subprocess error]`)
- [ ] Manual: `./lathe store --verify <tutorial>` → status transitions out of `verifying`

🤖 Generated with [Claude Code](https://claude.com/claude-code)