### PR TITLE
feat: on-demand tutorial part generation via lathe extend and web UI

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -13,20 +13,13 @@ The user says something like `/lathe build a digital synth in Zig` or `/lathe ho
 
 1. Ask: **"What's your experience level going in — beginner, some familiarity, or experienced in adjacent areas?"**
 2. If the topic is genuinely ambiguous (language? scale? embedded vs. server?), ask **one** clarifying question. Otherwise skip.
-3. Decide single-tutorial vs. series.
-4. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
-5. Write.
-6. Hand off to the CLI.
+3. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
+4. Write Part 1.
+5. Hand off to the CLI.
 
-## Single vs. series
+## Always write Part 1 only
 
-Generate a **series** when ALL of these hold:
-
-- The end product is non-trivial — a working compiler, synth, database, game engine.
-- There are 3+ natural milestones, each producing something runnable independently.
-- Done well, it would exceed ~2500 words.
-
-Otherwise, write a **single tutorial**.
+Every `/lathe` invocation produces exactly one file: `part-01.md`. Never write multiple parts in one shot and never write `index.md`. Readers add more parts via the "Add a new part" button in `lathe serve`, which gives them full control over pacing and direction.
 
 ## Pre-flight (private — do not ask the user)
 
@@ -82,17 +75,17 @@ Expected output:
 - If you see `<exact error text>`, you probably <short causal explanation, e.g. "skipped the import in §2">.
 - If you see `<exact error text>`, you probably <short causal explanation>.
 
-## What's next            (series only, except final part)
+## What's next
 
-One paragraph naming the unanswered question that the next part will answer.
+One paragraph naming the unanswered question a future part will answer. Include in every part — it invites the reader to continue.
 
-## Exercises               (final part of a series, or a single tutorial)
+## Exercises
 
 1. <specific>
 2. <specific>
 3. <specific>
 
-## Sources                 (final part of a series, or a single tutorial)
+## Sources
 
 1. [Title](url) — one sentence on why this source matters for the topic.
 2. ...
@@ -100,9 +93,7 @@ One paragraph naming the unanswered question that the next part will answer.
 (Numbered list. Only sources cited inline. Each entry: `[Title](url) — one sentence`. Group by primary docs / papers / deep-dives if more than ~5 entries.)
 ```
 
-For **series**, every part must open with *"By the end of this part, you'll have [specific, concrete thing]"* and close with a Checkpoint.
-
-**Spaced retrieval for Part 2 and later:** Before the opening promise, insert one `[!RECALL]` callout that asks the reader to reconstruct a *load-bearing* concept from the previous part — something the current part depends on. One sentence is enough: *"Quick recall: what does the ring buffer's `write_pos` field track, and why does it wrap at `BUFFER_SIZE`?"* The gap between reading sessions is a free spacing event; the callout turns it into a retrieval event.
+Every part opens with *"By the end of this part, you'll have [specific, concrete thing]"* and closes with a Checkpoint. Every part stands alone with its own `## Exercises` and `## Sources` — since any part may become the last one the reader sees, each must be independently complete.
 
 ## Openings
 
@@ -286,22 +277,21 @@ flowchart LR
 
 Every major section ends with a one-sentence forward-pointer naming the question the next section answers.
 
-Every tutorial — and the final part of a series — ends with **four** things:
+Every part ends with **four** things:
 
-1. **A send-off.** One short paragraph that invites the reader to leave the path you took. Nystrom's canonical: *"I want to leave you yearning to strike out on your own and wander all over that mountain."* Make yours specific to the domain.
-2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in the tutorial and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
+1. **A send-off (or forward hook).** For the final part: one short paragraph inviting the reader to leave the path you took. For non-final parts: a single forward-pointing sentence naming the question the next part will answer — lean into the cliffhanger.
+2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in this part and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
 3. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
-4. **`## Sources`**, numbered, one entry per source used inline. Format: `[Title](url) — one sentence on why this source matters`. Group by primary docs / papers / deep-dives if more than ~5 entries. For a series, only the final part carries the consolidated Sources section; earlier parts still link inline but do not repeat the full list.
+4. **`## Sources`**, numbered, one entry per source used inline in *this part*. Format: `[Title](url) — one sentence on why this source matters`. Group by primary docs / papers / deep-dives if more than ~5 entries.
 
 ## Output files
 
 Write to `/tmp/lathe-<slug>/`. Slug is the topic in kebab-case.
 
 - "build a digital synth in Zig" → `/tmp/lathe-digital-synth-zig/`
-- Series: `part-01.md`, `part-02.md`, … (zero-padded so they sort)
-- Single: `index.md`
+- Always: `part-01.md` — one file, zero-padded so it sorts cleanly.
 
-Decide the slug before writing.
+Decide the slug before writing. Never write `index.md` or multiple parts.
 
 ## After writing
 
@@ -314,7 +304,7 @@ lathe store --verify /tmp/lathe-<slug>
 Then tell the user:
 
 - "**Tutorial saved.** Run `lathe serve` to open it at http://localhost:4242."
-- For a series: *"This is a [N]-part series. Part 1 ends with [X], Part 2 with [Y], …"*
+- "This is Part 1. To add more parts, open the tutorial in `lathe serve` and use **'Add a new part'** at the bottom — you can give guidance or let it continue naturally."
 - "Verification is running in the background — the ⏳ badge turns ✅ when it's done."
 
 ## Stay in session

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .superpowers/
 /lathe
+.claude/

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Lathe targets topics where good documentation is scarce — *"build a digital sy
 
 Two layers with a clean boundary:
 
