### PR TITLE
feat: add tags + client-side search/filter/sort to the tutorial list

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -298,8 +298,14 @@ Decide the slug before writing. Never write `index.md` or multiple parts.
 Run:
 
 ```bash
-lathe store /tmp/lathe-<slug>
+lathe store /tmp/lathe-<slug> --tag <a> --tag <b> --tag <c>
 ```
+
+Choose **2–5** lowercase tags so the tutorial is findable in `lathe serve`'s
+search and tag filters. Cover, where they apply: the language/runtime (`zig`,
+`rust`, `go`), the domain (`audio`, `compilers`, `databases`), and the core
+technique (`parsing`, `dsp`, `concurrency`). Prefer short, reusable tags that
+will group naturally with other tutorials over hyper-specific one-offs.
 
 Then tell the user:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,14 @@ cmd/
   verify.go, extend.go            print the /lathe-verify, /lathe-extend handoff command
   verify-result.go                lathe verify-result — skill records verify status/result
   extend-start.go, extend-commit.go    lathe extend-{start,commit} — skill reserves/records a part
+  tag.go                          lathe tag — skill sets/adds/removes a tutorial's search tags
 internal/
   config/                         TutorialsDir() → ~/.lathe/tutorials
   store/
     metadata.go                   Tutorial struct, Status enum, Read/WriteMetadata, VerifyResult
     store.go                      Store(), Delete(), copyDir/copyFile, detectParts, SlugToTitle, PromoteIndexToPart
   serve/
-    server.go                     net/http handlers (list, tutorial, part, delete)
+    server.go                     net/http handlers (list, tutorial, part, delete); list.html does client-side search/filter/sort
     ask.go, verify.go, extend.go  POST endpoints that return a paste-able skill command (handoff.go)
     renderer.go                   goldmark + chroma markdown rendering
     layout.html, list.html        embed.FS page templates
@@ -38,6 +39,7 @@ internal/
   lathe-verify/SKILL.md           /lathe-verify — runs verification interactively
   lathe-extend/SKILL.md           /lathe-extend — writes the next part interactively
   lathe-ask/SKILL.md              /lathe-ask — answers reader questions about a part
+  lathe-tag/SKILL.md              /lathe-tag — picks/backfills search tags for stored tutorials
 docs/design-system.md            design-system docs (tokens, type scale, components, how-to-add)
 docs/superpowers/                 specs/ and plans/
 ```
@@ -57,6 +59,7 @@ There is no top-level test runner script — tests are plain `go test`. The `/la
 - **`cmd/serve.go`** registers `--port` on its command's flags but stores it in the package-level `servePort` variable, which `cmd/open.go` also reads. Keep them in sync if you add new commands that need the port.
 - **`internal/serve/server.go`** uses Go 1.22+ method-and-pattern routing (`mux.HandleFunc("GET /{slug}/", …)`). `safeTutorialPath` defends against path traversal by checking the joined path stays under `tutorialsDir` — preserve that check on any new route.
 - **Handoff model (verify/extend/ask).** The Go binary spawns no `claude` subprocess. The web POST endpoints (`internal/serve/{ask,verify,extend}.go`) validate + conflict-guard, then return `{"command": "/lathe-… <slug> …"}` via `writeHandoff` (`handoff.go`); the templates render a copy-to-clipboard panel. The CLI `lathe verify`/`lathe extend` likewise just print the command. The actual work runs in the user's interactive session via the matching skill, which calls back into the CLI to mutate state: `/lathe-verify` → `lathe verify-result <slug> --status verifying` (in-flight badge) then a terminal `--status verified|failed|skipped [...]`; `/lathe-extend` → `lathe extend-start` (reserves the part, prints its filename, sets `extending`) then `lathe extend-commit`. **Status is set by the skill, never by the web/CLI handoff** — that's deliberate, so an unclicked button can't leave a badge stuck at `verifying`/`extending`.
