### PR TITLE
feat: make tutorial verification opt-in, isolated, and legible

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -298,14 +298,14 @@ Decide the slug before writing. Never write `index.md` or multiple parts.
 Run:
 
 ```bash
-lathe store --verify /tmp/lathe-<slug>
+lathe store /tmp/lathe-<slug>
 ```
 
 Then tell the user:
 
 - "**Tutorial saved.** Run `lathe serve` to open it at http://localhost:4242."
 - "This is Part 1. To add more parts, open the tutorial in `lathe serve` and use **'Add a new part'** at the bottom — you can give guidance or let it continue naturally."
-- "Verification is running in the background — the ⏳ badge turns ✅ when it's done."
+- "Verification is opt-in: click **Verify this tutorial** in the web UI or run `lathe verify <slug>`. It needs the tutorial's toolchain installed locally; if a required tool is missing it shows a ⚠️ Skipped badge (not a failure)."
 
 ## Stay in session
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The boundary is strict: **skills generate content; the CLI owns durable state.**
 main.go                           cobra entrypoint
 cmd/
   root.go                         rootCmd ("lathe")
-  list.go, open.go, rm.go, serve.go, store.go    one subcommand per file
+  list.go, open.go, rm.go, serve.go, store.go, verify.go    one subcommand per file
 internal/
   config/                         TutorialsDir() → ~/.lathe/tutorials
   store/
@@ -25,7 +25,7 @@ internal/
     renderer.go                   goldmark + chroma markdown rendering
     layout.html, list.html        embed.FS templates
   verify/
-    verify.go                     SpawnVerifier — detached `claude` subprocess
+    verify.go                     StartVerification + SpawnVerifier — detached `claude` subprocess
     skills/lathe-verify.md        embedded skill (go:embed) shipped to subprocess temp dir
 .claude/skills/lathe/lathe.md     /lathe generation skill (user-invoked)
 docs/superpowers/                 specs/ and plans/
@@ -45,8 +45,8 @@ There is no top-level test runner script — tests are plain `go test`. The `/la
 
 - **`cmd/serve.go`** registers `--port` on its command's flags but stores it in the package-level `servePort` variable, which `cmd/open.go` also reads. Keep them in sync if you add new commands that need the port.
 - **`internal/serve/server.go`** uses Go 1.22+ method-and-pattern routing (`mux.HandleFunc("GET /{slug}/", …)`). `safeTutorialPath` defends against path traversal by checking the joined path stays under `tutorialsDir` — preserve that check on any new route.
-- **`internal/store/store.go`** writes `metadata.json` *before* spawning the verifier so the UI can show the `verifying` badge even if subprocess spawn fails. The `TestStoreWithVerifyStatus` test depends on this ordering.
-- **`internal/verify/verify.go`** embeds `skills/lathe-verify.md` via `//go:embed` and writes it into a fresh temp dir per invocation, then runs `claude --project-dir <temp> --dangerously-skip-permissions -p <prompt>`. The subprocess is detached; a goroutine `cmd.Wait()`s only to clean up the temp dir.
+- **`internal/verify/verify.go`** `StartVerification` writes `metadata.json` with status=`verifying` *before* spawning the verifier so the UI can show the in-flight badge even if subprocess spawn fails. The `TestStartVerificationSetsVerifying` test depends on this ordering. It conflict-guards against an already `verifying`/`extending` tutorial. All three triggers (`lathe verify`, `lathe store --verify`, the web button) funnel through it.
+- **`internal/verify/verify.go`** embeds `skills/lathe-verify.md` via `//go:embed` and writes it into a fresh temp dir per invocation, then runs `claude --add-dir <temp> --add-dir <tutorialDir> --dangerously-skip-permissions -p <prompt>` with `cmd.Dir` pinned to the temp dir (so files land there, not in the user's repo). Runs under a `context.WithTimeout(verifyTimeout)` (20 min); the detached goroutine `cmd.Wait()`s, calls `finalizeVerify` to flip a still-`verifying` status to `failed` (timeout/crash fallback), captures output to `verify.log`, and cleans up the temp dir.
 - **HTML templates** are `embed.FS`-bundled (`internal/serve/*.html`) so the binary is self-contained. They use a small `add` funcMap for 1-indexed part numbering.
 - **Markdown rendering** uses goldmark with the `github` Chroma style for code highlighting; tests assert that `<pre>` and a highlight class appear in output, so don't disable highlighting without updating `renderer_test.go`.
 
@@ -56,14 +56,14 @@ There is no top-level test runner script — tests are plain `go test`. The `/la
 - Errors flow up through `RunE`; the root `Execute()` exits non-zero on any error.
 - Keep `internal/` packages free of cobra imports — they should be usable from tests directly.
 - Skills are markdown files. The `/lathe` skill is checked into `.claude/skills/`; the `/lathe-verify` skill is *embedded* into the binary because it ships with the runtime, not the repo.
-- Status values are an enum (`store.Status`): `verifying`, `verified`, `failed`. New states should be added there and reflected in `cmd/list.go` `statusBadge`, `layout.html`, and `list.html`.
+- Status values are an enum (`store.Status`): `unverified` (default after store; renders no badge), `verifying`, `verified`, `failed`, `skipped` (required tool not installed — not a failure), `extending`. New states should be added there and reflected in `cmd/list.go` `statusBadge`, `layout.html`, and `list.html`.
 
 ## Things to avoid
 
-- Don't add a `lathe verify` or `lathe status` command — verification is intentionally always automatic via `--verify` (see "Out of Scope" in the design spec).
+- Verification is **opt-in / on-demand**: it runs only when the user asks (the `lathe verify <slug>` command, the `--verify` flag on `lathe store`, or the "Verify this tutorial" web button — all routed through `verify.StartVerification`). Storing never auto-verifies; the default status is `unverified`. Don't add a `lathe status` command — status is surfaced via `lathe list` and the web UI.
 - Don't add tutorial editing or sharing commands without checking with the user — the v1 scope is deliberately narrow. (Deletion is supported via `lathe rm <slug>` and the `×` button on the web list page; both go through `store.Delete` / `safeTutorialPath`.)
 - Don't have the verify skill modify the tutorial source markdown — it's read-only with respect to the tutorial directory, and only writes `verify-result.json` and the `status` field of `metadata.json`.
-- Don't add OS-level sandboxing (sandbox-exec, Docker) for verification unless explicitly asked — soft isolation via `--project-dir` is the chosen tradeoff.
+- Don't add OS-level sandboxing (sandbox-exec, Docker) for verification unless explicitly asked — soft isolation via `cmd.Dir`-into-a-temp-dir plus scoped `--add-dir` grants is the chosen tradeoff.
 
 ## Commit style
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lathe targets topics where good documentation is scarce — *"build a digital sy
 Two layers with a clean boundary:
 
 - **`/lathe` skill** (Claude Code) — generates the tutorial markdown. Asks one or two scoping questions, writes `part-01.md` to `/tmp/lathe-<slug>/`, then hands off to the CLI. Additional parts are added on demand via the browser UI.
-- **`lathe` CLI** (Go) — copies the tutorial into `~/.lathe/tutorials/`, optionally spawns a background Claude subprocess that works through the tutorial step by step to verify it compiles and runs, and serves the rendered output at `http://localhost:4242`.
+- **`lathe` CLI** (Go) — copies the tutorial into `~/.lathe/tutorials/`, serves the rendered output at `http://localhost:4242`, and — on demand — spawns a background Claude subprocess that works through the tutorial step by step to verify it compiles and runs.
 
 ```
 User: /lathe "build a digital synth in Zig"
@@ -17,16 +17,19 @@ User: /lathe "build a digital synth in Zig"
         ▼
   [/lathe skill]                     generates part-01.md
         │
-        ▼  lathe store --verify /tmp/lathe-<slug>
-  [lathe CLI]                        copies files, kicks off background verify
+        ▼  lathe store /tmp/lathe-<slug>
+  [lathe CLI]                        copies files (status: unverified)
         │
         ├── ~/.lathe/tutorials/<slug>/
-        │       metadata.json        status: verifying → verified | failed
+        │       metadata.json        status: unverified
         │       part-01.md, part-02.md, …
         │
-        └── [bg: claude + /lathe-verify skill in temp dir]
+        └── on demand: `lathe verify <slug>` / "Verify this tutorial" button
+                │       metadata.json   status: verifying → verified | failed | skipped
+                ▼
+            [bg: claude + /lathe-verify skill in a /tmp temp dir]
                 works through each step, runs every checkpoint command,
-                writes verify-result.json, updates metadata status
+                writes verify-result.json + verify.log, updates metadata status
 
 User: lathe serve  →  http://localhost:4242  (browser opens automatically)
 ```
@@ -68,8 +71,9 @@ Other commands:
 ```bash
 lathe list               # show all stored tutorials with status badges
 lathe open <slug>        # open a specific tutorial (requires lathe serve)
-lathe store <path>       # save a tutorial directory manually
-lathe store <path> --verify   # save and run background verification
+lathe store <path>       # save a tutorial directory manually (status: unverified)
+lathe store <path> --verify   # save and immediately run verification
+lathe verify <slug>      # run (or re-run) verification for a stored tutorial
 lathe rm <slug>          # delete a stored tutorial (prompts unless --force)
 ```
 
@@ -101,25 +105,29 @@ Tutorials live globally in `~/.lathe/tutorials/`, one directory per slug:
   "title": "Build a Digital Synth in Zig",
   "topic": "build a digital synth in Zig",
   "created": "2026-05-03T19:00:00Z",
-  "status": "verifying",
+  "status": "unverified",
   "series": true,
   "parts": ["part-01.md", "part-02.md", "part-03.md"]
 }
 ```
 
-Status is one of `verifying`, `verified`, or `failed`. On failure, a `verify-result.json` is written alongside with the failed part, step number, and error output.
+Status is one of `unverified` (the default after `lathe store`; renders no badge), `verifying`, `verified`, `failed`, or `skipped`. On failure, a `verify-result.json` is written alongside with the failed part, step number, and error output; the web UI renders it as a panel on the tutorial page.
 
 ## Verification
 
-`--verify` spawns a detached `claude` subprocess in a temp directory with the embedded `/lathe-verify` skill. The subprocess works through every step in the tutorial — creating files, running commands, executing each `## Checkpoint` block — and reports the result back into the tutorial's `metadata.json`. The web UI's status badge updates on the next page load.
+Verification is **opt-in**. Storing a tutorial leaves it `unverified` — nothing runs until you ask, either with `lathe verify <slug>`, the `--verify` flag on `lathe store`, or the **Verify this tutorial** button in the web UI.
 
