### PR TITLE
Apply learning-science pedagogy to /lathe tutorials

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -64,6 +64,9 @@ Aside or design note where it earns its keep.
 
 ## Checkpoint
 
+> [!PREDICT]
+> Before you run this: what output do you expect to see?
+
 **Run this to verify your work so far:**
 \`\`\`bash
 <the exact command>
@@ -73,6 +76,10 @@ Expected output:
 \`\`\`
 <what they should see>
 \`\`\`
+
+**Likely errors:**
+- If you see `<exact error text>`, you probably <short causal explanation, e.g. "skipped the import in §2">.
+- If you see `<exact error text>`, you probably <short causal explanation>.
 
 ## What's next            (series only, except final part)
 
@@ -86,6 +93,8 @@ One paragraph naming the unanswered question that the next part will answer.
 ```
 
 For **series**, every part must open with *"By the end of this part, you'll have [specific, concrete thing]"* and close with a Checkpoint.
+
+**Spaced retrieval for Part 2 and later:** Before the opening promise, insert one `[!RECALL]` callout that asks the reader to reconstruct a *load-bearing* concept from the previous part — something the current part depends on. One sentence is enough: *"Quick recall: what does the ring buffer's `write_pos` field track, and why does it wrap at `BUFFER_SIZE`?"* The gap between reading sessions is a free spacing event; the callout turns it into a retrieval event.
 
 ## Openings
 
@@ -145,6 +154,45 @@ You are not a docs page. You are a friend who has done this before, sitting next
 >
 > ✅ "The filter sounds like a filter — but with one note held it whines forever, which is what envelopes are for."
 
+**Prediction beat — before / after:**
+
+> ❌ *(no prediction; reader runs the command cold and either succeeds or is confused)*
+>
+> ✅
+> ```markdown
+> > [!PREDICT]
+> > Before you run this: the sine table has 1024 entries. What will `@sizeOf(@TypeOf(sine_table))` print?
+> ```
+> *(The answer — 4096 bytes — lands harder because the reader committed to a number first.)*
+
+**Recall beat — before / after (Part 2 opening):**
+
+> ❌ "In Part 2 we'll add the filter. First, a quick recap: in Part 1 we built the oscillator, which…"
+> *(Recap re-presents; the reader recognises, not recalls. No retrieval benefit.)*
+>
+> ✅
+> ```markdown
+> > [!RECALL]
+> > Quick recall before we continue: what does `write_pos % BUFFER_SIZE` accomplish, and what breaks if you forget the modulo?
+> ```
+> *(The reader must reconstruct the answer — if they can't, that's signal. If they can, the retrieval strengthens the memory.)*
+
+**Faded scaffolding — before / after:**
+
+> ❌ "Now add the Release stage:" *(followed by a fully worked block)*
+> *(Reader copies. Nothing to think about. Forgotten by tomorrow.)*
+>
+> ✅ "You've seen how `Attack` ramps from 0 to 1 over `attack_samples`. The `Release` stage does the mirror image — ramp from 1 back to 0 over `release_samples`. Write it now, using the same loop shape, then run the Checkpoint below."
+> *(One step ahead of what was shown. Pattern is in front of them. Effort is real but not punishing.)*
+
+**Closing reflection — before / after:**
+
+> ❌ "Great work! You've built a ring buffer, an oscillator, and a filter."
+> *(Cheerleading. The reader knows what they built.)*
+>
+> ✅ "Before you try the exercises: in two sentences, why does the ring buffer beat a `sync.Mutex`-guarded slice here? Write the answer that would satisfy a sceptical colleague."
+> *(Forces construction, not recognition. Surfaces gaps before the reader walks away.)*
+
 ## Asides and design notes
 
 Two distinct sidebar types, two different jobs. Lathe renders both as styled callouts.