+- **List-page search/filter/sort is client-side.** `handleList` renders every card with `data-*` attributes (title/slug/topic/tags/status/created/series) plus tag pills; the inline `<script>` in `list.html` does all search, tag/status/type filtering, and sorting in the browser — no new server round-trips, and it stays offline. The server is unchanged beyond the `Tags` field flowing through. Metadata-only by design: search never reads part bodies. Keep it progressive — with JS off, every card stays visible (`.hidden` is only ever set by that script). Tags are populated by `lathe store --tag` (from `/lathe`) and `lathe tag` (from `/lathe-tag`); `store.NormalizeTags` trims/lowercases/de-dupes and is the one place that vocabulary is canonicalized.
 - **HTML templates** are `embed.FS`-bundled (`internal/serve/*.html`) so the binary is self-contained. They use a small `add` funcMap for 1-indexed part numbering. `components.html` is parsed into **both** the layout and list template sets (with `funcMap` attached to both) so its shared partials are available everywhere — see `NewServer`.
 - **Design system**: `styles.css` is the single source of truth for all UI styling — light/dark color tokens, `@font-face`, base typography, and every component class. It's `go:embed`'d as `stylesCSS`, exposed to templates as `.CSS`, and injected inline via the `{{define "head"}}` partial (alongside `.HighlightCSS`) so there's no extra request and no FOUC. **Status and callout colors are CSS tokens in `styles.css`, not inline in the templates.** Full docs in `docs/design-system.md`.
 - **Fonts** are latin-subset `woff2` (`internal/serve/static/fonts/`), `go:embed`'d and served at flat `/_static/<name>.woff2` (single-segment route + explicit whitelist preserved; `handleStatic` resolves `.woff2` names into the `fonts/` subdir). The UI stays 100% offline.
@@ -67,12 +70,12 @@ There is no top-level test runner script — tests are plain `go test`. The `/la
 - One cobra subcommand per file in `cmd/`, registered via `init()` calling `rootCmd.AddCommand(...)`.
 - Errors flow up through `RunE`; the root `Execute()` exits non-zero on any error.
 - Keep `internal/` packages free of cobra imports — they should be usable from tests directly.
-- Skills are markdown files, all checked into `.claude/skills/<name>/SKILL.md` (`lathe`, `lathe-verify`, `lathe-extend`, `lathe-ask`) and user-invoked in an interactive session. None are embedded in the binary — the binary spawns no `claude`.
+- Skills are markdown files, all checked into `.claude/skills/<name>/SKILL.md` (`lathe`, `lathe-verify`, `lathe-extend`, `lathe-ask`, `lathe-tag`) and user-invoked in an interactive session. None are embedded in the binary — the binary spawns no `claude`.
 - Status values are an enum (`store.Status`): `unverified` (default after store; renders no badge), `verifying`, `verified`, `failed`, `skipped` (required tool not installed — not a failure), `extending`. New states should be added there and reflected in `cmd/list.go` `statusBadge`, the `{{define "badge"}}` partial in `components.html`, and the `--badge-*` tokens + `.badge.<status>` rule in `styles.css` (see "how to add a new status" in `docs/design-system.md`).
 
 ## Things to avoid
 
-- Verification is **opt-in / on-demand**: it runs only when the user asks (`/lathe-verify <slug>` in their session — surfaced by the `lathe verify` command, the `--verify` flag on `lathe store`, or the "Verify this tutorial" web button, all of which just hand off that command). Storing never auto-verifies; the default status is `unverified`. Don't re-introduce a Go-side verifier subprocess. Don't add a `lathe status` *read* command — status is surfaced via `lathe list` and the web UI (the `verify-result`/`extend-*` commands are write-only state mutations for skills).
+- Verification is **opt-in / on-demand**: it runs only when the user asks (`/lathe-verify <slug>` in their session — surfaced by the `lathe verify` command, the `--verify` flag on `lathe store`, or the "Verify this tutorial" web button, all of which just hand off that command). Storing never auto-verifies; the default status is `unverified`. Don't re-introduce a Go-side verifier subprocess. Don't add a `lathe status` *read* command — status is surfaced via `lathe list` and the web UI (the `verify-result`/`extend-*`/`tag` commands are write-only state mutations for skills).
 - Don't add tutorial editing or sharing commands without checking with the user — the v1 scope is deliberately narrow. (Deletion is supported via `lathe rm <slug>` and the `×` button on the web list page; both go through `store.Delete` / `safeTutorialPath`.)
 - Don't have the verify/extend skills edit `metadata.json` or `verify-result.json` directly — they call `lathe verify-result` / `lathe extend-commit` so the binary stays the sole writer of durable state. The verify skill is read-only with respect to the tutorial markdown.
 - Don't add OS-level sandboxing (sandbox-exec, Docker) for verification unless explicitly asked. With no subprocess, isolation is by instruction: the `/lathe-verify` skill builds in a fresh `mktemp -d` scratch dir under the user's normal interactive permission model.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lathe targets topics where good documentation is scarce — *"build a digital sy
 
 Two layers with a clean boundary:
 
-- **Claude Code skills** — generate and work with tutorials, all run in your **interactive** Claude Code session: `/lathe` writes `part-01.md`, `/lathe-extend` adds the next part, `/lathe-verify` works through a tutorial to confirm it compiles and runs, and `/lathe-ask` answers questions about a part you're reading. Running them interactively keeps the work on your Claude subscription (headless `claude -p` is metered as of 2026-06-15; interactive use is not).
+- **Claude Code skills** — generate and work with tutorials, all run in your **interactive** Claude Code session: `/lathe` writes `part-01.md`, `/lathe-extend` adds the next part, `/lathe-verify` works through a tutorial to confirm it compiles and runs, `/lathe-ask` answers questions about a part you're reading, and `/lathe-tag` adds search tags to existing tutorials. Running them interactively keeps the work on your Claude subscription (headless `claude -p` is metered as of 2026-06-15; interactive use is not).
 - **`lathe` CLI** (Go) — copies tutorials into `~/.lathe/tutorials/`, serves the rendered output at `http://localhost:4242`, and owns all durable state. It never calls `claude` itself: the web buttons and the `lathe verify`/`lathe extend` commands just hand you the skill command to paste into your session, and the skills call back into the CLI (`lathe store`, `lathe verify-result`, `lathe extend-start`/`extend-commit`) to record results.
 
 ```
@@ -50,7 +50,7 @@ cd lathe
 go build -o lathe
 ```
 
