### PR TITLE
fix: redirect single-part tutorials to their first part

### DIFF
--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -157,7 +157,10 @@ func (s *Server) handleTutorial(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if tut.IsSeries() && len(tut.Parts) > 0 {
+	// Any tutorial with parts (single or series) lives in part-NN.md files, not
+	// index.md, so redirect to the first part. The index.md fallback is only for
+	// legacy tutorials that were never split into parts.
+	if len(tut.Parts) > 0 {
 		http.Redirect(w, r, fmt.Sprintf("/%s/%s", slug, tut.Parts[0]), http.StatusFound)
 		return
 	}

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -325,6 +325,40 @@ func TestSeriesRedirect(t *testing.T) {
 	}
 }
 
+func TestSinglePartRedirect(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "single-part")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "single-part",
+		Title:   "Single Part",
+		Status:  store.StatusUnverified,
+		Created: time.Now(),
+		Parts:   []string{"part-01.md"},
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Only Part"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/single-part/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("GET /single-part/ = %d, want %d (redirect)", w.Code, http.StatusFound)
+	}
+	loc := w.Header().Get("Location")
+	if loc != "/single-part/part-01.md" {
+		t.Errorf("redirect Location = %q, want %q", loc, "/single-part/part-01.md")
+	}
+}
+
 func TestStaticMermaidAsset(t *testing.T) {
 	dir := t.TempDir()
 	srv := serve.NewServer(dir)


### PR DESCRIPTION
## Summary

- Single-part tutorials (`parts: ["part-01.md"]`) opened from the browser at `/<slug>/` resolved to the wrong link and 404'd.
- `handleTutorial` only redirected to the first part when `IsSeries()` was true, but `IsSeries()` requires `len(Parts) > 1`. A single-part tutorial fell through to the `index.md` fallback — which doesn't exist, since single-part content lives in `part-01.md`.
- Now redirect whenever the tutorial has any parts; the `index.md` fallback is reserved for legacy tutorials that were never split into parts.

## Test plan

- Added `TestSinglePartRedirect`, which confirms `GET /<slug>/` returns `302` → `/<slug>/part-01.md` for a single-part tutorial (it 404'd before the fix).
- `go test ./...` and `go vet ./...` pass.
- Manually: `http://localhost:4242/loam-build-command/` now redirects to `/loam-build-command/part-01.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)