@@ -170,8 +218,10 @@ Other callout types:
 - `> [!HEADS-UP]` — trapdoors. Things that will break in 20 minutes if the reader isn't warned now.
 - `> [!NOTE]` — neutral side info.
 - `> [!TIP]` — handy shortcut, not load-bearing.
+- `> [!PREDICT]` — prediction prompt before a Checkpoint or surprising output. One line only.
+- `> [!RECALL]` — spaced-retrieval prompt at the top of Part N≥2. One question, load-bearing concept only.
 
-Use them sparingly. One or two per part, max. A page full of callouts is a page of clutter.
+Use them sparingly. One or two per part, max. A page full of callouts is a page of clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical — the verifier skips them.
 
 ## Visual artifacts
 
@@ -213,14 +263,17 @@ flowchart LR
 - No unexplained `...` ellipses. If you elide, name what's elided and why.
 - Code is complete enough to run as shown. The reader copies, saves, and sees something predictable happen.
 
+**Faded scaffolding:** The first code block in each part (or tutorial) is fully worked — reader copies, saves, runs, sees output. The last one or two code blocks shift to fill-the-seam: name the pattern the reader has seen, then ask them to write the next instance. *"You've seen how the `Attack` stage ramps from 0 to 1. Using the same pattern, write the `Release` stage — it ramps from 1 back to 0 over `release_time` samples. Then run the Checkpoint."* This is not an open exercise: the reader has the template in front of them and takes exactly one step ahead of where you stopped.
+
 ## Endings
 
 Every major section ends with a one-sentence forward-pointer naming the question the next section answers.
 
-Every tutorial — and the final part of a series — ends with **two** things:
+Every tutorial — and the final part of a series — ends with **three** things:
 
 1. **A send-off.** One short paragraph that invites the reader to leave the path you took. Nystrom's canonical: *"I want to leave you yearning to strike out on your own and wander all over that mountain."* Make yours specific to the domain.
-2. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
+2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in the tutorial and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
+3. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
 
 ## Output files
 