-- **`/lathe` skill** (Claude Code) — generates the tutorial markdown. Asks one or two scoping questions, decides single-post vs. multi-part series, writes files to `/tmp/lathe-<slug>/`, then hands off to the CLI.
+- **`/lathe` skill** (Claude Code) — generates the tutorial markdown. Asks one or two scoping questions, writes `part-01.md` to `/tmp/lathe-<slug>/`, then hands off to the CLI. Additional parts are added on demand via the browser UI.
 - **`lathe` CLI** (Go) — copies the tutorial into `~/.lathe/tutorials/`, optionally spawns a background Claude subprocess that works through the tutorial step by step to verify it compiles and runs, and serves the rendered output at `http://localhost:4242`.
 
 ```
 User: /lathe "build a digital synth in Zig"
         │
         ▼
-  [/lathe skill]                     generates markdown, picks single vs series
+  [/lathe skill]                     generates part-01.md
         │
         ▼  lathe store --verify /tmp/lathe-<slug>
   [lathe CLI]                        copies files, kicks off background verify
         │
         ├── ~/.lathe/tutorials/<slug>/
         │       metadata.json        status: verifying → verified | failed
-        │       part-01.md, part-02.md, …  (or index.md for single)
+        │       part-01.md, part-02.md, …
         │
         └── [bg: claude + /lathe-verify skill in temp dir]
                 works through each step, runs every checkpoint command,

--- a/cmd/extend.go
+++ b/cmd/extend.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/devenjarvis/lathe/internal/config"
+	"github.com/devenjarvis/lathe/internal/extend"
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var extendGuidance string
+
+var extendCmd = &cobra.Command{
+	Use:   "extend <slug>",
+	Short: "Add a new part to an existing tutorial",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		tutorialsDir, err := config.TutorialsDir()
+		if err != nil {
+			return err
+		}
+		tutDir := filepath.Join(tutorialsDir, slug)
+
+		if err := store.PromoteIndexToPart(tutDir); err != nil {
+			return fmt.Errorf("promote legacy tutorial: %w", err)
+		}
+
+		if err := extend.SpawnExtender(slug, tutDir, extendGuidance); err != nil {
+			return err
+		}
+
+		tut, _ := store.ReadMetadata(tutDir)
+		pendingPart := ""
+		if tut != nil {
+			pendingPart = tut.PendingPart
+		}
+		if pendingPart != "" {
+			fmt.Printf("Extending tutorial %q with %s (running in background; refresh `lathe serve` to watch)\n", slug, pendingPart)
+		} else {
+			fmt.Printf("Extending tutorial %q (running in background; refresh `lathe serve` to watch)\n", slug)
+		}
+		return nil
+	},
+}
+
+func init() {
+	extendCmd.Flags().StringVar(&extendGuidance, "guidance", "", "optional guidance for the next part")
+	rootCmd.AddCommand(extendCmd)
+}

--- a/cmd/extend_test.go
+++ b/cmd/extend_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func TestExtendCommandFlipsMetadataToExtending(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "") // prevent claude from being found
+
+	// Create a minimal tutorial under ~/.lathe/tutorials/test-slug/
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", "test-slug")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:   "test-slug",
+		Title:  "Test Slug",
+		Status: store.StatusVerified,
+		Parts:  []string{"part-01.md"},
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the command directly; PATH="" means SpawnExtender will fail fast but
+	// metadata flip happens before spawn.
+	extendCmd.Flags().Set("guidance", "") //nolint:errcheck
+	extendCmd.RunE(extendCmd, []string{"test-slug"})
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata after extend: %v", err)
+	}
+	if got.Status != store.StatusExtending {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusExtending)
+	}
+	if got.PendingPart != "part-02.md" {
+		t.Errorf("PendingPart = %q, want %q", got.PendingPart, "part-02.md")
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ var listCmd = &cobra.Command{
 				continue
 			}
 			parts := "single"
-			if tut.Series {
+			if tut.IsSeries() {
 				parts = fmt.Sprintf("%d parts", len(tut.Parts))
 			}
 			badge := statusBadge(tut.Status)
@@ -57,6 +57,8 @@ func statusBadge(s store.Status) string {
 		return "⏳ verifying"
 	case store.StatusFailed:
 		return "❌ failed"
+	case store.StatusExtending:
+		return "⏳ extending"
 	default:
 		return string(s)
 	}

--- a/internal/extend/extend.go
+++ b/internal/extend/extend.go
@@ -1,0 +1,146 @@
+package extend
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/devenjarvis/lathe/internal/verify"
+)
+
+//go:embed skills/lathe-extend.md
+var extendSkillContent string
+
+// NextPartFilename returns the zero-padded part-NN.md filename that follows
+// the last entry in parts, or "part-01.md" when parts is empty.
+func NextPartFilename(parts []string) string {
+	return fmt.Sprintf("part-%02d.md", len(parts)+1)
+}
+
+// SpawnExtender writes metadata (status=extending, pending_part=next) before
+// spawning the claude subprocess so the UI shows the in-flight badge even if
+// spawn fails. On success the goroutine appends to Parts, clears PendingPart,
+// sets status=verifying, and calls verify.SpawnVerifier.
+func SpawnExtender(slug, tutorialDir, guidance string) error {
+	tut, err := store.ReadMetadata(tutorialDir)
+	if err != nil {
+		return fmt.Errorf("read metadata: %w", err)
+	}
+
+	if tut.Status == store.StatusExtending || tut.Status == store.StatusVerifying {
+		return fmt.Errorf("already extending or verifying: status is %q", tut.Status)
+	}
+
+	pendingPart := NextPartFilename(tut.Parts)
+
+	tut.Status = store.StatusExtending
+	tut.PendingPart = pendingPart
+	if err := store.WriteMetadata(tutorialDir, tut); err != nil {
+		return fmt.Errorf("write metadata: %w", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "lathe-extend-"+slug+"-")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+
+	skillDir := filepath.Join(tempDir, ".claude", "skills", "lathe-extend")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		os.RemoveAll(tempDir)
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	skillPath := filepath.Join(skillDir, "lathe-extend.md")
+	if err := os.WriteFile(skillPath, []byte(extendSkillContent), 0644); err != nil {
+		os.RemoveAll(tempDir)
+		return fmt.Errorf("write skill: %w", err)
+	}
+
+	system := buildSystemPrompt(tut, tutorialDir)
+	user := buildUserPrompt(tut, tutorialDir, pendingPart, guidance)
+
+	cmd := exec.Command("claude",
+		"--add-dir", tempDir,
+		"--add-dir", tutorialDir,
+		"--dangerously-skip-permissions",
+		"--allowedTools", "Read,Glob,Grep,Write",
+		"--system-prompt", system,
+		"-p", user,
+	)
+	cmd.Env = os.Environ()
+
+	if err := cmd.Start(); err != nil {
+		os.RemoveAll(tempDir)
+		// Leave metadata as "extending" — same contract as verify.SpawnVerifier:
+		// the status was committed before spawn; callers observe it in-flight.
+		return fmt.Errorf("start extender: %w", err)
+	}
+
+	go func() {
+		defer os.RemoveAll(tempDir)
+		waitErr := cmd.Wait()
+		partPath := filepath.Join(tutorialDir, pendingPart)
+		if waitErr == nil {
+			if _, statErr := os.Stat(partPath); statErr == nil {
+				// Success: append part, clear pending, chain to verifier
+				current, readErr := store.ReadMetadata(tutorialDir)
+				if readErr == nil {
+					current.Parts = append(current.Parts, pendingPart)
+					current.PendingPart = ""
+					current.Status = store.StatusVerifying
+					if writeErr := store.WriteMetadata(tutorialDir, current); writeErr == nil {
+						verify.SpawnVerifier(slug, tutorialDir) //nolint:errcheck
+					}
+					return
+				}
+			}
+		}
+		// Failure: flip to failed
+		current, readErr := store.ReadMetadata(tutorialDir)
+		if readErr == nil {
+			store.WriteMetadata(tutorialDir, failedMeta(current)) //nolint:errcheck
+		}
+	}()
+
+	return nil
+}
+
+func failedMeta(tut *store.Tutorial) *store.Tutorial {
+	tut.Status = store.StatusFailed
+	tut.PendingPart = ""
+	return tut
+}
+
+func buildSystemPrompt(tut *store.Tutorial, tutorialDir string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are continuing the tutorial %q (topic: %s).\n\n", tut.Title, tut.Topic)
+	b.WriteString("Below are all existing parts in order. Read them to understand the arc, voice, and controlling example.\n\n")
+	for _, p := range tut.Parts {
+		data, err := os.ReadFile(filepath.Join(tutorialDir, p))
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&b, "--- BEGIN %s ---\n", p)
+		b.Write(data)
+		if len(data) > 0 && data[len(data)-1] != '\n' {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "--- END %s ---\n\n", p)
+	}
+	return b.String()
+}
+
+func buildUserPrompt(tut *store.Tutorial, tutorialDir, pendingPart, guidance string) string {
+	var b strings.Builder
+	n, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(pendingPart, "part-"), ".md"))
+	fmt.Fprintf(&b, "Write Part %d of the tutorial. Save it as %q inside the tutorial directory %q.\n",
+		n, pendingPart, tutorialDir)
+	if guidance != "" {
+		fmt.Fprintf(&b, "\nUser guidance for this part: %s\n", guidance)
+	}
+	return b.String()
+}

--- a/internal/extend/extend_test.go
+++ b/internal/extend/extend_test.go
@@ -1,0 +1,112 @@
+package extend_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/extend"
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func makeTutorialDir(t *testing.T, parts []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	tut := &store.Tutorial{
+		Slug:   "test-tut",
+		Title:  "Test Tutorial",
+		Status: store.StatusVerified,
+		Parts:  parts,
+	}
+	for _, p := range parts {
+		if err := os.WriteFile(filepath.Join(dir, p), []byte("# "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestNextPartFilename(t *testing.T) {
+	cases := []struct {
+		parts []string
+		want  string
+	}{
+		{nil, "part-01.md"},
+		{[]string{}, "part-01.md"},
+		{[]string{"part-01.md"}, "part-02.md"},
+		{[]string{"part-01.md", "part-02.md"}, "part-03.md"},
+		{[]string{"part-01.md", "part-02.md", "part-03.md"}, "part-04.md"},
+	}
+	for _, tc := range cases {
+		got := extend.NextPartFilename(tc.parts)
+		if got != tc.want {
+			t.Errorf("NextPartFilename(%v) = %q, want %q", tc.parts, got, tc.want)
+		}
+	}
+}
+
+func TestSpawnExtenderWritesExtendingMetadataBeforeSpawn(t *testing.T) {
+	tutDir := makeTutorialDir(t, []string{"part-01.md"})
+	// Block claude so SpawnExtender fails fast, but metadata should already be written
+	t.Setenv("PATH", "")
+
+	// Intentionally ignoring error — claude won't be found
+	extend.SpawnExtender("test-tut", tutDir, "")
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("metadata not written before spawn: %v", err)
+	}
+	if got.Status != store.StatusExtending {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusExtending)
+	}
+	if got.PendingPart != "part-02.md" {
+		t.Errorf("PendingPart = %q, want %q", got.PendingPart, "part-02.md")
+	}
+}
+
+func TestSpawnExtenderRejectsConcurrent(t *testing.T) {
+	tutDir := makeTutorialDir(t, []string{"part-01.md"})
+	// Set status to extending manually
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tut.Status = store.StatusExtending
+	tut.PendingPart = "part-02.md"
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	err = extend.SpawnExtender("test-tut", tutDir, "")
+	if err == nil {
+		t.Fatal("SpawnExtender() should return error when already extending")
+	}
+	if !strings.Contains(err.Error(), "already extending") {
+		t.Errorf("error should mention 'already extending', got: %v", err)
+	}
+}
+
+func TestSpawnExtenderRejectsWhileVerifying(t *testing.T) {
+	tutDir := makeTutorialDir(t, []string{"part-01.md"})
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tut.Status = store.StatusVerifying
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	err = extend.SpawnExtender("test-tut", tutDir, "")
+	if err == nil {
+		t.Fatal("SpawnExtender() should return error when verifying")
+	}
+	if !strings.Contains(err.Error(), "already extending") {
+		t.Errorf("error should mention 'already extending', got: %v", err)
+	}
+}

--- a/internal/extend/skills/lathe-extend.md
+++ b/internal/extend/skills/lathe-extend.md
@@ -1,0 +1,122 @@
+# lathe-extend — Tutorial Part Extender
+
+<!-- NOTE: This skill is a focused subset of .claude/skills/lathe/SKILL.md.
+     It covers tutorial shape and voice rules only. The single-vs-series
+     decision and CLI handoff instructions are intentionally absent — the
+     parent process handles those. When SKILL.md changes substantially,
+     review this file for drift. -->
+
+You are continuing an existing hands-on technical tutorial by writing the next part. The system prompt provides the tutorial title, topic, all existing parts in full, and optional user guidance. Write exactly one new part file.
+
+## Your task
+
+1. Read the existing parts (provided in the system prompt) to understand the tutorial's arc, controlling example, voice, and where it left off.
+2. Decide what the next part should cover, building naturally on where the previous part ended. If the user provided guidance, follow it; otherwise continue the natural arc.
+3. Write the part as `part-NN.md` (the exact filename is specified in the user prompt). Do not write any other files.
+
+## Tutorial shape
+
+Every part follows this shape. Section *titles* must be specific to the domain — never `## Step 1: Setup`. Title the thing the section makes.
+
+```
+# [Title]
+
+> [!RECALL]
+> Quick recall before we continue: [one load-bearing question about a concept from a prior part].
+
+By the end of this part, you'll have [specific, concrete thing].
+
+## [Specific section title — name what this section makes]
+
+Why this exists. Then code, in small blocks, each with an insertion point.
+Aside or design note where it earns its keep.
+
+## [...]
+
+## Checkpoint
+
+> [!PREDICT]
+> Before you run this: what output do you expect to see?
+
+**Run this to verify your work so far:**
+```bash
+<the exact command>
+```
+
+Expected output:
+```
+<what they should see>
+```
+
+**Likely errors:**
+- If you see `<exact error text>`, you probably <short causal explanation>.
+
+## What's next
+
+One paragraph naming the unanswered question that the next part will answer.
+(Omit on the final part of the series; replace with Exercises and Sources instead.)
+
+## Exercises               (final part only)
+
+1. <specific>
+2. <specific>
+3. <specific>
+
+## Sources                 (final part only)
+
+1. [Title](url) — one sentence on why this source matters.
+```
+
+**The `[!RECALL]` callout is mandatory at the top of every continued part.** Pick the single most load-bearing concept from the previous part — the one the current part depends on — and ask the reader to reconstruct it. One sentence is enough.
+
+## Voice
+
+You are a friend who has done this before, sitting next to the reader at the keyboard, with opinions. Warm, specific, a little wry — never corporate, never breathless.
+
+### Do these
+
+- **Have a point of view.** Pick a side on tradeoffs.
+- **Name the trapdoors.** Warn before the reader falls in.
+- **Show the wrong version first, then the fix.** Let the reader feel why the fix matters.
+- **Real names from the domain.** Never `foo` / `bar`.
+- **Specific numbers, every time.** "Slow" is forgettable. `48000` isn't.
+- **Iterate code; don't dump it.** Show 3–15 line blocks. Name the seam for modifications.
+- **Cite inline** the first time a load-bearing fact lands.
+- **Forward-pointing endings.** End each section naming the question the next answers.
+
+### Avoid
+
+- LinkedIn voice: *leverage, robust, powerful, seamless, in today's fast-paced world*.
+- Hype words: *amazing, awesome, simply, just, easy, effortless*.
+- Throat-clearing: *In this part…, Let's dive in, Welcome back*.
+- Hedging tics: *you might want to consider perhaps possibly*.
+- Bot tells: bulleted lists of three sentences each starting with the same verb.
+
+## Asides and design notes
+
+````markdown
+> [!ASIDE]
+> Short inline note — etymology, war story, one-line joke that earns its keep.
+````
+
+````markdown
+> [!DESIGN-NOTE]
+> **Why X and not Y?**
+> Multi-paragraph. Lives at the end of a section, never mid-step.
+````
+
+Other callouts: `[!HEADS-UP]` (trapdoors), `[!NOTE]` (neutral info), `[!TIP]` (shortcut), `[!PREDICT]` (before a Checkpoint), `[!RECALL]` (top of part — mandatory).
+
+Use sparingly. One or two per part, max.
+
+## Code
+
+- One sentence before every block, telling the reader what to look at first.
+- Blocks are 3–15 lines, except for full small files. Larger means split.
+- For modifications, name the seam: *"Inside `process_buffer`, just after the voices loop, add:"*
+- No unexplained `...` ellipses.
+- Code is complete enough to run as shown.
+
+## Output
+
+Write exactly one file: the filename given in the user prompt (e.g. `part-02.md`). Write it to the tutorial directory specified. Do not write any other files. Do not call `lathe store` or any shell command.