-The skills live under `.claude/skills/` in this repo — `lathe/`, `lathe-verify/`, `lathe-extend/`, and `lathe-ask/`, each a `SKILL.md`. Copy them into your own project's `.claude/skills/` (or your user-level skills directory) so Claude Code can discover them.
+The skills live under `.claude/skills/` in this repo — `lathe/`, `lathe-verify/`, `lathe-extend/`, `lathe-ask/`, and `lathe-tag/`, each a `SKILL.md`. Copy them into your own project's `.claude/skills/` (or your user-level skills directory) so Claude Code can discover them.
 
 ## Usage
 
@@ -72,13 +72,31 @@ Other commands:
 lathe list               # show all stored tutorials with status badges
 lathe open <slug>        # open a specific tutorial (requires lathe serve)
 lathe store <path>       # save a tutorial directory manually (status: unverified)
+lathe store <path> --tag rust --tag audio   # save with search tags
 lathe store <path> --verify   # save, then print the /lathe-verify command to run
 lathe verify <slug>      # print the /lathe-verify <slug> command to run in your session
 lathe extend <slug>      # print the /lathe-extend <slug> command to run in your session
+lathe tag <slug> --set rust,audio   # set/--add/--remove a tutorial's tags
 lathe rm <slug>          # delete a stored tutorial (prompts unless --force)
 ```
 
 You can also delete tutorials from the web UI — each row on the list page has a `×` button that removes the tutorial after a confirmation.
+
+## Finding tutorials
+
+As your library grows, the web list page (`lathe serve`) has a search box and
+filters to narrow it down — all client-side, so it stays fast and offline:
+
+- **Search** matches a tutorial's title, slug, topic, and tags.
+- **Sort** by newest, oldest, or title (A–Z).
+- **Filter** by status, by type (single vs. series), and by tag — each tutorial's
+  tags also show as pills on its card.
+
+Tags come from the `tags` field in `metadata.json`. New tutorials get them when
+`/lathe` passes `--tag` to `lathe store`; for tutorials made before tagging
+existed, run `/lathe-tag <slug>` in your session (or `/lathe-tag` to backfill
+every untagged one) — the skill reads the tutorial and records tags via
+`lathe tag`. Untagged tutorials still show up and stay searchable by title/topic.
 
 Default port is `4242`; override with `--port`.
 
@@ -107,7 +125,7 @@ Tutorials live globally in `~/.lathe/tutorials/`, one directory per slug:
   "topic": "build a digital synth in Zig",
   "created": "2026-05-03T19:00:00Z",
   "status": "unverified",
-  "series": true,
+  "tags": ["zig", "audio", "dsp"],
   "parts": ["part-01.md", "part-02.md", "part-03.md"]
 }
 ```