--- a/docs/superpowers/specs/2026-05-10-pedagogy.md
+++ b/docs/superpowers/specs/2026-05-10-pedagogy.md
@@ -1,0 +1,119 @@
+# Pedagogy Principles for Lathe Tutorials
+
+*2026-05-10*
+
+This document records the learning-science evidence behind the pedagogical moves encoded in the `/lathe` generation skill. Future skill edits should be grounded here — if a proposed change contradicts the literature, it needs a stronger justification.
+
+---
+
+## Principles adopted
+
+### 1. Retrieval practice (testing effect)
+
+**What it is:** Asking learners to actively recall information — rather than re-reading it — produces stronger, more durable memory.
+
+**Evidence:** Roediger & Karpicke (2006) showed that students who practised retrieval after studying retained 50% more material on a delayed test than those who studied for the same total time. The effect is robust across domains and has been replicated in technical learning contexts.
+
+**How Lathe applies it:**
+- Every Part N≥2 in a series opens with one quick recall question (`[!RECALL]`) before introducing new material.
+- Prediction beats (`[!PREDICT]`) before Checkpoints engage retrieval: the reader must activate their mental model to generate a prediction, not just passively read expected output.
+
+**Citation:** Roediger, H. L., & Karpicke, J. D. (2006). Test-enhanced learning: Taking memory tests improves long-term retention. *Psychological Science, 17*(3), 249–255.
+
+---
+
+### 2. The prediction effect
+
+**What it is:** Being asked to predict an outcome before seeing it improves encoding of the correct answer, even when the prediction is wrong.
+
+**Evidence:** Kornell et al. (2009) demonstrated that generating an incorrect guess before seeing the answer produced better retention than simply studying the answer. The error itself primes encoding. This is a special case of "desirable difficulties" (Bjork, 1994).
+
+**How Lathe applies it:**
+- `[!PREDICT]` callouts appear before non-trivial Checkpoints and any output that might surprise the reader.
+- The prompt is a single line: *"Before you run this: what do you expect to see?"* — low friction, high payoff.
+
+**Citations:**
+- Kornell, N., Hays, M. J., & Bjork, R. A. (2009). Unsuccessful retrieval attempts enhance subsequent learning. *Journal of Experimental Psychology: Learning, Memory, and Cognition, 35*(4), 989–998.
+- Bjork, R. A. (1994). Memory and metamemory considerations in the training of human beings. In J. Metcalfe & A. Shimamura (Eds.), *Metacognition: Knowing about knowing* (pp. 185–205). MIT Press.
+
+---
+
+### 3. Worked-example-to-problem fading (faded scaffolding)
+
+**What it is:** Starting with fully worked examples and gradually removing support — first removing steps, then whole sections — transfers cognitive load from the instructor to the learner in a controlled way.
+
+**Evidence:** Renkl & Atkinson (2003) showed that learners who transitioned from worked examples to problem-solving outperformed those who only solved problems or only studied examples. The key is the *fade*, not just the mix.
+
+**How Lathe applies it:**
+- The first code block in a part is fully worked — the reader copies, saves, and runs it.
+- The last 1–2 code blocks are fill-the-seam: the tutorial names the pattern and tells the reader to write the next instance themselves (*"Using the pattern above, write the `release` stage yourself, then run it"*).
+- This is not an open-ended exercise — the reader has seen the pattern; they're applying it one step ahead.
+
+**Citation:** Renkl, A., & Atkinson, R. K. (2003). Structuring the transition from example study to problem solving in cognitive skill acquisition. *Educational Psychologist, 38*(1), 15–22.
+
+---
+
+### 4. Spaced retrieval / interleaved review
+
+**What it is:** Spacing practice across time — returning to earlier material rather than massing it — dramatically improves long-term retention. In a series, each part is a natural spacing event.
+
+**Evidence:** Cepeda et al. (2006) meta-analysed 254 spacing-effect studies and found a consistent advantage, especially for retention intervals longer than a day. In a multi-part series read over several sessions, spacing is essentially free.
+
+**How Lathe applies it:**
+- The `[!RECALL]` beat at the top of Part N≥2 uses the inter-part gap as a spacing event: the reader re-activates a load-bearing concept before the new material depends on it.
+- The concept targeted must be *load-bearing* for the current part — not trivia, not atmosphere.
+
+**Citation:** Cepeda, N. J., Pashler, H., Vul, E., Wixted, J. T., & Rohrer, D. (2006). Distributed practice in verbal recall tasks: A review and quantitative synthesis. *Psychological Bulletin, 132*(3), 354–380.
+
+---
+
+### 5. Elaborative feedback on errors
+
+**What it is:** When learners encounter errors, feedback that names the *cause* (not just the symptom) produces better transfer than feedback that only indicates wrong/right.
+
+**Evidence:** Moreno (2004) showed that explanatory feedback (telling learners *why* an answer was wrong) outperformed simple corrective feedback, particularly for transfer to novel problems. Failure-mode guidance in tutorials mimics elaborative feedback by pre-loading causal knowledge before the error occurs.
+
+**How Lathe applies it:**
+- Each Checkpoint includes a `**Likely errors**` block with 1–3 symptom → cause pairs.
+- The format is: *"If you see `<exact error text>`, you probably `<short causal explanation>`."*
+- These are pre-loaded rather than reactive, which means the reader can self-diagnose without breaking flow.
+
+**Citation:** Moreno, R. (2004). Decreasing cognitive load for novice students: Effects of explanatory versus corrective feedback in discovery-based multimedia. *Instructional Science, 32*(1–2), 99–113.
+
+---
+
+### 6. Self-explanation effect
+
+**What it is:** Asking learners to explain *why* something works — in their own words, to themselves — produces deeper understanding and better transfer than re-reading.
+
+**Evidence:** Chi et al. (1989) found that students who self-explained while reading worked examples significantly outperformed those who did not, even controlling for study time. The act of constructing an explanation reveals gaps and forces integration with prior knowledge.
+
+**How Lathe applies it:**
+- Before `## Exercises`, every tutorial includes a one-sentence self-explanation prompt: *"In two sentences, why does [key design choice] beat [the obvious alternative]?"*
+- This replaces the traditional recap (which re-presents what the reader just read) with something that requires construction, not recognition.
+
+**Citation:** Chi, M. T. H., Bassok, M., Lewis, M. W., Reimann, P., & Glaser, R. (1989). Self-explanations: How students study and use examples in learning to solve problems. *Cognitive Science, 13*(2), 145–182.
+
+---
+
+## Mapping to SKILL.md sections
+
+| Principle | SKILL.md section |
+|---|---|
+| Retrieval practice | "Spaced retrieval in series" rule |
+| Prediction effect | "Prediction beats" rule; `[!PREDICT]` callout |
+| Faded scaffolding | "Faded scaffolding" guidance in "Code" section |
+| Spaced retrieval | "Spaced retrieval in series" rule; `[!RECALL]` callout |
+| Elaborative feedback | "Checkpoint" template — Likely errors block |
+| Self-explanation | "Endings" — closing reflection before Exercises |
+
+---
+
+## What we are deliberately not doing
+
+- **Quizzes / interactive widgets** — require server-side state; out of scope for v1.
+- **Spaced-repetition scheduling** — would need user accounts and a review queue; out of scope.
+- **Analytics** — no tracking what readers actually struggle with; a future concern.
+- **Adaptive content** — tutorials are static; personalisation is not in scope.
+
+These omissions are conscious tradeoffs, not oversights.

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -37,6 +37,8 @@
       --callout-warn-bg:#fffbeb;--callout-warn-border:#f59e0b;--callout-warn-label:#b45309;
       --callout-design-bg:#f5f3ff;--callout-design-border:#8b5cf6;--callout-design-label:#6d28d9;
       --callout-aside-bg:transparent;--callout-aside-border:#d1d5db;--callout-aside-label:#6b7280;