--- a/internal/serve/ask.go
+++ b/internal/serve/ask.go
@@ -303,7 +303,7 @@ func buildAskPrompt(tut *store.Tutorial, part, articleBody, question string) (sy
 	b.WriteString("- Go as deep as the question warrants. There is no length cap — short questions deserve short answers, and substantive questions deserve substantive ones.\n")
 	b.WriteString("- Cite concrete sections, code snippets, or paragraphs from the part text below when they support your answer. Quote the relevant lines instead of paraphrasing them away.\n")
 
-	if tut != nil && tut.Series && len(tut.Parts) > 1 {
+	if tut != nil && tut.IsSeries() {
 		// Build the list of *other* parts so the model knows what it can
 		// consult via Read/Glob/Grep.
 		var siblings []string

--- a/internal/serve/ask_test.go
+++ b/internal/serve/ask_test.go
@@ -27,7 +27,6 @@ func makeTutFixture(t *testing.T, dir, slug string, series bool) string {
 		Slug:    slug,
 		Title:   "Test Tutorial",
 		Status:  store.StatusVerified,
-		Series:  series,
 		Created: time.Now(),
 	}
 	if series {
@@ -50,7 +49,7 @@ func makeTutFixture(t *testing.T, dir, slug string, series bool) string {
 
 func TestBuildAskPrompt(t *testing.T) {
 	t.Run("non-series", func(t *testing.T) {
-		tut := &store.Tutorial{Title: "Single", Series: false}
+		tut := &store.Tutorial{Title: "Single"}
 		system, user := buildAskPrompt(tut, "index.md", "Hello world", "What is X?")
 
 		if !strings.Contains(system, "Single") {
@@ -90,9 +89,8 @@ func TestBuildAskPrompt(t *testing.T) {
 
 	t.Run("series", func(t *testing.T) {
 		tut := &store.Tutorial{
-			Title:  "Series",
-			Series: true,
-			Parts:  []string{"part-01.md", "part-02.md", "part-03.md"},
+			Title: "Series",
+			Parts: []string{"part-01.md", "part-02.md", "part-03.md"},
 		}
 		system, user := buildAskPrompt(tut, "part-02.md", "Body of part 2", "Why?")
 
@@ -121,9 +119,8 @@ func TestBuildAskPrompt(t *testing.T) {
 
 	t.Run("series with single part omits sibling block", func(t *testing.T) {
 		tut := &store.Tutorial{
-			Title:  "Solo",
-			Series: true,
-			Parts:  []string{"part-01.md"},
+			Title: "Solo",
+			Parts: []string{"part-01.md"},
 		}
 		system, _ := buildAskPrompt(tut, "part-01.md", "Body", "Q?")
 		if strings.Contains(system, "Other parts in this series") {
@@ -135,9 +132,8 @@ func TestBuildAskPrompt(t *testing.T) {
 		// Same inputs must produce the same bytes — tests rely on this and
 		// it would be a regression for callers caching prompts.
 		tut := &store.Tutorial{
-			Title:  "Det",
-			Series: true,
-			Parts:  []string{"part-01.md", "part-02.md"},
+			Title: "Det",
+			Parts: []string{"part-01.md", "part-02.md"},
 		}
 		s1, u1 := buildAskPrompt(tut, "part-01.md", "Body", "Q?")
 		s2, u2 := buildAskPrompt(tut, "part-01.md", "Body", "Q?")

--- a/internal/serve/extend.go
+++ b/internal/serve/extend.go
@@ -1,0 +1,72 @@
+package serve
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/devenjarvis/lathe/internal/extend"
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+const maxGuidanceBytes = 2 * 1024
+
+func (s *Server) handleExtend(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	tutDir, ok := s.safeTutorialPath(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxGuidanceBytes)
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "request body too large", http.StatusBadRequest)
+		return
+	}
+
+	var payload struct {
+		Guidance string `json:"guidance"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+	}
+
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if tut.Status == store.StatusExtending || tut.Status == store.StatusVerifying {
+		http.Error(w, "conflict: tutorial is already extending or verifying", http.StatusConflict)
+		return
+	}
+
+	if err := store.PromoteIndexToPart(tutDir); err != nil {
+		http.Error(w, "promote failed", http.StatusInternalServerError)
+		return
+	}
+
+	// SpawnExtender writes metadata to "extending" before attempting spawn.
+	// A spawn failure leaves metadata committed; we return 202 regardless so
+	// the UI can show the in-flight badge (the background goroutine flips to
+	// "failed" if the subprocess exits badly).
+	extend.SpawnExtender(slug, tutDir, payload.Guidance) //nolint:errcheck
+
+	tut, err = store.ReadMetadata(tutDir)
+	if err != nil || tut.Status != store.StatusExtending {
+		http.Error(w, "extend failed", http.StatusInternalServerError)
+		return
+	}
+
+	if tut.PendingPart != "" {
+		w.Header().Set("Location", "/"+slug+"/"+tut.PendingPart)
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+

--- a/internal/serve/extend_test.go
+++ b/internal/serve/extend_test.go
@@ -1,0 +1,149 @@
+package serve_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/lathe/internal/serve"
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func makeExtendTutorial(t *testing.T, dir, slug string, status store.Status, parts []string) string {
+	t.Helper()
+	tutDir := filepath.Join(dir, slug)
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    slug,
+		Title:   store.SlugToTitle(slug),
+		Status:  status,
+		Parts:   parts,
+		Created: time.Now(),
+	}
+	for _, p := range parts {
+		if err := os.WriteFile(filepath.Join(tutDir, p), []byte("# "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	return tutDir
+}
+
+func postExtend(t *testing.T, srv *serve.Server, slug string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/-/extend/"+slug, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestExtendRejectsWrongMethod(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/-/extend/test-tut", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("GET /-/extend = %d, want method not allowed", w.Code)
+	}
+}
+
+func TestExtendUnknownSlugIs404(t *testing.T) {
+	dir := t.TempDir()
+	srv := serve.NewServer(dir)
+
+	w := postExtend(t, srv, "no-such-tutorial", []byte(`{}`))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown slug = %d, want 404", w.Code)
+	}
+}
+
+func TestExtendOversizeBodyIs400(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	big := strings.Repeat("a", 3*1024)
+	body := []byte(`{"guidance":"` + big + `"}`)
+	w := postExtend(t, srv, "test-tut", body)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("oversize body = %d, want 400", w.Code)
+	}
+}
+
+func TestExtendBlankGuidanceAccepted(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", "") // prevent claude from spawning
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	body, _ := json.Marshal(map[string]string{"guidance": ""})
+	w := postExtend(t, srv, "test-tut", body)
+
+	if w.Code != http.StatusAccepted {
+		t.Errorf("blank guidance = %d, want 202", w.Code)
+	}
+
+	tutDir := filepath.Join(dir, "test-tut")
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Status != store.StatusExtending {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusExtending)
+	}
+}
+
+func TestExtendRejectsWhileExtending(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-tut")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:        "test-tut",
+		Status:      store.StatusExtending,
+		PendingPart: "part-02.md",
+		Parts:       []string{"part-01.md"},
+		Created:     time.Now(),
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	srv := serve.NewServer(dir)
+
+	body, _ := json.Marshal(map[string]string{"guidance": ""})
+	w := postExtend(t, srv, "test-tut", body)
+	if w.Code != http.StatusConflict {
+		t.Errorf("while extending = %d, want 409", w.Code)
+	}
+}
+
+func TestExtendRejectsWhileVerifying(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerifying, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	body, _ := json.Marshal(map[string]string{"guidance": ""})
+	w := postExtend(t, srv, "test-tut", body)
+	if w.Code != http.StatusConflict {
+		t.Errorf("while verifying = %d, want 409", w.Code)
+	}
+}

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -31,7 +31,7 @@
       --bg:#f9fafb;--surface:#fff;--border:#e5e7eb;--text:#111827;--text-muted:#374151;--text-subtle:#4b5563;--text-faint:#6b7280;
       --hover-bg:#f3f4f6;--active-bg:#eff6ff;--active-text:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;--blockquote-border:#d1d5db;
       --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
-      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;
+      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;--badge-extending-bg:#e0f2fe;--badge-extending-text:#0369a1;
       --callout-note-bg:#eff6ff;--callout-note-border:#3b82f6;--callout-note-label:#1d4ed8;
       --callout-tip-bg:#ecfdf5;--callout-tip-border:#10b981;--callout-tip-label:#047857;
       --callout-warn-bg:#fffbeb;--callout-warn-border:#f59e0b;--callout-warn-label:#b45309;
@@ -44,7 +44,7 @@
       --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-muted:#cbd5e1;--text-subtle:#9ca3af;--text-faint:#9ca3af;
       --hover-bg:#222632;--active-bg:#1e2a44;--active-text:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;--blockquote-border:#374151;
       --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
-      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;
+      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;--badge-extending-bg:#0c2a40;--badge-extending-text:#7dd3fc;
       --callout-note-bg:#172033;--callout-note-border:#3b82f6;--callout-note-label:#93c5fd;
       --callout-tip-bg:#0f2820;--callout-tip-border:#10b981;--callout-tip-label:#6ee7b7;
       --callout-warn-bg:#2a1f0a;--callout-warn-border:#f59e0b;--callout-warn-label:#fcd34d;
@@ -69,6 +69,7 @@
     .badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
     .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
     .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
+    .badge.extending{background:var(--badge-extending-bg);color:var(--badge-extending-text)}
     nav ul{list-style:none}
     nav li{margin:.2rem 0}
     nav a{display:block;font-size:.85rem;color:var(--text-subtle);text-decoration:none;padding:.35rem .6rem;border-radius:5px}
@@ -240,7 +241,7 @@
 <div id="progressBar" aria-hidden="true"><div></div></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
-  <span class="crumb"><strong>{{.Tutorial.Title}}</strong>{{if and .Tutorial.Series .CurrentPartNumber}}<span class="sep">›</span>Part {{.CurrentPartNumber}}{{end}}</span>
+  <span class="crumb"><strong>{{.Tutorial.Title}}</strong>{{if and .Tutorial.IsSeries .CurrentPartNumber}}<span class="sep">›</span>Part {{.CurrentPartNumber}}{{end}}</span>
 </header>
 <div class="layout">
   <nav id="sidebar">
@@ -249,6 +250,7 @@
     {{if eq .Tutorial.Status "verified"}}<span class="badge verified">✅ Verified</span>
     {{else if eq .Tutorial.Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
     {{else if eq .Tutorial.Status "failed"}}<span class="badge failed">❌ Failed</span>
+    {{else if eq .Tutorial.Status "extending"}}<span class="badge extending">⏳ Extending…</span>
     {{end}}
     {{if .TOC}}
     <h3 class="toc-label">On this page</h3>
@@ -263,7 +265,7 @@
   </nav>
   <main>
     {{.Content}}
-    {{if and .Tutorial.Series (gt (len .Tutorial.Parts) 1)}}
+    {{if .Tutorial.IsSeries}}
     <section class="series-toc" aria-label="In this series">
       <h2>In this series</h2>
       <ol>
@@ -279,7 +281,7 @@
       </ol>
     </section>
     {{end}}
-    {{if .Tutorial.Series}}
+    {{if .Tutorial.IsSeries}}
     <nav class="part-nav" aria-label="Part navigation">
       {{if .PrevPart}}
       <a href="/{{.Tutorial.Slug}}/{{.PrevPart}}" class="prev">

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{.Title}} — Lathe</title>
+  {{if eq .Tutorial.Status "extending"}}<meta http-equiv="refresh" content="5">{{end}}
   <script>
     (function(){
       try {
@@ -167,6 +168,8 @@
     #extendForm button[type="submit"]{align-self:flex-start;background:var(--active-bg);color:var(--active-text);border:1px solid var(--active-text);padding:.5rem 1.1rem;border-radius:6px;font:inherit;font-size:.9rem;font-weight:600;cursor:pointer}
     #extendForm button[type="submit"]:hover{opacity:.85}
     .extend-error{font-size:.85rem;color:var(--badge-failed-text);min-height:1.2em}
+    .extending-panel{color:var(--text-muted)}
+    .extending-panel .muted{font-size:.85rem;color:var(--text-faint);margin-top:.25rem}
 
     /* Floating Ask button (wide screens) */
     #askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;background:var(--active-bg);color:var(--active-text);border:1px solid var(--border);font:inherit;font-weight:600;font-size:.9rem;padding:.65rem 1.1rem;border-radius:9999px;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.15);transition:transform 150ms ease-out,box-shadow 150ms ease-out}
@@ -306,7 +309,12 @@
     </nav>
     {{end}}
     {{if .IsLastPart}}
-    {{if ne .Tutorial.Status "extending"}}
+    {{if eq .Tutorial.Status "extending"}}
+    <section class="extend-section extending-panel">
+      <p>⏳ Generating part {{.PendingPartNumber}}…</p>
+      <p class="muted">This page will refresh automatically.</p>
+    </section>
+    {{else}}
     <section class="extend-section">
       <form id="extendForm" method="POST" action="/-/extend/{{.Tutorial.Slug}}" data-pending-number="{{.NextPartNumber}}">
         <h3>Continue this series</h3>

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -159,6 +159,14 @@
     .part-nav .title{font-size:.92rem;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
     .part-nav .next{text-align:right}
     .part-nav .spacer{display:block}
+    .extend-section{margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--border)}
+    .extend-section h3{font-size:.95rem;font-weight:600;margin:0 0 .75rem;color:var(--text-muted)}
+    #extendForm{display:flex;flex-direction:column;gap:.6rem}
+    #extendForm textarea{width:100%;padding:.6rem .75rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font:inherit;font-size:.92rem;resize:vertical;min-height:4.5rem}
+    #extendForm textarea:focus{outline:2px solid var(--active-text);outline-offset:1px}
+    #extendForm button[type="submit"]{align-self:flex-start;background:var(--active-bg);color:var(--active-text);border:1px solid var(--active-text);padding:.5rem 1.1rem;border-radius:6px;font:inherit;font-size:.9rem;font-weight:600;cursor:pointer}
+    #extendForm button[type="submit"]:hover{opacity:.85}
+    .extend-error{font-size:.85rem;color:var(--badge-failed-text);min-height:1.2em}
 
     /* Floating Ask button (wide screens) */
     #askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;background:var(--active-bg);color:var(--active-text);border:1px solid var(--border);font:inherit;font-weight:600;font-size:.9rem;padding:.65rem 1.1rem;border-radius:9999px;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.15);transition:transform 150ms ease-out,box-shadow 150ms ease-out}
@@ -296,6 +304,18 @@
       </a>
       {{else}}<span class="spacer"></span>{{end}}
     </nav>
+    {{end}}
+    {{if .IsLastPart}}
+    {{if ne .Tutorial.Status "extending"}}
+    <section class="extend-section">
+      <form id="extendForm" method="POST" action="/-/extend/{{.Tutorial.Slug}}" data-pending-number="{{.NextPartNumber}}">
+        <h3>Continue this series</h3>
+        <textarea name="guidance" placeholder="What should the next part cover? (optional)" rows="3"></textarea>
+        <button type="submit">Add Part {{.NextPartNumber}}</button>
+        <p class="extend-error" aria-live="polite"></p>
+      </form>
+    </section>
+    {{end}}
     {{end}}
   </main>
 </div>
@@ -743,6 +763,36 @@
         setSending(false);
         controller = null;
         try { input.focus(); } catch(e){}
+      });
+    });
+  })();
+</script>
+<script>
+  (function(){
+    var form = document.getElementById('extendForm');
+    if (!form) return;
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var action = form.getAttribute('action');
+      var guidance = form.querySelector('textarea[name="guidance"]').value;
+      var errEl = form.querySelector('.extend-error');
+      errEl.textContent = '';
+      var btn = form.querySelector('button[type="submit"]');
+      btn.disabled = true;
+      fetch(action, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({guidance: guidance})
+      }).then(function(r) {
+        if (r.status === 202) {
+          window.location.reload();
+        } else {
+          r.text().then(function(t){ errEl.textContent = 'Error: ' + (t || r.status); });
+          btn.disabled = false;
+        }
+      }).catch(function(err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        btn.disabled = false;
       });
     });
   })();

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -18,13 +18,13 @@
       --bg:#f9fafb;--surface:#fff;--border:#e5e7eb;--text:#111827;--text-faint:#6b7280;--text-empty:#9ca3af;
       --link:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;
       --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
-      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;
+      --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;--badge-extending-bg:#e0f2fe;--badge-extending-text:#0369a1;
     }
     [data-theme="dark"]{
       --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-faint:#9ca3af;--text-empty:#6b7280;
       --link:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;
       --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
-      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;
+      --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;--badge-extending-bg:#0c2a40;--badge-extending-text:#7dd3fc;
     }
     *{box-sizing:border-box;margin:0;padding:0}
     html,body{overflow-x:hidden}
@@ -46,6 +46,7 @@
     .badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
     .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
     .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
+    .badge.extending{background:var(--badge-extending-bg);color:var(--badge-extending-text)}
     .empty{color:var(--text-empty);text-align:center;padding:3rem 1rem;font-size:.95rem}
     .empty code{background:var(--code-bg);color:var(--code-text);padding:.1rem .35rem;border-radius:3px;font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em}
     .theme-toggle{background:transparent;border:1px solid var(--border);color:var(--text-faint);font:inherit;font-size:.8rem;padding:.4rem .6rem;border-radius:5px;cursor:pointer;display:inline-flex;align-items:center;gap:.4rem;flex-shrink:0;min-height:32px}
@@ -81,12 +82,13 @@
 <div class="tutorial">
   <div>
     <a href="/{{.Slug}}/">{{.Title}}</a>
-    <div class="meta">{{if .Series}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}</div>
+    <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}</div>
   </div>
   <div class="tutorial-actions">
     {{if eq .Status "verified"}}<span class="badge verified">✅ Verified</span>
     {{else if eq .Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
     {{else if eq .Status "failed"}}<span class="badge failed">❌ Failed</span>
+    {{else if eq .Status "extending"}}<span class="badge extending">⏳ Extending…</span>
     {{end}}
     <form method="POST" action="/-/delete/{{.Slug}}" class="delete-form" data-tutorial-title="{{.Title}}">
       <button type="submit" class="delete-btn" aria-label="Delete tutorial" title="Delete tutorial">×</button>

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/devenjarvis/lathe/internal/store"
@@ -239,10 +240,23 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"SeriesTOC":         seriesTOC,
 		"IsLastPart":        isLast,
 		"NextPartNumber":    len(tut.Parts) + 1,
+		"PendingPartNumber": pendingPartNumber(tut.PendingPart, len(tut.Parts)+1),
 	}); err != nil {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	buf.WriteTo(w)
+}
+
+func pendingPartNumber(pendingPart string, fallback int) int {
+	if pendingPart == "" {
+		return fallback
+	}
+	s := strings.TrimSuffix(strings.TrimPrefix(pendingPart, "part-"), ".md")
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return n
 }

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -126,7 +126,7 @@ func (s *Server) handleTutorial(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if tut.Series && len(tut.Parts) > 0 {
+	if tut.IsSeries() && len(tut.Parts) > 0 {
 		http.Redirect(w, r, fmt.Sprintf("/%s/%s", slug, tut.Parts[0]), http.StatusFound)
 		return
 	}
@@ -193,7 +193,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 	var prevPart, nextPart, prevTitle, nextTitle string
 	var prevNumber, nextNumber, currentNumber int
 	var seriesTOC []SeriesEntry
-	if tut.Series {
+	if tut.IsSeries() {
 		seriesTOC = make([]SeriesEntry, 0, len(tut.Parts))
 		for i, p := range tut.Parts {
 			seriesTOC = append(seriesTOC, SeriesEntry{

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -194,6 +194,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 	var prevPart, nextPart, prevTitle, nextTitle string
 	var prevNumber, nextNumber, currentNumber int
 	var seriesTOC []SeriesEntry
+	isLast := true
 	if tut.IsSeries() {
 		seriesTOC = make([]SeriesEntry, 0, len(tut.Parts))
 		for i, p := range tut.Parts {
@@ -205,6 +206,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 			})
 			if p == part {
 				currentNumber = i + 1
+				isLast = i == len(tut.Parts)-1
 				if i > 0 {
 					prevPart = tut.Parts[i-1]
 					prevTitle = store.SlugToTitle(strings.TrimSuffix(prevPart, ".md"))
@@ -235,6 +237,8 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"NextNumber":        nextNumber,
 		"TOC":               toc,
 		"SeriesTOC":         seriesTOC,
+		"IsLastPart":        isLast,
+		"NextPartNumber":    len(tut.Parts) + 1,
 	}); err != nil {
 		http.Error(w, "template error", http.StatusInternalServerError)
 		return

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -47,6 +47,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{slug}/{part}", s.handlePart)
 	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
 	mux.HandleFunc("POST /-/ask/{slug}/{part}", s.handleAsk)
+	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
 	return mux
 }
 

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -539,6 +539,50 @@ func TestExtendFormOnSinglePart(t *testing.T) {
 	}
 }
 
+func TestExtendingPanelRendersAndAutoRefreshes(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-extending")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:        "test-extending",
+		Title:       "Test Extending",
+		Status:      store.StatusExtending,
+		Parts:       []string{"part-01.md", "part-02.md", "part-03.md"},
+		PendingPart: "part-04.md",
+		Created:     time.Now(),
+	}
+	for _, p := range tut.Parts {
+		if err := os.WriteFile(filepath.Join(tutDir, p), []byte("# "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-extending/part-03.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-extending/part-03.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+
+	if !strings.Contains(body, "Generating part 4") {
+		t.Error("extending panel should show 'Generating part 4'")
+	}
+	if !strings.Contains(body, `http-equiv="refresh"`) {
+		t.Error("extending page should have meta refresh tag")
+	}
+	if strings.Contains(body, `id="extendForm"`) {
+		t.Error("extend form should NOT appear while status is extending")
+	}
+}
+
 func TestExtendingBadgeRendersOnList(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := filepath.Join(dir, "test-extending")

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -24,7 +24,6 @@ func makeTestTutorial(t *testing.T, dir, slug string, series bool) string {
 		Slug:    slug,
 		Title:   "Test Tutorial",
 		Status:  store.StatusVerified,
-		Series:  series,
 		Created: time.Now(),
 	}
 	if series {
@@ -107,7 +106,6 @@ func makeSeriesTutorialWithParts(t *testing.T, dir, slug string, numParts int) {
 		Slug:    slug,
 		Title:   "Test Series",
 		Status:  store.StatusVerified,
-		Series:  true,
 		Parts:   parts,
 		Created: time.Now(),
 	}
@@ -194,7 +192,6 @@ func TestSeriesSidebarAndBottomList(t *testing.T) {
 		Slug:    "test-series",
 		Title:   "Test Series",
 		Status:  store.StatusVerified,
-		Series:  true,
 		Parts:   []string{"part-01.md", "part-02.md"},
 		Created: time.Now(),
 	}
@@ -461,5 +458,77 @@ func TestPathTraversalBlocked(t *testing.T) {
 
 	if w.Code == http.StatusOK {
 		t.Error("path traversal should not succeed")
+	}
+}
+
+func TestExtendingBadgeRendersOnList(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-extending")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:        "test-extending",
+		Title:       "Test Extending",
+		Status:      store.StatusExtending,
+		Parts:       []string{"part-01.md", "part-02.md"},
+		PendingPart: "part-03.md",
+		Created:     time.Now(),
+	}
+	for _, p := range tut.Parts {
+		if err := os.WriteFile(filepath.Join(tutDir, p), []byte("# "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET / = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), `badge extending`) {
+		t.Error("list page missing extending badge for tutorial with status=extending")
+	}
+}
+
+func TestExtendingBadgeRendersOnPart(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-extending")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:        "test-extending",
+		Title:       "Test Extending",
+		Status:      store.StatusExtending,
+		Parts:       []string{"part-01.md", "part-02.md"},
+		PendingPart: "part-03.md",
+		Created:     time.Now(),
+	}
+	for _, p := range tut.Parts {
+		if err := os.WriteFile(filepath.Join(tutDir, p), []byte("# "+p), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-extending/part-02.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-extending/part-02.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), `badge extending`) {
+		t.Error("part page missing extending badge for tutorial with status=extending")
 	}
 }

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -461,6 +461,84 @@ func TestPathTraversalBlocked(t *testing.T) {
 	}
 }
 
+func TestExtendFormRendersOnLastPart(t *testing.T) {
+	dir := t.TempDir()
+	makeSeriesTutorialWithParts(t, dir, "test-series", 3)
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-series/part-03.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-series/part-03.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `id="extendForm"`) {
+		t.Error("last part should render extend form with id=extendForm")
+	}
+	if !strings.Contains(body, `action="/-/extend/test-series"`) {
+		t.Error("extend form should post to /-/extend/test-series")
+	}
+	if !strings.Contains(body, `placeholder="What should the next part cover?`) {
+		t.Error("extend form should have guidance textarea with placeholder")
+	}
+}
+
+func TestExtendFormHiddenOnNonLastPart(t *testing.T) {
+	dir := t.TempDir()
+	makeSeriesTutorialWithParts(t, dir, "test-series", 3)
+	srv := serve.NewServer(dir)
+
+	for _, part := range []string{"part-01.md", "part-02.md"} {
+		t.Run(part, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test-series/"+part, nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET /test-series/%s = %d, want %d", part, w.Code, http.StatusOK)
+			}
+			if strings.Contains(w.Body.String(), `id="extendForm"`) {
+				t.Errorf("non-last part %s should not render extend form", part)
+			}
+		})
+	}
+}
+
+func TestExtendFormOnSinglePart(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "single-tut")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "single-tut",
+		Title:   "Single Tutorial",
+		Status:  store.StatusVerified,
+		Parts:   []string{"part-01.md"},
+		Created: time.Now(),
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/single-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /single-tut/part-01.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), `id="extendForm"`) {
+		t.Error("single-part tutorial should render extend form on its only part")
+	}
+}
+
 func TestExtendingBadgeRendersOnList(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := filepath.Join(dir, "test-extending")

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -13,16 +13,21 @@ const (
 	StatusVerifying Status = "verifying"
 	StatusVerified  Status = "verified"
 	StatusFailed    Status = "failed"
+	StatusExtending Status = "extending"
 )
 
 type Tutorial struct {
-	Slug    string    `json:"slug"`
-	Title   string    `json:"title"`
-	Topic   string    `json:"topic"`
-	Created time.Time `json:"created"`
-	Status  Status    `json:"status"`
-	Series  bool      `json:"series"`
-	Parts   []string  `json:"parts,omitempty"`
+	Slug        string    `json:"slug"`
+	Title       string    `json:"title"`
+	Topic       string    `json:"topic"`
+	Created     time.Time `json:"created"`
+	Status      Status    `json:"status"`
+	Parts       []string  `json:"parts,omitempty"`
+	PendingPart string    `json:"pending_part,omitempty"`
+}
+
+func (t *Tutorial) IsSeries() bool {
+	return len(t.Parts) > 1
 }
 
 type VerifyResult struct {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -1,6 +1,9 @@
 package store_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,7 +18,6 @@ func TestWriteReadMetadata(t *testing.T) {
 		Topic:   "test tutorial",
 		Created: time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
 		Status:  store.StatusVerified,
-		Series:  false,
 	}
 
 	if err := store.WriteMetadata(dir, original); err != nil {
@@ -38,5 +40,74 @@ func TestReadMetadataNotFound(t *testing.T) {
 	_, err := store.ReadMetadata("/nonexistent/path/abc123")
 	if err == nil {
 		t.Error("ReadMetadata() expected error for missing file, got nil")
+	}
+}
+
+func TestTutorialIsSeries(t *testing.T) {
+	cases := []struct {
+		name  string
+		parts []string
+		want  bool
+	}{
+		{"zero parts", nil, false},
+		{"one part", []string{"part-01.md"}, false},
+		{"two parts", []string{"part-01.md", "part-02.md"}, true},
+		{"three parts", []string{"part-01.md", "part-02.md", "part-03.md"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tut := &store.Tutorial{Parts: tc.parts}
+			if got := tut.IsSeries(); got != tc.want {
+				t.Errorf("IsSeries() = %v, want %v (parts=%v)", got, tc.want, tc.parts)
+			}
+		})
+	}
+}
+
+func TestMetadataRoundTripPendingPart(t *testing.T) {
+	dir := t.TempDir()
+	tut := &store.Tutorial{
+		Slug:        "test-tut",
+		Title:       "Test Tutorial",
+		Status:      store.StatusExtending,
+		Parts:       []string{"part-01.md", "part-02.md", "part-03.md"},
+		PendingPart: "part-04.md",
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.PendingPart != "part-04.md" {
+		t.Errorf("PendingPart = %q, want %q", got.PendingPart, "part-04.md")
+	}
+	if got.Status != store.StatusExtending {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusExtending)
+	}
+}
+
+func TestStatusExtendingValue(t *testing.T) {
+	if store.StatusExtending != "extending" {
+		t.Errorf("StatusExtending = %q, want %q", store.StatusExtending, "extending")
+	}
+}
+
+func TestPendingPartOmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	tut := &store.Tutorial{
+		Slug:   "test-tut",
+		Status: store.StatusVerified,
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "pending_part") {
+		t.Error("pending_part should be omitted from JSON when empty")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,7 +26,7 @@ func Store(srcPath string, withVerify bool) (*Tutorial, error) {
 		return nil, fmt.Errorf("copy tutorial: %w", err)
 	}
 
-	parts, series := detectParts(destDir)
+	parts := detectParts(destDir)
 	status := StatusVerified
 	if withVerify {
 		status = StatusVerifying
@@ -38,7 +38,6 @@ func Store(srcPath string, withVerify bool) (*Tutorial, error) {
 		Topic:   slug,
 		Created: time.Now().UTC(),
 		Status:  status,
-		Series:  series,
 		Parts:   parts,
 	}
 
@@ -92,10 +91,10 @@ func copyFile(src, dst string) error {
 	return out.Close()
 }
 
-func detectParts(dir string) ([]string, bool) {
+func detectParts(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, false
+		return nil
 	}
 	var parts []string
 	for _, e := range entries {
@@ -104,7 +103,7 @@ func detectParts(dir string) ([]string, bool) {
 		}
 	}
 	sort.Strings(parts)
-	return parts, len(parts) > 0
+	return parts
 }
 
 func Delete(slug string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -140,3 +140,36 @@ func SlugToTitle(slug string) string {
 	}
 	return strings.Join(words, " ")
 }
+
+// PromoteIndexToPart renames index.md to part-01.md and updates metadata.Parts.
+// No-op if part-01.md already exists or index.md is absent.
+// Rename is done first; metadata is written only after a successful rename,
+// so a failure mid-operation leaves the tutorial in a consistent state.
+func PromoteIndexToPart(tutorialDir string) error {
+	indexPath := filepath.Join(tutorialDir, "index.md")
+	partPath := filepath.Join(tutorialDir, "part-01.md")
+
+	// stat the tutorial dir to detect missing dir early
+	if _, err := os.Stat(tutorialDir); err != nil {
+		return fmt.Errorf("tutorial dir: %w", err)
+	}
+
+	// already promoted or nothing to promote
+	if _, err := os.Stat(partPath); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := os.Rename(indexPath, partPath); err != nil {
+		return fmt.Errorf("rename index.md to part-01.md: %w", err)
+	}
+
+	tut, err := ReadMetadata(tutorialDir)
+	if err != nil {
+		return fmt.Errorf("read metadata after rename: %w", err)
+	}
+	tut.Parts = []string{"part-01.md"}
+	return WriteMetadata(tutorialDir, tut)
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -20,8 +20,8 @@ func TestStoreSingleTutorial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
-	if tut.Series {
-		t.Error("Store() Series = true, want false for single tutorial")
+	if tut.IsSeries() {
+		t.Error("Store() IsSeries() = true, want false for single tutorial")
 	}
 	if tut.Status != store.StatusVerified {
 		t.Errorf("Store() Status = %q, want %q", tut.Status, store.StatusVerified)
@@ -41,8 +41,8 @@ func TestStoreSeriesTutorial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
-	if !tut.Series {
-		t.Error("Store() Series = false, want true for series")
+	if !tut.IsSeries() {
+		t.Error("Store() IsSeries() = false, want true for series")
 	}
 	if len(tut.Parts) != 3 {
 		t.Errorf("Store() Parts = %v, want 3 parts", tut.Parts)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -158,3 +158,65 @@ func TestSlugToTitle(t *testing.T) {
 		}
 	}
 }
+
+func TestPromoteIndexToPartRenamesAndUpdatesMetadata(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.md"), []byte("# Hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:   "test-tut",
+		Title:  "Test Tutorial",
+		Status: store.StatusVerified,
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.PromoteIndexToPart(dir); err != nil {
+		t.Fatalf("PromoteIndexToPart() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "part-01.md")); err != nil {
+		t.Error("part-01.md should exist after promotion")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "index.md")); !os.IsNotExist(err) {
+		t.Error("index.md should be gone after promotion")
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if len(got.Parts) != 1 || got.Parts[0] != "part-01.md" {
+		t.Errorf("Parts = %v, want [part-01.md]", got.Parts)
+	}
+}
+
+func TestPromoteIndexToPartIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "part-01.md"), []byte("# Hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:   "test-tut",
+		Parts:  []string{"part-01.md"},
+		Status: store.StatusVerified,
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.PromoteIndexToPart(dir); err != nil {
+		t.Fatalf("PromoteIndexToPart() error = %v (should be no-op)", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "part-01.md")); err != nil {
+		t.Error("part-01.md should still exist")
+	}
+}
+
+func TestPromoteIndexToPartFailsCleanly(t *testing.T) {
+	err := store.PromoteIndexToPart("/nonexistent/path/abc123xyz")
+	if err == nil {
+		t.Error("PromoteIndexToPart() on missing dir should return error")
+	}
+}


### PR DESCRIPTION
## Summary

- **Metadata refactor:** Drop `Series bool` in favour of derived `IsSeries()` (len(Parts) > 1). Add `PendingPart string` and `StatusExtending` to track in-flight generation.
- **`store.PromoteIndexToPart`:** Atomically renames legacy `index.md` → `part-01.md` and updates metadata so the extension flow works uniformly.
- **`internal/extend.SpawnExtender`:** New package that writes metadata before spawning `claude` (so the UI shows the in-flight badge even on spawn failure), builds a system prompt from all existing parts, and chains to `verify.SpawnVerifier` on success.
- **`lathe extend <slug> [--guidance "..."]`:** CLI command with the same code path as the web endpoint.
- **`POST /-/extend/{slug}`:** HTTP endpoint — returns 202, rejects with 409 while extending/verifying, caps body at 2 KiB.
- **"Add a new part" form:** Renders on the last part of every tutorial (including single-part). JS intercepts submit and JSON-POSTs to the endpoint, reloading on 202.
- **Generating panel + 5s meta-refresh:** Replaces the form while `status == extending`; shows "Generating part N…" and auto-refreshes.
- **`/lathe` skill update:** Always writes `part-01.md` only; each part carries its own `## Exercises` and `## Sources`; post-write message guides users to the browser UI for subsequent parts.

## Test plan

- `go test -race ./...` — all packages, race detector clean
- `go vet ./...` — no issues
- `go build -o lathe` — binary builds

Manual verification (from the plan):
- [ ] Run `/lathe build a digital synth in Zig`, confirm only `part-01.md` lands in `~/.lathe/tutorials/digital-synth-zig/`
- [ ] Open tutorial in browser, scroll to bottom — "Continue this series" form renders
- [ ] Submit with guidance, confirm page reloads showing "Generating part 2…" with auto-refresh and form hidden
- [ ] Wait for completion, confirm part-02.md appears in series TOC and prev/next nav, badge returns to verifying then verified
- [ ] Extend a legacy tutorial with only `index.md` — confirm rename happens cleanly
- [ ] `lathe extend <slug> --guidance "..."` — metadata flips identically to web endpoint
- [ ] POST `/-/extend/<slug>` twice rapidly — second returns 409

🤖 Generated with [Claude Code](https://claude.ai/claude-code)