### PR TITLE
fix: strip lathe- prefix from stored tutorial titles

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,10 @@ import (
 // here — callers trigger it separately via verify.StartVerification.
 func Store(srcPath string) (*Tutorial, error) {
 	slug := filepath.Base(strings.TrimSuffix(srcPath, string(filepath.Separator)))
+	// The generation skill writes to /tmp/lathe-<slug>/ (the "lathe-" prefix
+	// namespaces the temp dir). Strip it so the prefix doesn't leak into the
+	// stored slug — and from there into the derived title.
+	slug = strings.TrimPrefix(slug, "lathe-")
 
 	tutorialsDir, err := config.TutorialsDir()
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -28,6 +28,30 @@ func TestStoreSingleTutorial(t *testing.T) {
 	}
 }
 
+func TestStoreStripsLathePrefixFromSlug(t *testing.T) {
+	// The generation skill writes to /tmp/lathe-<slug>/; the "lathe-" prefix
+	// must not leak into the stored slug or the derived title.
+	src := filepath.Join(t.TempDir(), "lathe-digital-synth-zig")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	tut, err := store.Store(src)
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if tut.Slug != "digital-synth-zig" {
+		t.Errorf("Store() Slug = %q, want %q", tut.Slug, "digital-synth-zig")
+	}
+	if tut.Title != "Digital Synth Zig" {
+		t.Errorf("Store() Title = %q, want %q", tut.Title, "Digital Synth Zig")
+	}
+}
+
 func TestStoreSeriesTutorial(t *testing.T) {
 	src := t.TempDir()
 	for _, name := range []string{"part-01.md", "part-02.md", "part-03.md"} {


### PR DESCRIPTION
## Summary
- Tutorial titles always started with "Lathe" (e.g. "Lathe Digital Synth Zig").
- Root cause: the `/lathe` generation skill writes to `/tmp/lathe-<slug>/`, where the `lathe-` prefix only namespaces the temp dir. `store.Store` derived the slug via `filepath.Base`, so the prefix leaked into the slug, topic, and `SlugToTitle` output.
- Fix: strip the conventional `lathe-` prefix right after deriving the slug, so slug/topic/title are all clean. Works whether the skill passes a prefixed or already-clean path.
- Added `TestStoreStripsLathePrefixFromSlug` covering the slug + title result.

Note: this corrects newly stored tutorials. The 8 already-stored tutorials in `~/.lathe/tutorials/` are intentionally left untouched (per request — code fix only, no data backfill).

## Test plan
- `go test ./internal/store/` — passes (including the new test)
- `go vet ./...` — clean
- `go build` — succeeds