+      --callout-predict-bg:#fdf4ff;--callout-predict-border:#a855f7;--callout-predict-label:#7e22ce;
+      --callout-recall-bg:#fff7ed;--callout-recall-border:#f97316;--callout-recall-label:#c2410c;
     }
     [data-theme="dark"]{
       --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-muted:#cbd5e1;--text-subtle:#9ca3af;--text-faint:#9ca3af;
@@ -48,6 +50,8 @@
       --callout-warn-bg:#2a1f0a;--callout-warn-border:#f59e0b;--callout-warn-label:#fcd34d;
       --callout-design-bg:#1d1730;--callout-design-border:#8b5cf6;--callout-design-label:#c4b5fd;
       --callout-aside-bg:transparent;--callout-aside-border:#374151;--callout-aside-label:#9ca3af;
+      --callout-predict-bg:#1e0a2e;--callout-predict-border:#a855f7;--callout-predict-label:#d8b4fe;
+      --callout-recall-bg:#2a1500;--callout-recall-border:#f97316;--callout-recall-label:#fdba74;
     }
     *{box-sizing:border-box;margin:0;padding:0}
     html,body{overflow-x:hidden}
@@ -127,6 +131,10 @@
     .callout-designnote .callout-label{color:var(--callout-design-label)}
     .callout-aside{background:var(--callout-aside-bg);border-color:var(--callout-aside-border);font-style:italic}
     .callout-aside .callout-label{color:var(--callout-aside-label);font-style:normal}