@@ -132,18 +150,18 @@ Because verification now runs in your own interactive session, it executes under
 
 - [`spf13/cobra`](https://github.com/spf13/cobra) — CLI command structure
 - [`yuin/goldmark`](https://github.com/yuin/goldmark) + [`goldmark-highlighting`](https://github.com/yuin/goldmark-highlighting) — markdown rendering with Chroma syntax highlighting
-- `claude` CLI — Claude Code, where the `/lathe`, `/lathe-verify`, `/lathe-extend`, and `/lathe-ask` skills run
+- `claude` CLI — Claude Code, where the `/lathe`, `/lathe-verify`, `/lathe-extend`, `/lathe-ask`, and `/lathe-tag` skills run
 
 ## Repository layout
 
 ```
 cmd/                CLI commands (root, list, open, rm, serve, store, verify, extend,
-                    verify-result, extend-start, extend-commit)
+                    verify-result, extend-start, extend-commit, tag)
 internal/config/    ~/.lathe/tutorials path resolution
 internal/store/     copy + metadata read/write, slug detection
 internal/serve/     HTTP server, markdown renderer, embedded HTML templates, handoff endpoints
 internal/extend/    NextPartFilename helper
-.claude/skills/     lathe, lathe-verify, lathe-extend, lathe-ask skills (user-invoked, interactive)
+.claude/skills/     lathe, lathe-verify, lathe-extend, lathe-ask, lathe-tag skills (user-invoked, interactive)
 docs/superpowers/   design spec and bootstrap plan
 main.go             cobra entrypoint
 ```

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -2,19 +2,24 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/devenjarvis/lathe/internal/store"
 	"github.com/spf13/cobra"
 )
 
-var withVerify bool
+var (
+	withVerify    bool
+	storeTags     []string
+	storeTagsList []string
+)
 
 var storeCmd = &cobra.Command{
 	Use:   "store <path>",
 	Short: "Save a tutorial directory to ~/.lathe/tutorials/",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tut, err := store.Store(args[0])
+		tut, err := store.Store(args[0], splitTags(append(storeTags, storeTagsList...))...)
 		if err != nil {
 			return err
 		}
@@ -29,7 +34,22 @@ var storeCmd = &cobra.Command{
 	},
 }
 
+// splitTags flattens the repeatable --tag flag, also splitting any
+// comma-separated values so `--tags "a,b"` and `--tag a --tag b` both work.
+// Normalization (trim/lowercase/dedupe) happens in store.NormalizeTags.
+func splitTags(raw []string) []string {
+	var out []string
+	for _, r := range raw {
+		for _, p := range strings.Split(r, ",") {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func init() {
 	storeCmd.Flags().BoolVar(&withVerify, "verify", false, "print the command to verify after storing")
+	storeCmd.Flags().StringArrayVar(&storeTags, "tag", nil, "tag to attach (repeatable; --tag also accepts comma-separated values)")
+	storeCmd.Flags().StringSliceVar(&storeTagsList, "tags", nil, "comma-separated tags (alias for repeated --tag)")
 	rootCmd.AddCommand(storeCmd)
 }

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/devenjarvis/lathe/internal/config"
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tagSet    []string
+	tagAdd    []string
+	tagRemove []string
+)
+
+// tagCmd mutates a tutorial's tags. Like verify-result and extend-commit, it is
+// a write-only state mutation: the /lathe-tag skill (or the user) chooses the
+// tags — the model work — and this command persists them, keeping the Go binary
+// the sole writer of metadata.json.
+var tagCmd = &cobra.Command{
+	Use:   "tag <slug>",
+	Short: "Set, add, or remove tags on a tutorial (used by the /lathe-tag skill)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		if err := validateSlug(slug); err != nil {
+			return err
+		}
+		if len(tagSet) == 0 && len(tagAdd) == 0 && len(tagRemove) == 0 {
+			return fmt.Errorf("nothing to do: pass --set, --add, or --remove")
+		}
+
+		tutorialsDir, err := config.TutorialsDir()
+		if err != nil {
+			return err
+		}
+		tutDir := filepath.Join(tutorialsDir, slug)
+		tut, err := store.ReadMetadata(tutDir)
+		if err != nil {
+			return fmt.Errorf("read metadata for %q: %w", slug, err)
+		}
+
+		// --set replaces the whole list; --add/--remove edit it in place.
+		tags := tut.Tags
+		if len(tagSet) > 0 {
+			tags = splitTags(tagSet)
+		}
+		tags = append(tags, splitTags(tagAdd)...)
+		tags = store.NormalizeTags(tags)
+
+		if remove := store.NormalizeTags(splitTags(tagRemove)); len(remove) > 0 {
+			drop := make(map[string]struct{}, len(remove))
+			for _, r := range remove {
+				drop[r] = struct{}{}
+			}
+			kept := tags[:0]
+			for _, t := range tags {
+				if _, ok := drop[t]; !ok {
+					kept = append(kept, t)
+				}
+			}
+			tags = kept
+		}
+
+		tut.Tags = tags
+		if err := store.WriteMetadata(tutDir, tut); err != nil {
+			return fmt.Errorf("write metadata: %w", err)
+		}
+		if len(tags) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Cleared tags for %q\n", slug)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Tags for %q: %s\n", slug, strings.Join(tags, ", "))
+		}
+		return nil
+	},
+}
+
+func init() {
+	tagCmd.Flags().StringArrayVar(&tagSet, "set", nil, "replace all tags (repeatable; accepts comma-separated values)")
+	tagCmd.Flags().StringArrayVar(&tagAdd, "add", nil, "add a tag (repeatable; accepts comma-separated values)")
+	tagCmd.Flags().StringArrayVar(&tagRemove, "remove", nil, "remove a tag (repeatable; accepts comma-separated values)")
+	rootCmd.AddCommand(tagCmd)
+}

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+// resetTagFlags restores the package-level flag vars between cases, since cobra
+// binds flags to shared package state.
+func resetTagFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		tagSet = nil
+		tagAdd = nil
+		tagRemove = nil
+	})
+}
+
+func tagsOf(t *testing.T, tutDir string) []string {
+	t.Helper()
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tut.Tags
+}
+
+func sameTags(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTagSetReplacesAndNormalizes(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := writeTutorial(t, homeDir, "test-slug", store.StatusUnverified, []string{"part-01.md"})
+
+	resetTagFlags(t)
+	tagSet = []string{"Rust,audio", " rust ", "dsp"}
+	if err := tagCmd.RunE(tagCmd, []string{"test-slug"}); err != nil {
+		t.Fatalf("tag --set: %v", err)
+	}
+	if got, want := tagsOf(t, tutDir), []string{"rust", "audio", "dsp"}; !sameTags(got, want) {
+		t.Errorf("tags = %v, want %v", got, want)
+	}
+}
+
+func TestTagAddAndRemove(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := writeTutorial(t, homeDir, "test-slug", store.StatusUnverified, []string{"part-01.md"})
+
+	resetTagFlags(t)
+	tagSet = []string{"rust", "cli"}
+	if err := tagCmd.RunE(tagCmd, []string{"test-slug"}); err != nil {
+		t.Fatalf("tag --set: %v", err)
+	}
+
+	resetTagFlags(t)
+	tagAdd = []string{"parsing"}
+	tagRemove = []string{"cli"}
+	if err := tagCmd.RunE(tagCmd, []string{"test-slug"}); err != nil {
+		t.Fatalf("tag --add/--remove: %v", err)
+	}
+	if got, want := tagsOf(t, tutDir), []string{"rust", "parsing"}; !sameTags(got, want) {
+		t.Errorf("tags = %v, want %v", got, want)
+	}
+}
+
+func TestTagRequiresAnAction(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	writeTutorial(t, homeDir, "test-slug", store.StatusUnverified, []string{"part-01.md"})
+
+	resetTagFlags(t)
+	if err := tagCmd.RunE(tagCmd, []string{"test-slug"}); err == nil {
+		t.Error("tag with no --set/--add/--remove should error")
+	}
+}

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -13,11 +13,37 @@
   {{template "themeToggle" .}}
 </div>
 {{if .Tutorials}}
+<div class="controls">
+  <div class="controls-row">
+    <input type="search" id="searchInput" class="search-input" placeholder="Search by title, topic, or tag…" aria-label="Search tutorials" autocomplete="off">
+    <select id="sortSelect" class="sort-select" aria-label="Sort tutorials">
+      <option value="newest">Newest</option>
+      <option value="oldest">Oldest</option>
+      <option value="title">Title A–Z</option>
+    </select>
+  </div>
+  <div class="filter-row" id="statusFilters">
+    <span class="filter-label">Status</span>
+    <button type="button" class="filter-pill" aria-pressed="false" data-status="verified">✅ Verified</button>
+    <button type="button" class="filter-pill" aria-pressed="false" data-status="failed">❌ Failed</button>
+    <button type="button" class="filter-pill" aria-pressed="false" data-status="skipped">⚠️ Skipped</button>
+    <button type="button" class="filter-pill" aria-pressed="false" data-status="unverified">Unverified</button>
+  </div>
+  <div class="filter-row" id="typeFilters">
+    <span class="filter-label">Type</span>
+    <button type="button" class="filter-pill" aria-pressed="false" data-series="false">Single</button>
+    <button type="button" class="filter-pill" aria-pressed="false" data-series="true">Series</button>
+  </div>
+  <div class="filter-row" id="tagFilters" hidden>
+    <span class="filter-label">Tags</span>
+  </div>
+</div>
 {{range .Tutorials}}
-<div class="tutorial">
+<div class="tutorial" data-title="{{.Title}}" data-slug="{{.Slug}}" data-topic="{{.Topic}}" data-tags="{{range .Tags}}{{.}},{{end}}" data-status="{{.Status}}" data-created="{{.Created.Format "2006-01-02T15:04:05Z07:00"}}" data-series="{{.IsSeries}}">
   <div>
     <a href="/{{.Slug}}/">{{.Title}}</a>
     <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}</div>