-Verification runs with `--dangerously-skip-permissions` and is sandboxed only by `--project-dir`-into-a-temp-dir plus skill instructions to stay within the project directory. Treat it as soft isolation, not a security boundary.
+When triggered, Lathe spawns a detached `claude` subprocess **inside a fresh `/tmp/lathe-verify-*` directory** (its working directory is pinned there with `cmd.Dir`, so build artifacts never land in your repo) with the embedded `/lathe-verify` skill. The subprocess works through every step in the tutorial — creating files, running commands, executing each `## Checkpoint` block — and reports the result back into the tutorial's `metadata.json`. While it runs, the web page auto-refreshes every 5s, so the badge moves ⏳ → ✅ / ❌ / ⚠️ on its own. The subprocess's stdout/stderr are captured to `~/.lathe/tutorials/<slug>/verify.log`.
+
+Verification only makes sense where the tutorial's toolchain is installed. If a required tool is missing (e.g. no `zig` binary), the run is reported as **skipped** (⚠️) rather than failed — "couldn't verify here" is not the same as "broken." A run is bounded by a 20-minute timeout (generous, to tolerate first-time toolchain downloads); if the subprocess hangs or crashes without reporting, the status falls back to `failed` with an explanatory error instead of sticking at ⏳.
+
+Verification runs with `--dangerously-skip-permissions` and is sandboxed only by the temp working directory plus scoped `--add-dir` grants (the temp dir and the tutorial dir) and skill instructions to stay within them. Treat it as soft isolation, not a security boundary.
 
 ## Dependencies
 
 - [`spf13/cobra`](https://github.com/spf13/cobra) — CLI command structure
 - [`yuin/goldmark`](https://github.com/yuin/goldmark) + [`goldmark-highlighting`](https://github.com/yuin/goldmark-highlighting) — markdown rendering with Chroma syntax highlighting
-- `claude` CLI — required for `--verify` and for invoking the `/lathe` skill
+- `claude` CLI — required for verification (`lathe verify` / `--verify`) and for invoking the `/lathe` skill
 
 ## Repository layout
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,12 +51,16 @@ var listCmd = &cobra.Command{
 
 func statusBadge(s store.Status) string {
 	switch s {
+	case store.StatusUnverified:
+		return "" // calm default — no badge, matching the web UI
 	case store.StatusVerified:
 		return "✅ verified"
 	case store.StatusVerifying:
 		return "⏳ verifying"
 	case store.StatusFailed:
 		return "❌ failed"
+	case store.StatusSkipped:
+		return "⚠️ skipped"
 	case store.StatusExtending:
 		return "⏳ extending"
 	default:

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/devenjarvis/lathe/internal/config"
 	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/devenjarvis/lathe/internal/verify"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +17,20 @@ var storeCmd = &cobra.Command{
 	Short: "Save a tutorial directory to ~/.lathe/tutorials/",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tut, err := store.Store(args[0], withVerify)
+		tut, err := store.Store(args[0])
 		if err != nil {
 			return err
+		}
+		if withVerify {
+			tutorialsDir, err := config.TutorialsDir()
+			if err != nil {
+				return err
+			}
+			tutDir := filepath.Join(tutorialsDir, tut.Slug)
+			if err := verify.StartVerification(tut.Slug, tutDir); err != nil {
+				return fmt.Errorf("start verification: %w", err)
+			}
+			tut.Status = store.StatusVerifying
 		}
 		fmt.Printf("Stored: %s (%s)\n", tut.Title, tut.Status)
 		if withVerify {
@@ -27,6 +41,6 @@ var storeCmd = &cobra.Command{
 }
 
 func init() {
-	storeCmd.Flags().BoolVar(&withVerify, "verify", false, "spawn background verification after storing")
+	storeCmd.Flags().BoolVar(&withVerify, "verify", false, "run verification after storing")
 	rootCmd.AddCommand(storeCmd)
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/devenjarvis/lathe/internal/config"
+	"github.com/devenjarvis/lathe/internal/verify"
+	"github.com/spf13/cobra"
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify <slug>",
+	Short: "Run verification for a stored tutorial",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		if slug == "" || slug == "." || slug == ".." || strings.ContainsAny(slug, `/\`) {
+			return fmt.Errorf("invalid slug: %q", slug)
+		}
+		tutorialsDir, err := config.TutorialsDir()
+		if err != nil {
+			return err
+		}
+		tutDir := filepath.Join(tutorialsDir, slug)
+
+		if err := verify.StartVerification(slug, tutDir); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"Verifying tutorial %q (running in background; refresh `lathe serve` to watch)\n", slug)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(verifyCmd)
+}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func TestVerifyCommandFlipsMetadataToVerifying(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "") // prevent claude from being found
+
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", "test-slug")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:   "test-slug",
+		Title:  "Test Slug",
+		Status: store.StatusUnverified,
+		Parts:  []string{"part-01.md"},
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	// PATH="" means SpawnVerifier fails fast, but the metadata flip to
+	// verifying happens before spawn.
+	verifyCmd.RunE(verifyCmd, []string{"test-slug"}) //nolint:errcheck
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata after verify: %v", err)
+	}
+	if got.Status != store.StatusVerifying {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusVerifying)
+	}
+}
+
+func TestVerifyCommandRejectsBadSlug(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, slug := range []string{"", ".", "..", "foo/bar", `foo\bar`} {
+		if err := verifyCmd.RunE(verifyCmd, []string{slug}); err == nil {
+			t.Errorf("verify %q should be rejected as invalid", slug)
+		}
+	}
+}

--- a/internal/serve/extend.go
+++ b/internal/serve/extend.go
@@ -69,4 +69,3 @@ func (s *Server) handleExtend(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusAccepted)
 }
-

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{.Title}} — Lathe</title>
-  {{if eq .Tutorial.Status "extending"}}<meta http-equiv="refresh" content="5">{{end}}
+  {{if or (eq .Tutorial.Status "extending") (eq .Tutorial.Status "verifying")}}<meta http-equiv="refresh" content="5">{{end}}
   <script>
     (function(){
       try {
@@ -33,6 +33,7 @@
       --hover-bg:#f3f4f6;--active-bg:#eff6ff;--active-text:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;--blockquote-border:#d1d5db;
       --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
       --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;--badge-extending-bg:#e0f2fe;--badge-extending-text:#0369a1;
+      --badge-skipped-bg:#f3f4f6;--badge-skipped-text:#4b5563;
       --callout-note-bg:#eff6ff;--callout-note-border:#3b82f6;--callout-note-label:#1d4ed8;
       --callout-tip-bg:#ecfdf5;--callout-tip-border:#10b981;--callout-tip-label:#047857;
       --callout-warn-bg:#fffbeb;--callout-warn-border:#f59e0b;--callout-warn-label:#b45309;
@@ -46,6 +47,7 @@
       --hover-bg:#222632;--active-bg:#1e2a44;--active-text:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;--blockquote-border:#374151;
       --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
       --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;--badge-extending-bg:#0c2a40;--badge-extending-text:#7dd3fc;
+      --badge-skipped-bg:#2a2f3a;--badge-skipped-text:#cbd5e1;
       --callout-note-bg:#172033;--callout-note-border:#3b82f6;--callout-note-label:#93c5fd;
       --callout-tip-bg:#0f2820;--callout-tip-border:#10b981;--callout-tip-label:#6ee7b7;
       --callout-warn-bg:#2a1f0a;--callout-warn-border:#f59e0b;--callout-warn-label:#fcd34d;
@@ -71,6 +73,7 @@
     .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
     .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
     .badge.extending{background:var(--badge-extending-bg);color:var(--badge-extending-text)}
+    .badge.skipped{background:var(--badge-skipped-bg);color:var(--badge-skipped-text)}
     nav ul{list-style:none}
     nav li{margin:.2rem 0}
     nav a{display:block;font-size:.85rem;color:var(--text-subtle);text-decoration:none;padding:.35rem .6rem;border-radius:5px}
@@ -170,6 +173,13 @@
     .extend-error{font-size:.85rem;color:var(--badge-failed-text);min-height:1.2em}
     .extending-panel{color:var(--text-muted)}
     .extending-panel .muted{font-size:.85rem;color:var(--text-faint);margin-top:.25rem}
+    .verify-section{margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--border)}
+    #verifyForm button[type="submit"]{background:var(--active-bg);color:var(--active-text);border:1px solid var(--active-text);padding:.5rem 1.1rem;border-radius:6px;font:inherit;font-size:.9rem;font-weight:600;cursor:pointer}
+    #verifyForm button[type="submit"]:hover{opacity:.85}
+    .verify-error{font-size:.85rem;color:var(--badge-failed-text);min-height:1.2em;margin-top:.5rem}
+    .verifying-panel{color:var(--text-muted)}
+    .verifying-panel .muted{font-size:.85rem;color:var(--text-faint);margin-top:.25rem}
+    .verify-failure code{word-break:break-all}
 
     /* Floating Ask button (wide screens) */
     #askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;background:var(--active-bg);color:var(--active-text);border:1px solid var(--border);font:inherit;font-weight:600;font-size:.9rem;padding:.65rem 1.1rem;border-radius:9999px;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.15);transition:transform 150ms ease-out,box-shadow 150ms ease-out}
@@ -261,6 +271,7 @@
     {{if eq .Tutorial.Status "verified"}}<span class="badge verified">✅ Verified</span>
     {{else if eq .Tutorial.Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
     {{else if eq .Tutorial.Status "failed"}}<span class="badge failed">❌ Failed</span>
+    {{else if eq .Tutorial.Status "skipped"}}<span class="badge skipped">⚠️ Skipped</span>
     {{else if eq .Tutorial.Status "extending"}}<span class="badge extending">⏳ Extending…</span>
     {{end}}
     {{if .TOC}}
@@ -276,6 +287,27 @@
   </nav>
   <main>
     {{.Content}}
+    {{if and (eq .Tutorial.Status "failed") .VerifyResult}}
+    <div class="callout callout-warning verify-failure">
+      <p class="callout-label">Verification failed</p>
+      {{if .VerifyResult.Part}}<p>Part: <code>{{.VerifyResult.Part}}</code></p>{{end}}
+      {{if .VerifyResult.FailedStep}}<p>Failed at step {{.VerifyResult.FailedStep}}.</p>{{end}}
+      {{if .VerifyResult.Error}}<p>{{.VerifyResult.Error}}</p>{{end}}
+    </div>
+    {{end}}
+    {{if eq .Tutorial.Status "verifying"}}
+    <section class="verify-section verifying-panel">
+      <p>⏳ Verifying this tutorial…</p>
+      <p class="muted">This page will refresh automatically.</p>
+    </section>
+    {{else if or (eq .Tutorial.Status "unverified") (eq .Tutorial.Status "failed") (eq .Tutorial.Status "skipped")}}
+    <section class="verify-section">
+      <form id="verifyForm" method="POST" action="/-/verify/{{.Tutorial.Slug}}">
+        <button type="submit">{{if eq .Tutorial.Status "unverified"}}Verify this tutorial{{else}}Re-verify this tutorial{{end}}</button>
+        <p class="verify-error" aria-live="polite"></p>
+      </form>
+    </section>
+    {{end}}
     {{if .Tutorial.IsSeries}}
     <section class="series-toc" aria-label="In this series">
       <h2>In this series</h2>
@@ -792,6 +824,31 @@
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({guidance: guidance})
       }).then(function(r) {
+        if (r.status === 202) {
+          window.location.reload();
+        } else {
+          r.text().then(function(t){ errEl.textContent = 'Error: ' + (t || r.status); });
+          btn.disabled = false;
+        }
+      }).catch(function(err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        btn.disabled = false;
+      });
+    });
+  })();
+</script>
+<script>
+  (function(){
+    var form = document.getElementById('verifyForm');
+    if (!form) return;
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var action = form.getAttribute('action');
+      var errEl = form.querySelector('.verify-error');
+      errEl.textContent = '';
+      var btn = form.querySelector('button[type="submit"]');
+      btn.disabled = true;
+      fetch(action, {method: 'POST'}).then(function(r) {
         if (r.status === 202) {
           window.location.reload();
         } else {

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -19,12 +19,14 @@
       --link:#1d4ed8;--code-bg:#f3f4f6;--code-text:#1f2937;
       --badge-verified-bg:#d1fae5;--badge-verified-text:#065f46;--badge-verifying-bg:#fef3c7;--badge-verifying-text:#92400e;
       --badge-failed-bg:#fee2e2;--badge-failed-text:#991b1b;--badge-extending-bg:#e0f2fe;--badge-extending-text:#0369a1;
+      --badge-skipped-bg:#f3f4f6;--badge-skipped-text:#4b5563;
     }
     [data-theme="dark"]{
       --bg:#0f1115;--surface:#181b22;--border:#2a2f3a;--text:#e5e7eb;--text-faint:#9ca3af;--text-empty:#6b7280;
       --link:#93c5fd;--code-bg:#222632;--code-text:#e5e7eb;
       --badge-verified-bg:#064e3b;--badge-verified-text:#a7f3d0;--badge-verifying-bg:#78350f;--badge-verifying-text:#fde68a;
       --badge-failed-bg:#7f1d1d;--badge-failed-text:#fecaca;--badge-extending-bg:#0c2a40;--badge-extending-text:#7dd3fc;
+      --badge-skipped-bg:#2a2f3a;--badge-skipped-text:#cbd5e1;
     }
     *{box-sizing:border-box;margin:0;padding:0}
     html,body{overflow-x:hidden}
@@ -47,6 +49,7 @@
     .badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
     .badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
     .badge.extending{background:var(--badge-extending-bg);color:var(--badge-extending-text)}
+    .badge.skipped{background:var(--badge-skipped-bg);color:var(--badge-skipped-text)}
     .empty{color:var(--text-empty);text-align:center;padding:3rem 1rem;font-size:.95rem}
     .empty code{background:var(--code-bg);color:var(--code-text);padding:.1rem .35rem;border-radius:3px;font-family:'JetBrains Mono','Fira Code',monospace;font-size:.85em}
     .theme-toggle{background:transparent;border:1px solid var(--border);color:var(--text-faint);font:inherit;font-size:.8rem;padding:.4rem .6rem;border-radius:5px;cursor:pointer;display:inline-flex;align-items:center;gap:.4rem;flex-shrink:0;min-height:32px}
@@ -88,6 +91,7 @@
     {{if eq .Status "verified"}}<span class="badge verified">✅ Verified</span>
     {{else if eq .Status "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
     {{else if eq .Status "failed"}}<span class="badge failed">❌ Failed</span>
+    {{else if eq .Status "skipped"}}<span class="badge skipped">⚠️ Skipped</span>
     {{else if eq .Status "extending"}}<span class="badge extending">⏳ Extending…</span>
     {{end}}
     <form method="POST" action="/-/delete/{{.Slug}}" class="delete-form" data-tutorial-title="{{.Title}}">

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -107,9 +107,9 @@ func TestRenderCalloutBlock(t *testing.T) {
 
 func TestRenderCalloutTypes(t *testing.T) {
 	cases := []struct {
-		marker     string
-		wantClass  string
-		wantLabel  string
+		marker    string
+		wantClass string
+		wantLabel string
 	}{
 		{"NOTE", "callout-note", "Note"},
 		{"TIP", "callout-tip", "Tip"},

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -49,6 +49,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
 	mux.HandleFunc("POST /-/ask/{slug}/{part}", s.handleAsk)
 	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
+	mux.HandleFunc("POST /-/verify/{slug}", s.handleVerify)
 	return mux
 }
 
@@ -222,10 +223,21 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		}
 	}
 
+	// On failure, surface the verifier's recorded part/step/error so the page
+	// explains what broke instead of just showing a red badge. Best-effort:
+	// a missing or malformed verify-result.json simply renders no panel.
+	var verifyResult *store.VerifyResult
+	if tut.Status == store.StatusFailed {
+		if vr, err := store.ReadVerifyResult(tutDir); err == nil {
+			verifyResult = vr
+		}
+	}
+
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
 		"Title":             tut.Title,
 		"Tutorial":          tut,
+		"VerifyResult":      verifyResult,
 		"CurrentPart":       part,
 		"CurrentPartNumber": currentNumber,
 		"Content":           template.HTML(content),

--- a/internal/serve/verify.go
+++ b/internal/serve/verify.go
@@ -1,0 +1,46 @@
+package serve
+
+import (
+	"net/http"
+
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/devenjarvis/lathe/internal/verify"
+)
+
+// handleVerify triggers on-demand verification for a tutorial. Mirrors
+// handleExtend/handleDelete: safeTutorialPath guards traversal, the conflict
+// case returns 409, and a 202 is returned once status is committed to
+// verifying (verify.StartVerification writes it before spawning).
+func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("slug")
+	tutDir, ok := s.safeTutorialPath(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if tut.Status == store.StatusExtending || tut.Status == store.StatusVerifying {
+		http.Error(w, "conflict: tutorial is already extending or verifying", http.StatusConflict)
+		return
+	}
+
+	// StartVerification commits status=verifying before spawning. A spawn
+	// failure leaves metadata committed; we return 202 regardless so the UI
+	// can show the in-flight badge (the background goroutine flips to failed
+	// if the subprocess exits badly).
+	verify.StartVerification(slug, tutDir) //nolint:errcheck
+
+	tut, err = store.ReadMetadata(tutDir)
+	if err != nil || tut.Status != store.StatusVerifying {
+		http.Error(w, "verify failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/serve/verify_test.go
+++ b/internal/serve/verify_test.go
@@ -1,0 +1,222 @@
+package serve_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/serve"
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func postVerify(t *testing.T, srv *serve.Server, slug string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/-/verify/"+slug, nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestVerifyRejectsWrongMethod(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusUnverified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/-/verify/test-tut", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK || w.Code == http.StatusAccepted {
+		t.Errorf("GET /-/verify = %d, want method not allowed", w.Code)
+	}
+}
+
+func TestVerifyUnknownSlugIs404(t *testing.T) {
+	dir := t.TempDir()
+	srv := serve.NewServer(dir)
+
+	w := postVerify(t, srv, "no-such-tutorial")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown slug = %d, want 404", w.Code)
+	}
+}
+
+func TestVerifyAcceptedSetsVerifying(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", "") // prevent claude from spawning; status flip still happens
+	makeExtendTutorial(t, dir, "test-tut", store.StatusUnverified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	w := postVerify(t, srv, "test-tut")
+	if w.Code != http.StatusAccepted {
+		t.Errorf("verify = %d, want 202", w.Code)
+	}
+
+	got, err := store.ReadMetadata(filepath.Join(dir, "test-tut"))
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Status != store.StatusVerifying {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusVerifying)
+	}
+}
+
+func TestVerifyRejectsWhileVerifying(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerifying, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	w := postVerify(t, srv, "test-tut")
+	if w.Code != http.StatusConflict {
+		t.Errorf("while verifying = %d, want 409", w.Code)
+	}
+}
+
+func TestVerifyRejectsWhileExtending(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusExtending, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	w := postVerify(t, srv, "test-tut")
+	if w.Code != http.StatusConflict {
+		t.Errorf("while extending = %d, want 409", w.Code)
+	}
+}
+
+func TestVerifyButtonRendersForVerifiableStatuses(t *testing.T) {
+	for _, status := range []store.Status{store.StatusUnverified, store.StatusFailed, store.StatusSkipped} {
+		t.Run(string(status), func(t *testing.T) {
+			dir := t.TempDir()
+			makeExtendTutorial(t, dir, "test-tut", status, []string{"part-01.md"})
+			srv := serve.NewServer(dir)
+
+			req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET part = %d, want 200", w.Code)
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, `id="verifyForm"`) {
+				t.Errorf("status %q should render the verify form", status)
+			}
+			if !strings.Contains(body, `action="/-/verify/test-tut"`) {
+				t.Errorf("verify form should post to /-/verify/test-tut")
+			}
+		})
+	}
+}
+
+func TestVerifyButtonHiddenWhenVerified(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if strings.Contains(w.Body.String(), `id="verifyForm"`) {
+		t.Error("verified tutorial should not render the verify form")
+	}
+}
+
+func TestVerifyingPanelAutoRefreshes(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusVerifying, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET part = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `http-equiv="refresh"`) {
+		t.Error("verifying page should have meta refresh tag")
+	}
+	if strings.Contains(body, `id="verifyForm"`) {
+		t.Error("verify form should NOT appear while status is verifying")
+	}
+}
+
+func TestSkippedBadgeRendersOnPart(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusSkipped, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), `badge skipped`) {
+		t.Error("part page missing skipped badge for tutorial with status=skipped")
+	}
+}
+
+func TestSkippedBadgeRendersOnList(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusSkipped, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), `badge skipped`) {
+		t.Error("list page missing skipped badge for tutorial with status=skipped")
+	}
+}
+
+func TestUnverifiedRendersNoBadge(t *testing.T) {
+	dir := t.TempDir()
+	makeExtendTutorial(t, dir, "test-tut", store.StatusUnverified, []string{"part-01.md"})
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	// No status badge span should render for the calm unverified state.
+	if strings.Contains(body, `class="badge `) {
+		t.Error("unverified tutorial should render no status badge")
+	}
+}
+
+func TestFailurePanelRendersFromVerifyResult(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeExtendTutorial(t, dir, "test-tut", store.StatusFailed, []string{"part-01.md"})
+	if err := store.WriteVerifyResult(tutDir, &store.VerifyResult{
+		Status:     store.StatusFailed,
+		Part:       "part-01.md",
+		FailedStep: 3,
+		Error:      "zig: command failed with exit code 1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv := serve.NewServer(dir)
+
+	req := httptest.NewRequest(http.MethodGet, "/test-tut/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET part = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "verify-failure") {
+		t.Error("failed tutorial should render the verify-failure panel")
+	}
+	if !strings.Contains(body, "part-01.md") {
+		t.Error("failure panel should name the failing part")
+	}
+	if !strings.Contains(body, "zig: command failed with exit code 1") {
+		t.Error("failure panel should show the recorded error")
+	}
+}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -10,10 +10,12 @@ import (
 type Status string
 
 const (
-	StatusVerifying Status = "verifying"
-	StatusVerified  Status = "verified"
-	StatusFailed    Status = "failed"
-	StatusExtending Status = "extending"
+	StatusUnverified Status = "unverified"
+	StatusVerifying  Status = "verifying"
+	StatusVerified   Status = "verified"
+	StatusFailed     Status = "failed"
+	StatusSkipped    Status = "skipped"
+	StatusExtending  Status = "extending"
 )
 
 type Tutorial struct {
@@ -53,4 +55,21 @@ func WriteMetadata(tutorialDir string, t *Tutorial) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(tutorialDir, "metadata.json"), data, 0644)
+}
+
+func ReadVerifyResult(tutorialDir string) (*VerifyResult, error) {
+	data, err := os.ReadFile(filepath.Join(tutorialDir, "verify-result.json"))
+	if err != nil {
+		return nil, err
+	}
+	var v VerifyResult
+	return &v, json.Unmarshal(data, &v)
+}
+
+func WriteVerifyResult(tutorialDir string, v *VerifyResult) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(tutorialDir, "verify-result.json"), data, 0644)
 }

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -94,6 +94,61 @@ func TestStatusExtendingValue(t *testing.T) {
 	}
 }
 
+func TestVerifyResultRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &store.VerifyResult{
+		Status:     store.StatusFailed,
+		Part:       "part-02.md",
+		FailedStep: 4,
+		Error:      "zig build failed: error: expected ';'",
+		CheckedAt:  "2026-06-03T12:00:00Z",
+	}
+	if err := store.WriteVerifyResult(dir, original); err != nil {
+		t.Fatalf("WriteVerifyResult: %v", err)
+	}
+	got, err := store.ReadVerifyResult(dir)
+	if err != nil {
+		t.Fatalf("ReadVerifyResult: %v", err)
+	}
+	if got.Status != original.Status {
+		t.Errorf("Status = %q, want %q", got.Status, original.Status)
+	}
+	if got.Part != original.Part {
+		t.Errorf("Part = %q, want %q", got.Part, original.Part)
+	}
+	if got.FailedStep != original.FailedStep {
+		t.Errorf("FailedStep = %d, want %d", got.FailedStep, original.FailedStep)
+	}
+	if got.Error != original.Error {
+		t.Errorf("Error = %q, want %q", got.Error, original.Error)
+	}
+}
+
+func TestReadVerifyResultNotFound(t *testing.T) {
+	if _, err := store.ReadVerifyResult(t.TempDir()); err == nil {
+		t.Error("ReadVerifyResult() expected error for missing file, got nil")
+	}
+}
+
+func TestStatusValues(t *testing.T) {
+	cases := []struct {
+		status store.Status
+		want   string
+	}{
+		{store.StatusUnverified, "unverified"},
+		{store.StatusVerifying, "verifying"},
+		{store.StatusVerified, "verified"},
+		{store.StatusFailed, "failed"},
+		{store.StatusSkipped, "skipped"},
+		{store.StatusExtending, "extending"},
+	}
+	for _, c := range cases {
+		if string(c.status) != c.want {
+			t.Errorf("status = %q, want %q", c.status, c.want)
+		}
+	}
+}
+
 func TestPendingPartOmittedWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	tut := &store.Tutorial{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/devenjarvis/lathe/internal/config"
-	"github.com/devenjarvis/lathe/internal/verify"
 )
 
-func Store(srcPath string, withVerify bool) (*Tutorial, error) {
+// Store copies a tutorial directory into ~/.lathe/tutorials/ and writes its
+// metadata with status=unverified. Verification is opt-in and never auto-runs
+// here — callers trigger it separately via verify.StartVerification.
+func Store(srcPath string) (*Tutorial, error) {
 	slug := filepath.Base(strings.TrimSuffix(srcPath, string(filepath.Separator)))
 
 	tutorialsDir, err := config.TutorialsDir()
@@ -27,28 +29,18 @@ func Store(srcPath string, withVerify bool) (*Tutorial, error) {
 	}
 
 	parts := detectParts(destDir)
-	status := StatusVerified
-	if withVerify {
-		status = StatusVerifying
-	}
 
 	t := &Tutorial{
 		Slug:    slug,
 		Title:   SlugToTitle(slug),
 		Topic:   slug,
 		Created: time.Now().UTC(),
-		Status:  status,
+		Status:  StatusUnverified,
 		Parts:   parts,
 	}
 
 	if err := WriteMetadata(destDir, t); err != nil {
 		return nil, err
-	}
-
-	if withVerify {
-		if err := verify.SpawnVerifier(slug, destDir); err != nil {
-			return nil, fmt.Errorf("spawn verifier: %w", err)
-		}
 	}
 
 	return t, nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -16,15 +16,15 @@ func TestStoreSingleTutorial(t *testing.T) {
 	// Override home so we don't pollute the real ~/.lathe
 	t.Setenv("HOME", t.TempDir())
 
-	tut, err := store.Store(src, false)
+	tut, err := store.Store(src)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
 	if tut.IsSeries() {
 		t.Error("Store() IsSeries() = true, want false for single tutorial")
 	}
-	if tut.Status != store.StatusVerified {
-		t.Errorf("Store() Status = %q, want %q", tut.Status, store.StatusVerified)
+	if tut.Status != store.StatusUnverified {
+		t.Errorf("Store() Status = %q, want %q", tut.Status, store.StatusUnverified)
 	}
 }
 
@@ -37,7 +37,7 @@ func TestStoreSeriesTutorial(t *testing.T) {
 	}
 	t.Setenv("HOME", t.TempDir())
 
-	tut, err := store.Store(src, false)
+	tut, err := store.Store(src)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -49,45 +49,39 @@ func TestStoreSeriesTutorial(t *testing.T) {
 	}
 }
 
-func TestStoreVerifyingStatus(t *testing.T) {
+func TestStoreDefaultsToUnverified(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", t.TempDir())
-	// withVerify=true would try to spawn claude; we skip that by not passing it.
-	// This test uses false — verify the status is "verified" (default) when not verifying.
-	tut, err := store.Store(src, false)
+	// Store never auto-verifies; the default status is unverified.
+	tut, err := store.Store(src)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
-	if tut.Status != store.StatusVerified {
-		t.Errorf("Store() Status = %q, want %q", tut.Status, store.StatusVerified)
+	if tut.Status != store.StatusUnverified {
+		t.Errorf("Store() Status = %q, want %q", tut.Status, store.StatusUnverified)
 	}
 }
 
-func TestStoreWithVerifyStatus(t *testing.T) {
+func TestStoreDoesNotSpawnVerifier(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
-	t.Setenv("PATH", "") // block claude so SpawnVerifier fails fast without spawning
 
-	// Store should fail because SpawnVerifier can't find claude, but
-	// the metadata.json is written BEFORE SpawnVerifier is called.
-	// We verify the metadata file was written with status=verifying.
-	store.Store(src, true) // intentionally ignoring error
-
-	slug := filepath.Base(src)
-	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", slug)
-	tut, err := store.ReadMetadata(tutDir)
+	tut, err := store.Store(src)
 	if err != nil {
-		t.Fatalf("metadata not written before SpawnVerifier: %v", err)
+		t.Fatalf("Store() error = %v", err)
 	}
-	if tut.Status != store.StatusVerifying {
-		t.Errorf("Status = %q, want %q", tut.Status, store.StatusVerifying)
+
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", tut.Slug)
+	// No verify.log means no subprocess was launched.
+	if _, err := os.Stat(filepath.Join(tutDir, "verify.log")); !os.IsNotExist(err) {
+		t.Errorf("Store() should not spawn a verifier; verify.log stat err = %v", err)
 	}
 }
 
@@ -99,7 +93,7 @@ func TestDeleteRemovesTutorial(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
-	tut, err := store.Store(src, false)
+	tut, err := store.Store(src)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}

--- a/internal/verify/skills/lathe-verify.md
+++ b/internal/verify/skills/lathe-verify.md
@@ -5,8 +5,12 @@ Verify that a technical tutorial works end-to-end on this machine by working thr
 ## Setup
 
 The tutorial to verify is at the absolute path in the `LATHE_TUTORIAL_DIR` environment variable.
-Your working directory (the project dir) is a temp directory — write all code and create all files here only.
-Never write files outside the current working directory.
+Your working directory is a fresh temp directory — build everything here. Write all code, create all
+files, and run all commands in the current working directory only.
+
+The tutorial directory (`LATHE_TUTORIAL_DIR`) is **read-only** except for the two output files you
+report into: `verify-result.json` and the `status` field of `metadata.json`. Never write tutorial
+code or build artifacts there, and never modify the tutorial markdown.
 
 ## Process
 
@@ -54,9 +58,24 @@ Write `$LATHE_TUTORIAL_DIR/verify-result.json`:
 
 Then update `$LATHE_TUTORIAL_DIR/metadata.json`: change the `"status"` field value to `"failed"`. Do not modify any other fields.
 
+## Reporting: Skipped
+
+If a tool the tutorial requires is not installed on this machine (e.g., the `zig` binary is not found), this is **not** a failure — the tutorial may be perfectly correct; it simply can't be verified here. Stop and report it as skipped.
+
+Write `$LATHE_TUTORIAL_DIR/verify-result.json`:
+```json
+{
+  "status": "skipped",
+  "error": "required tool not installed: zig",
+  "checked_at": "<RFC3339 timestamp>"
+}
+```
+
+Then update `$LATHE_TUTORIAL_DIR/metadata.json`: change the `"status"` field value to `"skipped"`. Do not modify any other fields. Then stop.
+
 ## Rules
 
 - Only create or modify files inside the current working directory
 - Never modify the tutorial markdown files
-- If a required tool is not installed (e.g., `zig` binary not found), treat it as a failure: `"error": "required tool not installed: zig"`
+- If a required tool is not installed, report it as **skipped** (see above), not failed
 - Count steps per part, resetting to 1 for each new part file

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,15 +1,47 @@
 package verify
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
+
+	"github.com/devenjarvis/lathe/internal/store"
 )
 
 //go:embed skills/lathe-verify.md
 var verifySkillContent string
+
+// verifyTimeout bounds a verification run. It is generous on purpose: a
+// first-time run may download and install a toolchain before it can build.
+const verifyTimeout = 20 * time.Minute
+
+// StartVerification is the single entry point all three triggers (the CLI
+// `lathe verify`, the `--verify` store flag, and the web button) funnel
+// through. It conflict-guards against an in-flight extend/verify, commits
+// status=verifying to metadata before spawning, then launches the detached
+// verifier subprocess. Mirrors extend.SpawnExtender's status-before-spawn
+// contract so the UI can show the in-flight badge even if spawn fails.
+func StartVerification(slug, tutorialDir string) error {
+	tut, err := store.ReadMetadata(tutorialDir)
+	if err != nil {
+		return fmt.Errorf("read metadata: %w", err)
+	}
+
+	if tut.Status == store.StatusExtending || tut.Status == store.StatusVerifying {
+		return fmt.Errorf("already extending or verifying: status is %q", tut.Status)
+	}
+
+	tut.Status = store.StatusVerifying
+	if err := store.WriteMetadata(tutorialDir, tut); err != nil {
+		return fmt.Errorf("write metadata: %w", err)
+	}
+
+	return SpawnVerifier(slug, tutorialDir)
+}
 
 func SpawnVerifier(slug, tutorialDir string) error {
 	tempDir, err := os.MkdirTemp("", "lathe-verify-"+slug+"-")
@@ -29,29 +61,90 @@ func SpawnVerifier(slug, tutorialDir string) error {
 		return fmt.Errorf("write skill: %w", err)
 	}
 
+	// Capture the subprocess's stdout+stderr in the tutorial dir so a failed
+	// run leaves a legible trail. Best-effort: a missing log must not block.
+	logFile, _ := os.Create(filepath.Join(tutorialDir, "verify.log"))
+
 	prompt := fmt.Sprintf(
 		"Use the /lathe-verify skill to verify the tutorial. "+
 			"LATHE_TUTORIAL_DIR is set to %q.",
 		tutorialDir,
 	)
 
-	cmd := exec.Command("claude",
+	ctx, cancel := context.WithTimeout(context.Background(), verifyTimeout)
+
+	// cmd.Dir pins the working directory to the temp dir so every file the
+	// verifier creates lands there, not in the user's repo. --add-dir grants
+	// access only; it does not change the cwd. The tutorial dir is granted too
+	// so the subprocess can read metadata.json and write its result + status.
+	cmd := exec.CommandContext(ctx, "claude",
 		"--add-dir", tempDir,
+		"--add-dir", tutorialDir,
 		"--dangerously-skip-permissions",
 		"-p", prompt,
 	)
+	cmd.Dir = tempDir
 	cmd.Env = append(os.Environ(), "LATHE_TUTORIAL_DIR="+tutorialDir)
+	if logFile != nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
 
 	if err := cmd.Start(); err != nil {
+		cancel()
+		if logFile != nil {
+			logFile.Close()
+		}
 		os.RemoveAll(tempDir)
 		return fmt.Errorf("start verifier: %w", err)
 	}
 
-	// Detach: clean up temp dir when subprocess exits, don't block
+	// Detach: clean up temp dir when subprocess exits, don't block. The
+	// goroutine also enforces the fallback so the badge never sticks at ⏳.
 	go func() {
-		cmd.Wait()
-		os.RemoveAll(tempDir)
+		defer cancel()
+		defer os.RemoveAll(tempDir)
+		if logFile != nil {
+			defer logFile.Close()
+		}
+		waitErr := cmd.Wait()
+		timedOut := ctx.Err() == context.DeadlineExceeded
+		finalizeVerify(tutorialDir, timedOut, waitErr)
 	}()
 
 	return nil
+}
+
+// finalizeVerify is the post-Wait fallback. The verifier skill is responsible
+// for writing the terminal status (verified/failed/skipped). If it never did —
+// the subprocess crashed, timed out, or exited non-zero before reporting — the
+// status is still "verifying", so we flip it to failed with a clear reason.
+// Pure and side-effect-scoped to the tutorial dir, so it's unit-testable
+// without a real subprocess.
+func finalizeVerify(tutorialDir string, timedOut bool, waitErr error) {
+	tut, err := store.ReadMetadata(tutorialDir)
+	if err != nil {
+		return
+	}
+	// The skill already reported a terminal status — nothing to override.
+	if tut.Status != store.StatusVerifying {
+		return
+	}
+
+	var reason string
+	switch {
+	case timedOut:
+		reason = fmt.Sprintf("verification timed out after %s", verifyTimeout)
+	case waitErr != nil:
+		reason = fmt.Sprintf("verifier exited without reporting: %v", waitErr)
+	default:
+		reason = "verifier exited without reporting a result"
+	}
+
+	tut.Status = store.StatusFailed
+	store.WriteMetadata(tutorialDir, tut)                     //nolint:errcheck
+	store.WriteVerifyResult(tutorialDir, &store.VerifyResult{ //nolint:errcheck
+		Status: store.StatusFailed,
+		Error:  reason,
+	})
 }

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,10 +1,12 @@
-package verify_test
+package verify
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/devenjarvis/lathe/internal/verify"
+	"github.com/devenjarvis/lathe/internal/store"
 )
 
 func TestSpawnVerifierMissingClaude(t *testing.T) {
@@ -15,8 +17,107 @@ func TestSpawnVerifierMissingClaude(t *testing.T) {
 	os.Setenv("PATH", "")
 	defer os.Setenv("PATH", origPath)
 
-	err := verify.SpawnVerifier("test-slug", tutDir)
+	err := SpawnVerifier("test-slug", tutDir)
 	if err == nil {
 		t.Error("SpawnVerifier() expected error when claude not in PATH, got nil")
+	}
+}
+
+func writeTut(t *testing.T, dir string, status store.Status) {
+	t.Helper()
+	tut := &store.Tutorial{
+		Slug:   "test-slug",
+		Title:  "Test Slug",
+		Status: status,
+		Parts:  []string{"part-01.md"},
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStartVerificationSetsVerifying(t *testing.T) {
+	tutDir := t.TempDir()
+	writeTut(t, tutDir, store.StatusUnverified)
+
+	// PATH="" makes the spawn fail fast, but StartVerification writes
+	// status=verifying BEFORE spawning, so we observe it regardless.
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	defer os.Setenv("PATH", origPath)
+
+	StartVerification("test-slug", tutDir) //nolint:errcheck
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Status != store.StatusVerifying {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusVerifying)
+	}
+}
+
+func TestStartVerificationRejectsWhileVerifying(t *testing.T) {
+	tutDir := t.TempDir()
+	writeTut(t, tutDir, store.StatusVerifying)
+
+	if err := StartVerification("test-slug", tutDir); err == nil {
+		t.Error("StartVerification() should reject a tutorial already verifying")
+	}
+}
+
+func TestStartVerificationRejectsWhileExtending(t *testing.T) {
+	tutDir := t.TempDir()
+	writeTut(t, tutDir, store.StatusExtending)
+
+	if err := StartVerification("test-slug", tutDir); err == nil {
+		t.Error("StartVerification() should reject a tutorial that is extending")
+	}
+}
+
+func TestFinalizeVerifyFlipsStuckVerifyingToFailed(t *testing.T) {
+	tutDir := t.TempDir()
+	writeTut(t, tutDir, store.StatusVerifying)
+
+	// Subprocess timed out without ever reporting a terminal status.
+	finalizeVerify(tutDir, true, errors.New("signal: killed"))
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Status != store.StatusFailed {
+		t.Errorf("Status = %q, want %q", got.Status, store.StatusFailed)
+	}
+
+	vr, err := store.ReadVerifyResult(tutDir)
+	if err != nil {
+		t.Fatalf("ReadVerifyResult: %v", err)
+	}
+	if vr.Status != store.StatusFailed {
+		t.Errorf("VerifyResult.Status = %q, want %q", vr.Status, store.StatusFailed)
+	}
+	if vr.Error == "" {
+		t.Error("VerifyResult.Error should explain the timeout, got empty")
+	}
+}
+
+func TestFinalizeVerifyLeavesReportedStatusAlone(t *testing.T) {
+	tutDir := t.TempDir()
+	// The skill already reported success before the goroutine ran.
+	writeTut(t, tutDir, store.StatusVerified)
+
+	finalizeVerify(tutDir, false, nil)
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want %q (must not override a reported status)", got.Status, store.StatusVerified)
+	}
+	// No fallback verify-result.json should be written when the skill reported.
+	if _, err := os.Stat(filepath.Join(tutDir, "verify-result.json")); !os.IsNotExist(err) {
+		t.Errorf("finalizeVerify wrote a verify-result.json over a reported status: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Reworks tutorial verification from auto-run-on-`store` to **opt-in, isolated, and legible**, fixing three real pains: verifier files polluting the user's repo, runs that hang forever at ⏳, and failures that never surfaced.

- **Opt-in triggers.** `lathe store` now leaves a tutorial `unverified` (no badge) and spawns no subprocess. Verification runs only on request — `lathe verify <slug>`, `lathe store --verify`, or the new **Verify this tutorial** web button (`POST /-/verify/{slug}`) — all funneled through a shared `verify.StartVerification` (conflict-guard against in-flight extend/verify; commits `verifying` status before spawn).
- **Isolation (the core fix).** `cmd.Dir` is pinned to a fresh `/tmp/lathe-verify-*` dir so every file the verifier creates lands there, not in the user's repo. The temp dir and tutorial dir are granted via two `--add-dir` flags.
- **Robustness.** Runs under a 20-minute `context.WithTimeout`. A detached goroutine calls `finalizeVerify`, which flips a still-`verifying` status to `failed` with a clear reason (timeout / crash / silent exit) — the badge can never stick at ⏳. `finalizeVerify` never overrides a status the skill already reported.
- **Legibility.** Subprocess stdout/stderr captured to `verify.log` in the tutorial dir; `verify-result.json` is now read by Go and rendered as a failure panel (part / failed step / error) on the tutorial page.
- **Honest env handling.** New `skipped` status (⚠️) for "required tool not installed" — distinct from a genuinely broken tutorial. The `/lathe-verify` skill reports skipped instead of failed.
- **Status model.** Enum gains `unverified` and `skipped`; badges, the verifying meta-refresh, and the no-badge `unverified` case are reflected across `layout.html`, `list.html`, and `lathe list`.
- **Import cycle.** `store` no longer imports `verify`; `verify` now imports `store`. Skill docs, `CLAUDE.md` (inverts the old "don't add a `lathe verify` command" rule), and `README.md` updated.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green. New tests cover `Read/WriteVerifyResult` round-trip, new status values, `StartVerification` (sets verifying + conflict-guards), `finalizeVerify` fallback (flips stuck-verifying → failed; leaves reported status alone), the `lathe verify` command, and the serve layer (verify route 202/404/409, button rendering, verifying meta-refresh, skipped badge, failure panel).
- **No-noise check:** `lathe store <path>` from a throwaway repo leaves status `unverified`, writes no `verify.log`, and spawns no subprocess (smoke-tested).
- Manual end-to-end for happy/failure/skip/timeout paths follows the steps in the implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)