+    .callout-predict{background:var(--callout-predict-bg);border-color:var(--callout-predict-border)}
+    .callout-predict .callout-label{color:var(--callout-predict-label)}
+    .callout-recall{background:var(--callout-recall-bg);border-color:var(--callout-recall-border)}
+    .callout-recall .callout-label{color:var(--callout-recall-label)}
     .mermaid{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:1rem;margin:1.25rem 0;text-align:center;overflow-x:auto;max-width:100%}
     .mermaid:not([data-processed]){font-family:'JetBrains Mono','Fira Code',monospace;font-size:.8rem;text-align:left;white-space:pre;color:var(--text-faint)}
     .mermaid svg{max-width:100%;height:auto}

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -39,7 +39,7 @@ var mermaidBlock = regexp.MustCompile("(?ms)^[ \t]{0,3}```[ \t]*mermaid[ \t]*\r?
 // calloutBlock matches a GFM-alert-style blockquote whose first line is
 // `> [!TYPE]`. Group 1 is the type, group 2 is the body (still blockquote-
 // prefixed; preprocessCallouts strips the `> ` from each body line).
-var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNING|HEADS-UP|ASIDE|DESIGN-NOTE)\][ \t]*\r?\n((?:[ \t]{0,3}>.*(?:\r?\n|$))*)`)
+var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNING|HEADS-UP|ASIDE|DESIGN-NOTE|PREDICT|RECALL)\][ \t]*\r?\n((?:[ \t]{0,3}>.*(?:\r?\n|$))*)`)
 
 // calloutLineStrip removes the `>` (and one optional following space) from the
 // start of each body line of a callout, leaving the inner markdown.
@@ -169,6 +169,10 @@ func calloutLabel(kind string) string {
 		return "Warning"
 	case "ASIDE":
 		return "Aside"
+	case "PREDICT":
+		return "Predict"
+	case "RECALL":
+		return "Recall"
 	}
 	return kind
 }

--- a/internal/verify/skills/lathe-verify.md
+++ b/internal/verify/skills/lathe-verify.md
@@ -24,7 +24,7 @@ Never write files outside the current working directory.
 
 The tutorial may include callouts and other non-load-bearing content. **Do not** execute commands or write files based on:
 
-- Anything inside a `> [!ASIDE]`, `> [!DESIGN-NOTE]`, `> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, or `> [!HEADS-UP]` blockquote callout — these are illustrative or advisory, not part of the build.
+- Anything inside a `> [!ASIDE]`, `> [!DESIGN-NOTE]`, `> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, `> [!HEADS-UP]`, `> [!PREDICT]`, or `> [!RECALL]` blockquote callout — these are illustrative or advisory, not part of the build.
 - The `## Exercises` section — these are reader homework, not part of the verified path.
 - The `## What's next` section (series only) — narrative bridge, no commands.
 


### PR DESCRIPTION
## Summary

Adds research-backed pedagogical beats to the `/lathe` tutorial generation skill, motivated by six learning-science principles (retrieval practice, prediction effect, faded scaffolding, spaced retrieval, elaborative feedback, self-explanation).

- New `[!PREDICT]` callout before every Checkpoint — reader commits to a prediction before seeing expected output (testing effect).
- New `[!RECALL]` callout at the top of Part N≥2 — turns inter-part gaps into spaced retrieval events.
- Faded scaffolding pattern: first code block fully worked, later ones become fill-the-seam where the reader writes the next instance.
- Likely-errors block on every Checkpoint (symptom → cause pairs) for elaborative feedback.
- Closing self-explanation prompt before Exercises, replacing recap with construction.
- Voice calibration before/after pairs for all four new beats.
- Verifier (`lathe-verify`) updated to treat `[!PREDICT]` / `[!RECALL]` as advisory, not load-bearing commands.
- Pedagogy research doc with citations and mapping to SKILL.md sections.

## Test plan

- [ ] `go test ./...` passes (renderer test covers the new callout classes).
- [ ] `go vet ./...` clean.
- [ ] Generate a fresh tutorial via `/lathe` and confirm `[!PREDICT]` and `[!RECALL]` callouts render with the expected styling in `lathe serve`.
- [ ] Confirm verifier still passes a known-good existing tutorial (no false positives on the new callout types).