+    {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
   </div>
   <div class="tutorial-actions">
     {{template "badge" .Status}}
@@ -27,6 +53,7 @@
   </div>
 </div>
 {{end}}
+<div class="no-results" id="noResults" hidden>No tutorials match your search.</div>
 {{else}}
 <div class="empty">No tutorials yet. Run <code>/lathe</code> in Claude Code to generate one.</div>
 {{end}}
@@ -64,6 +91,91 @@
         }
       });
     });
+  })();
+  // Client-side search / filter / sort. Metadata only — matches the data-*
+  // attributes the template renders, so there are no server round-trips. With
+  // JS off, every card stays visible (.hidden is only ever set here).
+  (function(){
+    var cards = Array.prototype.slice.call(document.querySelectorAll('.tutorial'));
+    if (!cards.length) return;
+    var search = document.getElementById('searchInput');
+    var sortSel = document.getElementById('sortSelect');
+    var statusRow = document.getElementById('statusFilters');
+    var typeRow = document.getElementById('typeFilters');
+    var tagRow = document.getElementById('tagFilters');
+    var noResults = document.getElementById('noResults');
+    var container = cards[0].parentNode;
+
+    function cardTags(card){
+      return (card.dataset.tags || '').split(',').map(function(s){return s.trim();}).filter(Boolean);
+    }
+    function activeValues(row, key){
+      return Array.prototype.slice.call(row.querySelectorAll('[aria-pressed="true"]'))
+        .map(function(b){ return b.dataset[key]; });
+    }
+
+    // Build tag-filter pills from the union of every card's tags.
+    var tagSet = {};
+    cards.forEach(function(c){ cardTags(c).forEach(function(t){ tagSet[t] = true; }); });
+    var tagNames = Object.keys(tagSet).sort();
+    if (tagNames.length){
+      tagNames.forEach(function(t){
+        var b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'filter-pill';
+        b.setAttribute('aria-pressed', 'false');
+        b.dataset.tag = t;
+        b.textContent = t;
+        tagRow.appendChild(b);
+      });
+      tagRow.hidden = false;
+    }
+
+    function apply(){
+      var q = (search.value || '').trim().toLowerCase();
+      var statuses = activeValues(statusRow, 'status');
+      var types = activeValues(typeRow, 'series');
+      var tags = activeValues(tagRow, 'tag');
+      var visible = 0;
+      cards.forEach(function(card){
+        var hay = (card.dataset.title + ' ' + card.dataset.slug + ' ' +
+                   card.dataset.topic + ' ' + card.dataset.tags).toLowerCase();
+        var ct = cardTags(card);
+        var show = (!q || hay.indexOf(q) !== -1)
+          && (!statuses.length || statuses.indexOf(card.dataset.status) !== -1)
+          && (!types.length || types.indexOf(card.dataset.series) !== -1)
+          && (!tags.length || tags.some(function(t){ return ct.indexOf(t) !== -1; }));
+        card.classList.toggle('hidden', !show);
+        if (show) visible++;
+      });
+      noResults.hidden = visible !== 0;
+    }
+
+    function sort(){
+      var mode = sortSel.value;
+      cards.slice().sort(function(a, b){
+        if (mode === 'title'){
+          return a.dataset.title.toLowerCase().localeCompare(b.dataset.title.toLowerCase());
+        }
+        var da = a.dataset.created, db = b.dataset.created;
+        if (mode === 'oldest') return da < db ? -1 : da > db ? 1 : 0;
+        return da > db ? -1 : da < db ? 1 : 0; // newest first
+      }).forEach(function(c){ container.insertBefore(c, noResults); });
+    }
+
+    search.addEventListener('input', apply);
+    sortSel.addEventListener('change', sort);
+    [statusRow, typeRow, tagRow].forEach(function(row){
+      row.addEventListener('click', function(e){
+        var btn = e.target.closest('.filter-pill');
+        if (!btn) return;
+        btn.setAttribute('aria-pressed', btn.getAttribute('aria-pressed') === 'true' ? 'false' : 'true');
+        apply();
+      });
+    });
+
+    sort();   // default ordering (newest)
+    apply();
   })();
 </script>
 </body>

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -61,6 +61,46 @@ func TestListPage(t *testing.T) {
 	}
 }
 
