### PR TITLE
ci: add GitHub Actions gate and Mage runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
+
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15.0
+
+      # Mirrors local `mage check`: fmt-check, vet, lint, test (-race), build.
+      - name: Run checks
+        run: mage check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+# Report every finding rather than capping repeats, so CI never silently hides
+# issues behind the default per-issue limits.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,19 @@ go test ./...                     # run all tests
 go vet ./...                      # static checks
 ```
 
-There is no top-level test runner script — tests are plain `go test`. The `/lathe` (`lathe`) binary built from this repo is gitignored at the repo root.
+Tests are plain `go test` (no top-level runner script). The `/lathe` (`lathe`) binary built from this repo is gitignored at the repo root.
+
+### CI gate — run before opening a PR
+
+CI (`.github/workflows/ci.yml`) runs `mage check` on every PR and push to `main`: gofmt, `go vet`, `golangci-lint`, `go test -race ./...`, and `go build`. **Before opening or updating a PR, run `mage check` and make sure it's green** — don't push work that leaves CI red. `mage check` is the exact command CI runs, so local and CI cannot drift.
+
+`magefile.go` defines the targets (`mage fmt|fmtCheck|vet|lint|test|build`, and `mage check` for all of them; `mage` alone runs `check`). It's stdlib-only and build-tagged (`//go:build mage`), so it adds nothing to `go.mod`. Lint config lives in `.golangci.yml`. One-time tool install:
+
+```bash
+go install github.com/magefile/mage@v1.15.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
+mage fmt                          # auto-fix formatting; mage check is read-only on fmt
+```
 
 ## Architecture notes
 

--- a/cmd/extend-commit.go
+++ b/cmd/extend-commit.go
@@ -57,7 +57,7 @@ var extendCommitCmd = &cobra.Command{
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			return fmt.Errorf("write metadata: %w", err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Added %s to %q\n", partFile, slug)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added %s to %q\n", partFile, slug)
 		return nil
 	},
 }

--- a/cmd/extend-start.go
+++ b/cmd/extend-start.go
@@ -51,7 +51,7 @@ var extendStartCmd = &cobra.Command{
 		}
 
 		// Print only the filename so the skill can capture it cleanly.
-		fmt.Fprintln(cmd.OutOrStdout(), pendingPart)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), pendingPart)
 		return nil
 	},
 }

--- a/cmd/extend.go
+++ b/cmd/extend.go
@@ -37,7 +37,7 @@ var extendCmd = &cobra.Command{
 		if extendGuidance != "" {
 			handoff += " " + extendGuidance
 		}
-		fmt.Fprintf(cmd.OutOrStdout(),
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"To add a new part to %q, run this in your Claude Code session:\n\n  %s\n", slug, handoff)
 		return nil
 	},

--- a/cmd/extend_test.go
+++ b/cmd/extend_test.go
@@ -47,7 +47,7 @@ func TestExtendCommandFoldsGuidanceIntoHandoff(t *testing.T) {
 	extendCmd.SetOut(&out)
 	t.Cleanup(func() { extendCmd.SetOut(nil) })
 	extendCmd.Flags().Set("guidance", "cover the filter envelope") //nolint:errcheck
-	t.Cleanup(func() { extendCmd.Flags().Set("guidance", "") })     //nolint:errcheck
+	t.Cleanup(func() { extendCmd.Flags().Set("guidance", "") })    //nolint:errcheck
 	if err := extendCmd.RunE(extendCmd, []string{"test-slug"}); err != nil {
 		t.Fatalf("extend: %v", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,7 +29,7 @@ var listCmd = &cobra.Command{
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "SLUG\tTITLE\tSTATUS\tPARTS")
+		_, _ = fmt.Fprintln(w, "SLUG\tTITLE\tSTATUS\tPARTS")
 		for _, e := range entries {
 			if !e.IsDir() {
 				continue
@@ -43,7 +43,7 @@ var listCmd = &cobra.Command{
 				parts = fmt.Sprintf("%d parts", len(tut.Parts))
 			}
 			badge := statusBadge(tut.Status)
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", tut.Slug, tut.Title, badge, parts)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", tut.Slug, tut.Title, badge, parts)
 		}
 		return w.Flush()
 	},

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -18,18 +18,18 @@ var rmCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		slug := args[0]
 		if !rmForce {
-			fmt.Fprintf(cmd.OutOrStdout(), "Delete tutorial %q? [y/N]: ", slug)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Delete tutorial %q? [y/N]: ", slug)
 			reader := bufio.NewReader(cmd.InOrStdin())
 			line, _ := reader.ReadString('\n')
 			if strings.ToLower(strings.TrimSpace(line)) != "y" {
-				fmt.Fprintln(cmd.OutOrStdout(), "aborted")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "aborted")
 				return nil
 			}
 		}
 		if err := store.Delete(slug); err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s\n", slug)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s\n", slug)
 		return nil
 	},
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -41,7 +41,7 @@ func openBrowser(url string) {
 		return
 	}
 	if err := exec.Command(bin, url).Start(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not open browser: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "warning: could not open browser: %v\n", err)
 	}
 }
 

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -40,9 +40,7 @@ var storeCmd = &cobra.Command{
 func splitTags(raw []string) []string {
 	var out []string
 	for _, r := range raw {
-		for _, p := range strings.Split(r, ",") {
-			out = append(out, p)
-		}
+		out = append(out, strings.Split(r, ",")...)
 	}
 	return out
 }

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -70,9 +70,9 @@ var tagCmd = &cobra.Command{
 			return fmt.Errorf("write metadata: %w", err)
 		}
 		if len(tags) == 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "Cleared tags for %q\n", slug)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cleared tags for %q\n", slug)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "Tags for %q: %s\n", slug, strings.Join(tags, ", "))
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Tags for %q: %s\n", slug, strings.Join(tags, ", "))
 		}
 		return nil
 	},