+func TestListPageRendersTagsAndControls(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "tagged-tutorial")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "tagged-tutorial",
+		Title:   "Tagged Tutorial",
+		Status:  store.StatusVerified,
+		Created: time.Now(),
+		Tags:    []string{"rust", "audio"},
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "index.md"), []byte("# Index"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, `id="searchInput"`) {
+		t.Error("list page missing the search input control")
+	}
+	if !strings.Contains(body, `id="sortSelect"`) {
+		t.Error("list page missing the sort control")
+	}
+	if !strings.Contains(body, `data-tags="rust,audio,"`) {
+		t.Error("list page card missing data-tags attribute for search/filter")
+	}
+	if !strings.Contains(body, `<span class="tag">rust</span>`) {
+		t.Error("list page missing rendered tag pill")
+	}
+}
+
 func TestTutorialPage(t *testing.T) {
 	dir := t.TempDir()
 	makeTestTutorial(t, dir, "test-tutorial", false)

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -348,6 +348,29 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
 .empty{color:var(--text-faint);text-align:center;padding:3rem 1rem;font-size:1rem;font-style:italic}
 .empty code{background:var(--code-bg);color:var(--code-text);padding:.1rem .35rem;border-radius:var(--radius-sm);font-family:var(--font-mono);font-size:.85em;font-style:normal}
 
+/* List controls — client-side search, sort, and tag/status filters. Pure
+   progressive enhancement: without JS every card stays visible (.hidden is only
+   ever set by the list page script). */
+.controls{margin:0 0 1.25rem;display:flex;flex-direction:column;gap:.7rem}
+.controls-row{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}
+.search-input{flex:1 1 14rem;min-width:0;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-md);padding:.55rem .75rem;font-family:var(--font-body);font-size:.95rem;line-height:1.4}
+.search-input:focus{outline:2px solid var(--accent);outline-offset:1px}
+.sort-select{background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-md);padding:.5rem .65rem;font-family:var(--font-display);font-size:.85rem;font-weight:600;cursor:pointer}
+.sort-select:focus{outline:2px solid var(--accent);outline-offset:1px}
+.filter-row{display:flex;gap:.4rem;flex-wrap:wrap;align-items:center}
+.filter-label{font-family:var(--font-display);font-size:.75rem;font-weight:600;color:var(--text-faint);margin-right:.15rem}
+.filter-pill{font-family:var(--font-display);font-size:.78rem;font-weight:600;color:var(--text-subtle);background:transparent;border:1px solid var(--border);padding:.3rem .7rem;border-radius:9999px;cursor:pointer;transition:background var(--transition),color var(--transition),border-color var(--transition)}
+.filter-pill:hover{background:var(--surface-sunken);color:var(--text)}
+.filter-pill:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.filter-pill[aria-pressed="true"]{background:var(--accent);color:var(--btn-on-accent);border-color:var(--accent)}
+
+/* Tag chips on each card */
+.tags{display:flex;gap:.35rem;flex-wrap:wrap;margin-top:.45rem}
+.tag{font-family:var(--font-display);font-size:.72rem;font-weight:600;color:var(--text-subtle);background:var(--surface-sunken);border:1px solid var(--border);padding:.12rem .5rem;border-radius:9999px;line-height:1.4}
+
+.tutorial.hidden{display:none}
+.no-results{color:var(--text-faint);text-align:center;padding:2.5rem 1rem;font-size:.98rem;font-style:italic}
+
 /* ---- 5. Responsive ------------------------------------------------------- */
 
 /* Narrow viewport (<900px): off-canvas sidebar, sticky header, bottom dock */

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -24,6 +24,7 @@ type Tutorial struct {
 	Topic       string    `json:"topic"`
 	Created     time.Time `json:"created"`
 	Status      Status    `json:"status"`
+	Tags        []string  `json:"tags,omitempty"`
 	Parts       []string  `json:"parts,omitempty"`
 	PendingPart string    `json:"pending_part,omitempty"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,7 +15,7 @@ import (
 // Store copies a tutorial directory into ~/.lathe/tutorials/ and writes its
 // metadata with status=unverified. Verification is opt-in and never auto-runs
 // here — the user triggers it separately via the /lathe-verify skill.
-func Store(srcPath string) (*Tutorial, error) {
+func Store(srcPath string, tags ...string) (*Tutorial, error) {
 	slug := filepath.Base(strings.TrimSuffix(srcPath, string(filepath.Separator)))
 	// The generation skill writes to /tmp/lathe-<slug>/ (the "lathe-" prefix
 	// namespaces the temp dir). Strip it so the prefix doesn't leak into the
@@ -40,6 +40,7 @@ func Store(srcPath string) (*Tutorial, error) {
 		Topic:   slug,
 		Created: time.Now().UTC(),
 		Status:  StatusUnverified,
+		Tags:    NormalizeTags(tags),
 		Parts:   parts,
 	}
 
@@ -125,6 +126,26 @@ func Delete(slug string) error {
 		return fmt.Errorf("not a tutorial directory: %q", slug)
 	}
 	return os.RemoveAll(target)
+}
+
+// NormalizeTags cleans a tag list: trims surrounding whitespace, lowercases,
+// drops empties, and removes duplicates while preserving first-seen order.
+// Returns nil for an all-empty input so it stays omitempty in metadata.json.
+func NormalizeTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	var out []string
+	for _, t := range tags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
 }
 
 func SlugToTitle(slug string) string {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -73,6 +73,45 @@ func TestStoreSeriesTutorial(t *testing.T) {
 	}
 }
 
+func TestStorePersistsAndNormalizesTags(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tut, err := store.Store(src, "  Rust ", "audio", "rust", "")
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	want := []string{"rust", "audio"} // trimmed, lowercased, de-duped, empty dropped
+	if got := tut.Tags; !equalStrings(got, want) {
+		t.Errorf("Store() Tags = %v, want %v", got, want)
+	}
+
+	// Tags must round-trip through metadata.json.
+	read, err := store.ReadMetadata(filepath.Join(home, ".lathe", "tutorials", tut.Slug))
+	if err != nil {
+		t.Fatalf("ReadMetadata() error = %v", err)
+	}
+	if !equalStrings(read.Tags, want) {
+		t.Errorf("ReadMetadata() Tags = %v, want %v", read.Tags, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestStoreDefaultsToUnverified(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "index.md"), []byte("# Hello"), 0644); err != nil {


### PR DESCRIPTION
The library of generated tutorials has grown to the point where the flat,
unsorted list page is hard to navigate. Add a metadata-only search experience
to the web UI plus a tags vocabulary to organize tutorials.

- store: new Tags field on Tutorial (omitempty, backward-compatible) and a
  NormalizeTags helper (trim/lowercase/dedupe); Store accepts variadic tags.
- cmd/store: --tag/--tags flags so /lathe can attach tags at store time.
- cmd/tag: write-only command to set/add/remove a tutorial's tags, mirroring
  the verify-result/extend-commit state-mutation pattern.
- serve: list.html renders per-card data-* attributes and tag pills; an inline
  script does live search, status/type/tag filtering, and sort entirely in the
  browser (no new round-trips, stays offline, degrades gracefully without JS).
- skills: /lathe emits tags on store; new /lathe-tag backfills tags for
  existing tutorials.
- docs: README + CLAUDE.md updated.