--- a/cmd/verify-result.go
+++ b/cmd/verify-result.go
@@ -81,7 +81,7 @@ var verifyResultCmd = &cobra.Command{
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			return fmt.Errorf("write metadata: %w", err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Recorded %s for %q\n", status, slug)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Recorded %s for %q\n", status, slug)
 		return nil
 	},
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -31,7 +31,7 @@ var verifyCmd = &cobra.Command{
 			return fmt.Errorf("no stored tutorial %q: %w", slug, err)
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(),
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 			"To verify %q, run this in your Claude Code session:\n\n  /lathe-verify %s\n", slug, slug)
 		return nil
 	},

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -90,7 +90,8 @@ func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 // formatting like `code` or *emphasis* contributes plain text only.
 func collectH2TOC(doc ast.Node, src []byte) []TOCEntry {
 	var toc []TOCEntry
-	ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+	// The walk callback never returns an error, so the Walk result is safe to drop.
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
@@ -120,7 +121,8 @@ func collectH2TOC(doc ast.Node, src []byte) []TOCEntry {
 // so this captures their visible text without HTML markup.
 func extractInlineText(n ast.Node, src []byte) string {
 	var b strings.Builder
-	ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
+	// The walk callback never returns an error, so the Walk result is safe to drop.
+	_ = ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -102,7 +102,7 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-	w.Write(data)
+	_, _ = w.Write(data)
 }
 
 func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +132,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	buf.WriteTo(w)
+	_, _ = buf.WriteTo(w)
 }
 
 func (s *Server) safeTutorialPath(parts ...string) (string, bool) {
@@ -288,7 +288,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	buf.WriteTo(w)
+	_, _ = buf.WriteTo(w)
 }
 
 func pendingPartNumber(pendingPart string, fallback int) int {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,14 +75,14 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer in.Close() //nolint:errcheck
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
 	if _, err = io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(dst)
+		_ = out.Close()
+		_ = os.Remove(dst)
 		return err
 	}
 	return out.Close()

--- a/magefile.go
+++ b/magefile.go
@@ -1,0 +1,89 @@
+//go:build mage
+
+// Mage build/check targets for Lathe.
+//
+// This file is excluded from normal builds by the mage build tag, so it never
+// collides with the real package main (main.go). It imports only the standard
+// library on purpose, so it adds nothing to go.mod/go.sum -- mage compiles it
+// itself.
+//
+// Run "mage" (defaults to Check) or a single target, e.g. "mage test". CI runs
+// the same "mage check", so local and CI cannot drift.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Default target when `mage` is run with no arguments.
+var Default = Check
+
+// run executes a command with stdout/stderr wired through to the caller.
+func run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Fmt formats the tree with gofmt -w.
+func Fmt() error {
+	return run("gofmt", "-w", ".")
+}
+
+// FmtCheck fails if any files are not gofmt-clean (the CI-safe check).
+func FmtCheck() error {
+	out, err := exec.Command("gofmt", "-l", ".").Output()
+	if err != nil {
+		return err
+	}
+	if files := strings.TrimSpace(string(out)); files != "" {
+		return fmt.Errorf("these files need gofmt:\n%s\nrun `mage fmt`", files)
+	}
+	return nil
+}
+
+// Vet runs go vet over all packages.
+func Vet() error {
+	return run("go", "vet", "./...")
+}
+
+// Lint runs golangci-lint (config in .golangci.yml).
+func Lint() error {
+	return run("golangci-lint", "run")
+}
+
+// Test runs the unit tests with the race detector.
+func Test() error {
+	return run("go", "test", "-race", "./...")
+}
+
+// Build compiles the self-contained binary (embedded assets included).
+func Build() error {
+	return run("go", "build", "-o", "lathe")
+}
+
+// Check runs the full gate: fmt check, vet, lint, test, build. This is what CI
+// runs and what you should run before opening a PR. It stops at the first
+// failure.
+func Check() error {
+	for _, step := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"fmt-check", FmtCheck},
+		{"vet", Vet},
+		{"lint", Lint},
+		{"test", Test},
+		{"build", Build},
+	} {
+		fmt.Printf("==> %s\n", step.name)
+		if err := step.fn(); err != nil {
+			return fmt.Errorf("%s: %w", step.name, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add CI that runs fmt, vet, golangci-lint, race tests, and build on every
PR and push to main, plus a Mage runner so local checks match CI exactly.

- .github/workflows/ci.yml runs `mage check` (the same command devs run)
- magefile.go: stdlib-only, build-tagged targets (fmt/fmtCheck/vet/lint/test/build/check)
- .golangci.yml: errcheck/govet/ineffassign/staticcheck/unused, no issue caps
- fix pre-existing gofmt and golangci-lint findings so the gate starts green
- document the pre-PR `mage check` requirement in CLAUDE.md