### PR TITLE
feat: research-first generation, [!UNVERIFIED] callouts, and source provenance

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -13,9 +13,19 @@ The user says something like `/lathe build a digital synth in Zig` or `/lathe ho
 
 1. Ask: **"What's your experience level going in — beginner, some familiarity, or experienced in adjacent areas?"**
 2. If the topic is genuinely ambiguous (language? scale? embedded vs. server?), ask **one** clarifying question. Otherwise skip.
-3. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
-4. Write Part 1.
-5. Hand off to the CLI.
+3. **Research the topic first** (see below) — this is the single most important step for accuracy. Lathe exists to teach things with little training material behind them, which is exactly where recalled "knowledge" is most likely to be invented. Don't skip it.
+4. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
+5. Write Part 1.
+6. Hand off to the CLI.
+
+## Research first (do this before drafting)
+
+Before you write a single sentence, **go read**. Use your web search and fetch tools to find and *actually open* 3–8 authoritative sources for this topic — official docs, specs/RFCs, primary papers, source code, well-regarded deep-dives. Don't reconstruct them from memory.
+
+- **Read for the load-bearing facts** you'll commit to in the tutorial: exact API/function signatures, default values, flag names, version numbers, sample rates, page sizes, semantic guarantees, error messages, historical claims. Take notes with the URL beside each fact — deep-link to the section or anchor, not the homepage.
+- **Ground the prose in what you read, not what you recall.** When a source contradicts your memory, the source wins. When you can't find a source for a load-bearing claim, that's not a green light to assert it confidently — mark it with `[!UNVERIFIED]` (see Callouts) and tell the reader what to check.
+- **Keep the list of URLs you consulted.** You'll cite the load-bearing ones inline, list them in each part's `## Sources`, and pass them to `lathe store --source` (see "After writing") so the research trail is recorded as provenance.
+- **No web tools in this session?** Say so to the user in one line ("Heads up — I don't have web access here, so I'm working from training knowledge; I've marked the claims I couldn't confirm"). Then write more conservatively: lean harder on `[!UNVERIFIED]`, claim fewer exact numbers, and prefer "check your version's docs" over a guessed default.
 
 ## Always write Part 1 only
 
@@ -25,7 +35,7 @@ Every `/lathe` invocation produces exactly one file: `part-01.md`. Never write m
 
 Before writing a single sentence, settle these in your head. They are constraints on your prose, not user-facing artifacts.
 
-- **Research and sources.** Before writing a single sentence, identify 3–8 authoritative sources: official docs, specs/RFCs, primary papers, well-regarded deep-dives. When a claim is load-bearing — a number, a default, a semantic guarantee, a historical fact — prefer a source over recalled knowledge. Collect URLs now; you'll cite them inline and list them in `## Sources`.
+- **Research and sources.** You've already done the **Research first** step above — by now you've actually read 3–8 authoritative sources and have URLs beside the load-bearing facts. Hold those notes in front of you as you write: cite the load-bearing ones inline, list them in `## Sources`, and `[!UNVERIFIED]`-mark anything you couldn't confirm. A load-bearing claim — a number, a default, a semantic guarantee, a historical fact — is either grounded in a source you read or flagged; it is never asserted from recall as if settled.
 - **The controlling example.** Pick one concrete artifact and stay with it. Crafting Interpreters has Lox. You might have *"a 4-voice subtractive synth playing a sustained A minor triad"* or *"a key-value store called `pebble` that survives `kill -9`"*. Don't switch examples mid-tutorial.
 - **Specific numbers.** Sample rate, buffer size, page size, table cardinality, latency budget — whatever the domain offers. Numbers are how you earn the reader's trust. Decide them now so they're consistent across parts.
 - **One controlling metaphor (optional but powerful).** A mountain. A factory line. A kitchen. If you adopt one, deploy it across at least three section transitions, then *explicitly retire it* with a wink (Nystrom: *"Henceforth, I promise to tone down the whole mountain metaphor thing."*). Don't mix metaphors silently.
@@ -130,6 +140,7 @@ You are not a docs page. You are a friend who has done this before, sitting next
 - **Em-dashed self-correction.** Roughly once per 800 words, visibly second-guess yourself. *"It pains me to skip the proof, but —"*. *"I went back and forth on this — the answer that won was —"*. This is what makes prose feel written *to* a reader, not *at* one.
 - **Forward-pointing endings, not recaps.** End each section by naming the question the next section answers. The reader was just there; don't summarise.
 - **Cite inline the first time a load-bearing fact lands.** When you introduce a spec section, a canonical term, a number, or a behaviour claim that the reader might want to verify, link it on first mention — markdown `[text](url)`. Deep-link to the exact section or anchor, not the homepage. Every source used inline must appear in `## Sources`.
+- **Ground or flag — never bluff.** Every load-bearing claim has exactly one of two fates: a source you actually read (cite it inline) or, if you couldn't find one, an `[!UNVERIFIED]` callout that names what to check. The failure mode this kills is the confident-but-invented default, flag, or signature — the thing the reader copies, runs, and loses an hour to. On a sparse-data topic that risk is highest; treat "I'm fairly sure it's X" as a flag, not a fact.
 
 ### Avoid
 
@@ -228,8 +239,9 @@ Other callout types:
 - `> [!TIP]` — handy shortcut, not load-bearing.
 - `> [!PREDICT]` — prediction prompt before a Checkpoint or surprising output. One line only.
 - `> [!RECALL]` — spaced-retrieval prompt at the top of Part N≥2. One question, load-bearing concept only.
+- `> [!UNVERIFIED]` — a load-bearing claim you could **not** ground in a source you read. State what you believe and, in the same breath, what the reader should check. *"The default ring-buffer size is 4096 frames — I'm working from memory here and couldn't find this in the docs; confirm it with `default_config()` before you rely on it."* Honest uncertainty beats a confident guess that sends the reader down an hour-long dead end.
 
-Use them sparingly. One or two per part, max. A page full of callouts is a page of clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical — the verifier skips them.
+Use them sparingly — except `[!UNVERIFIED]`, which you use exactly as often as honesty requires (more when you had no web access). One or two of the others per part, max; a page full of callouts is clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical, and `[!UNVERIFIED]` is a provenance signal — the verifier skips all three.
 
 ## Visual artifacts
 
@@ -298,7 +310,9 @@ Decide the slug before writing. Never write `index.md` or multiple parts.
 Run:
 
 ```bash
-lathe store /tmp/lathe-<slug> --tag <a> --tag <b> --tag <c>
+lathe store /tmp/lathe-<slug> \
+  --tag <a> --tag <b> --tag <c> \
+  --source <url> --source <url>
 ```
 
 Choose **2–5** lowercase tags so the tutorial is findable in `lathe serve`'s
@@ -306,6 +320,12 @@ search and tag filters. Cover, where they apply: the language/runtime (`zig`,
 `rust`, `go`), the domain (`audio`, `compilers`, `databases`), and the core
 technique (`parsing`, `dsp`, `concurrency`). Prefer short, reusable tags that
 will group naturally with other tutorials over hyper-specific one-offs.
+
+Pass `--source <url>` once for each authoritative source you consulted during
+the **Research first** step — the research trail, not just the ones you cited
+inline. Lathe records them as provenance: the reading page shows "Researched
+against N sources" with the list, and the list page marks how many sources back
+each tutorial. If you genuinely had no web access, omit `--source`.
 
 Then tell the user:
 

--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -25,7 +25,7 @@ Before you write a single sentence, **go read**. Use your web search and fetch t
 - **Read for the load-bearing facts** you'll commit to in the tutorial: exact API/function signatures, default values, flag names, version numbers, sample rates, page sizes, semantic guarantees, error messages, historical claims. Take notes with the URL beside each fact — deep-link to the section or anchor, not the homepage.
 - **Ground the prose in what you read, not what you recall.** When a source contradicts your memory, the source wins. When you can't find a source for a load-bearing claim, that's not a green light to assert it confidently — mark it with `[!UNVERIFIED]` (see Callouts) and tell the reader what to check.
 - **Keep the list of URLs you consulted.** You'll cite the load-bearing ones inline, list them in each part's `## Sources`, and pass them to `lathe store --source` (see "After writing") so the research trail is recorded as provenance.
-- **No web tools in this session?** Say so to the user in one line ("Heads up — I don't have web access here, so I'm working from training knowledge; I've marked the claims I couldn't confirm"). Then write more conservatively: lean harder on `[!UNVERIFIED]`, claim fewer exact numbers, and prefer "check your version's docs" over a guessed default.
+- **No web tools in this session?** Say so to the user in one line ("Heads up — I don't have web access here, so I'm working from training knowledge; I've marked the load-bearing claims I couldn't confirm"). Then write more conservatively: claim fewer exact numbers, prefer "check your version's docs" over a guessed default, and `[!UNVERIFIED]`-flag the load-bearing unknowns (still only the load-bearing ones — don't paper the page with caveats).
 
 ## Always write Part 1 only
 
@@ -239,9 +239,9 @@ Other callout types:
 - `> [!TIP]` — handy shortcut, not load-bearing.
 - `> [!PREDICT]` — prediction prompt before a Checkpoint or surprising output. One line only.
 - `> [!RECALL]` — spaced-retrieval prompt at the top of Part N≥2. One question, load-bearing concept only.
-- `> [!UNVERIFIED]` — a load-bearing claim you could **not** ground in a source you read. State what you believe and, in the same breath, what the reader should check. *"The default ring-buffer size is 4096 frames — I'm working from memory here and couldn't find this in the docs; confirm it with `default_config()` before you rely on it."* Honest uncertainty beats a confident guess that sends the reader down an hour-long dead end.
+- `> [!UNVERIFIED]` — a **genuinely load-bearing** claim you could not ground in a source you read: one the reader will *act on* and that would cost them real time if it's wrong (a default they'll rely on, a flag they'll type, a signature they'll call). State what you believe and, in the same breath, what to check. *"The default ring-buffer size is 4096 frames — I'm working from memory here and couldn't find this in the docs; confirm it with `default_config()` before you rely on it."* Reserve it for those; not for ordinary hedging or background colour you're merely unsure about. If a claim isn't load-bearing, either confirm it or cut it — don't flag it.
 
-Use them sparingly — except `[!UNVERIFIED]`, which you use exactly as often as honesty requires (more when you had no web access). One or two of the others per part, max; a page full of callouts is clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical, and `[!UNVERIFIED]` is a provenance signal — the verifier skips all three.
+Use them sparingly — `[!UNVERIFIED]` included. Reach for it only when a load-bearing unknown genuinely warrants it (a little more often when you had no web access, but still only for the load-bearing ones). One or two of the others per part, max; a page peppered with caveats reads as low-confidence and is its own kind of clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical, and `[!UNVERIFIED]` is a provenance signal — the verifier skips all three.
 
 ## Visual artifacts
 

--- a/cmd/extend-commit.go
+++ b/cmd/extend-commit.go
@@ -52,6 +52,12 @@ var extendCommitCmd = &cobra.Command{
 		if !found {
 			tut.Parts = append(tut.Parts, partFile)
 		}
+		// Fold any newly-consulted sources into the existing trail so provenance
+		// stays live as parts are added. NormalizeSources de-dupes against what's
+		// already recorded.
+		if len(extendCommitSources) > 0 {
+			tut.Sources = store.NormalizeSources(append(tut.Sources, extendCommitSources...))
+		}
 		tut.PendingPart = ""
 		tut.Status = store.StatusUnverified
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
@@ -62,6 +68,9 @@ var extendCommitCmd = &cobra.Command{
 	},
 }
 
+var extendCommitSources []string
+
 func init() {
+	extendCommitCmd.Flags().StringArrayVar(&extendCommitSources, "source", nil, "URL consulted while researching this part (repeatable; appended to the tutorial's research trail)")
 	rootCmd.AddCommand(extendCommitCmd)
 }

--- a/cmd/extend-commit_test.go
+++ b/cmd/extend-commit_test.go
@@ -64,6 +64,43 @@ func TestExtendCommitIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestExtendCommitAppendsSources(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := writeTutorial(t, homeDir, "test-slug", store.StatusExtending, []string{"part-01.md"})
+	if err := os.WriteFile(filepath.Join(tutDir, "part-02.md"), []byte("# Part 2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Seed an existing research trail; the new part adds one fresh source plus a
+	// duplicate of an existing one.
+	tut, _ := store.ReadMetadata(tutDir)
+	tut.Sources = []string{"https://a.com/spec"}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	extendCommitSources = []string{"https://a.com/spec", "https://b.com/paper"}
+	t.Cleanup(func() { extendCommitSources = nil })
+
+	if err := extendCommitCmd.RunE(extendCommitCmd, []string{"test-slug", "part-02.md"}); err != nil {
+		t.Fatalf("extend-commit: %v", err)
+	}
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"https://a.com/spec", "https://b.com/paper"}
+	if len(got.Sources) != len(want) {
+		t.Fatalf("Sources = %v, want %v (de-duped union)", got.Sources, want)
+	}
+	for i := range want {
+		if got.Sources[i] != want[i] {
+			t.Errorf("Sources[%d] = %q, want %q", i, got.Sources[i], want[i])
+		}
+	}
+}
+
 func TestExtendCommitRejectsMissingFile(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -12,6 +12,7 @@ var (
 	withVerify    bool
 	storeTags     []string
 	storeTagsList []string
+	storeSources  []string
 )
 
 var storeCmd = &cobra.Command{
@@ -19,7 +20,7 @@ var storeCmd = &cobra.Command{
 	Short: "Save a tutorial directory to ~/.lathe/tutorials/",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tut, err := store.Store(args[0], splitTags(append(storeTags, storeTagsList...))...)
+		tut, err := store.Store(args[0], splitTags(append(storeTags, storeTagsList...)), storeSources)
 		if err != nil {
 			return err
 		}
@@ -49,5 +50,6 @@ func init() {
 	storeCmd.Flags().BoolVar(&withVerify, "verify", false, "print the command to verify after storing")
 	storeCmd.Flags().StringArrayVar(&storeTags, "tag", nil, "tag to attach (repeatable; --tag also accepts comma-separated values)")
 	storeCmd.Flags().StringSliceVar(&storeTagsList, "tags", nil, "comma-separated tags (alias for repeated --tag)")
+	storeCmd.Flags().StringArrayVar(&storeSources, "source", nil, "URL consulted while researching the tutorial (repeatable; the research trail surfaced as provenance)")
 	rootCmd.AddCommand(storeCmd)
 }

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -59,9 +59,11 @@ nothing screams against the paper.
 
 ### Color — callouts (`-bg` / `-border` / `-label`)
 
-Seven color groups (the `warning` and `headsup` classes share the warn triple):
+Eight color groups (the `warning` and `headsup` classes share the warn triple):
 `note` (dusty blue), `tip` (olive green), `warn` (amber), `design` (violet-gray),
-`aside` (transparent, italic), `predict` (berry), `recall` (orange).
+`aside` (transparent, italic), `predict` (berry), `recall` (orange),
+`unverified` (rust — for `[!UNVERIFIED]`, a load-bearing claim the generator
+couldn't ground in a source).
 
 ### Typography
 

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -28,6 +28,14 @@
     <a href="/" class="back-link">← All tutorials</a>
     <h2>{{.Tutorial.Title}}</h2>
     {{template "badge" .Tutorial.Status}}
+    {{if .VerifiedDate}}<p class="provenance verified-date">Verified {{.VerifiedDate}}</p>{{end}}
+    {{if .UnverifiedCount}}<p class="provenance unverified-note">{{.UnverifiedCount}} claim{{if ne .UnverifiedCount 1}}s{{end}} flagged unverified — marked inline.</p>{{end}}
+    {{if .Tutorial.Sources}}
+    <details class="provenance sources">
+      <summary>Researched against {{len .Tutorial.Sources}} source{{if ne (len .Tutorial.Sources) 1}}s{{end}}</summary>
+      <ul>{{range .Tutorial.Sources}}<li><a href="{{.}}" rel="noopener noreferrer" target="_blank">{{.}}</a></li>{{end}}</ul>
+    </details>
+    {{end}}
     {{if .TOC}}
     <h3 class="toc-label">On this page</h3>
     <ul class="toc">

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -42,7 +42,7 @@
 <div class="tutorial" data-title="{{.Title}}" data-slug="{{.Slug}}" data-topic="{{.Topic}}" data-tags="{{range .Tags}}{{.}},{{end}}" data-status="{{.Status}}" data-created="{{.Created.Format "2006-01-02T15:04:05Z07:00"}}" data-series="{{.IsSeries}}">
   <div>
     <a href="/{{.Slug}}/">{{.Title}}</a>
-    <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}</div>
+    <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
     {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
   </div>
   <div class="tutorial-actions">

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -44,7 +44,7 @@ var mermaidBlock = regexp.MustCompile("(?ms)^[ \t]{0,3}```[ \t]*mermaid[ \t]*\r?
 // calloutBlock matches a GFM-alert-style blockquote whose first line is
 // `> [!TYPE]`. Group 1 is the type, group 2 is the body (still blockquote-
 // prefixed; preprocessCallouts strips the `> ` from each body line).
-var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNING|HEADS-UP|ASIDE|DESIGN-NOTE|PREDICT|RECALL)\][ \t]*\r?\n((?:[ \t]{0,3}>.*(?:\r?\n|$))*)`)
+var calloutBlock = regexp.MustCompile(`(?m)^[ \t]{0,3}>[ \t]*\[!(NOTE|TIP|WARNING|HEADS-UP|ASIDE|DESIGN-NOTE|PREDICT|RECALL|UNVERIFIED)\][ \t]*\r?\n((?:[ \t]{0,3}>.*(?:\r?\n|$))*)`)
 
 // calloutLineStrip removes the `>` (and one optional following space) from the
 // start of each body line of a callout, leaving the inner markdown.
@@ -180,6 +180,8 @@ func calloutLabel(kind string) string {
 		return "Predict"
 	case "RECALL":
 		return "Recall"
+	case "UNVERIFIED":
+		return "Unverified"
 	}
 	return kind
 }

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -117,6 +117,7 @@ func TestRenderCalloutTypes(t *testing.T) {
 		{"HEADS-UP", "callout-headsup", "Heads up"},
 		{"ASIDE", "callout-aside", "Aside"},
 		{"DESIGN-NOTE", "callout-designnote", "Design note"},
+		{"UNVERIFIED", "callout-unverified", "Unverified"},
 	}
 	for _, c := range cases {
 		t.Run(c.marker, func(t *testing.T) {

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/devenjarvis/lathe/internal/store"
 )
@@ -252,21 +253,41 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		}
 	}
 
-	// On failure, surface the verifier's recorded part/step/error so the page
-	// explains what broke instead of just showing a red badge. Best-effort:
-	// a missing or malformed verify-result.json simply renders no panel.
+	// Surface the verifier's recorded result. On failure it explains what broke
+	// (part/step/error); on verified/skipped it carries the CheckedAt timestamp
+	// we show as "Verified <date>". Best-effort: a missing or malformed
+	// verify-result.json simply renders no panel and no date.
 	var verifyResult *store.VerifyResult
-	if tut.Status == store.StatusFailed {
+	switch tut.Status {
+	case store.StatusFailed, store.StatusVerified, store.StatusSkipped:
 		if vr, err := store.ReadVerifyResult(tutDir); err == nil {
 			verifyResult = vr
 		}
 	}
+
+	// On verified/skipped, format the verifier's timestamp as a friendly date for
+	// the "Verified <date>" provenance line. Best-effort: an unparseable or empty
+	// CheckedAt simply yields no date.
+	var verifiedDate string
+	if verifyResult != nil && (tut.Status == store.StatusVerified || tut.Status == store.StatusSkipped) {
+		if ts, err := time.Parse(time.RFC3339, verifyResult.CheckedAt); err == nil {
+			verifiedDate = ts.Format("Jan 2, 2006")
+		}
+	}
+
+	// Count inline [!UNVERIFIED] callouts so the page can flag, near the badge,
+	// how many claims the author couldn't ground in a source. Derived at render
+	// time from the rendered HTML, so it stays live as parts change with no
+	// metadata bookkeeping.
+	unverifiedCount := bytes.Count(content, []byte("callout-unverified"))
 
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
 		"Title":             tut.Title,
 		"Tutorial":          tut,
 		"VerifyResult":      verifyResult,
+		"VerifiedDate":      verifiedDate,
+		"UnverifiedCount":   unverifiedCount,
 		"CurrentPart":       part,
 		"CurrentPartNumber": currentNumber,
 		"Content":           template.HTML(content),

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -335,6 +335,109 @@ func TestNonSeriesNoPartNav(t *testing.T) {
 	}
 }
 
+func TestProvenanceSourcesRendered(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "researched")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "researched",
+		Title:   "Researched Tutorial",
+		Status:  store.StatusUnverified,
+		Created: time.Now(),
+		Parts:   []string{"part-01.md"},
+		Sources: []string{"https://ziglang.org/documentation/master/#comptime"},
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/researched/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Researched against 1 source") {
+		t.Error("part page missing the 'Researched against N sources' provenance line")
+	}
+	if !strings.Contains(body, "https://ziglang.org/documentation/master/#comptime") {
+		t.Error("part page missing the consulted source link")
+	}
+}
+
+func TestVerifiedDateRendered(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "checked")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "checked",
+		Title:   "Checked Tutorial",
+		Status:  store.StatusVerified,
+		Created: time.Now(),
+		Parts:   []string{"part-01.md"},
+	}
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte("# Part 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteVerifyResult(tutDir, &store.VerifyResult{Status: store.StatusVerified, CheckedAt: "2026-06-03T12:00:00Z"}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/checked/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), "Verified Jun 3, 2026") {
+		t.Error("verified part page missing the 'Verified <date>' provenance line")
+	}
+}
+
+func TestUnverifiedCalloutCountRendered(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "shaky")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:    "shaky",
+		Title:   "Shaky Tutorial",
+		Status:  store.StatusUnverified,
+		Created: time.Now(),
+		Parts:   []string{"part-01.md"},
+	}
+	body := "# Part 1\n\n> [!UNVERIFIED]\n> The default buffer size is 4096 — I couldn't confirm this.\n"
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/shaky/part-01.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	got := w.Body.String()
+	if !strings.Contains(got, `callout-unverified`) {
+		t.Error("part page missing rendered [!UNVERIFIED] callout")
+	}
+	if !strings.Contains(got, "1 claim flagged unverified") {
+		t.Error("part page missing the unverified-claim count note near the badge")
+	}
+}
+
 func TestNotFound(t *testing.T) {
 	dir := t.TempDir()
 	srv := serve.NewServer(dir)

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -39,6 +39,7 @@
   --callout-aside-bg:transparent; --callout-aside-border:#D6C9B4; --callout-aside-label:#8A7C6C;
   --callout-predict-bg:#F1E5EA; --callout-predict-border:#A86A86; --callout-predict-label:#7A4458;
   --callout-recall-bg:#F7E7D6; --callout-recall-border:#D17A3F; --callout-recall-label:#A0501F;
+  --callout-unverified-bg:#F6E2DA; --callout-unverified-border:#C2603C; --callout-unverified-label:#8A3417;
 
   /* Type */
   --font-display:'Fraunces','Iowan Old Style',Georgia,serif;
@@ -78,6 +79,7 @@
   --callout-aside-bg:transparent; --callout-aside-border:#463D31; --callout-aside-label:#7C7060;
   --callout-predict-bg:#2A1E26; --callout-predict-border:#9A6076; --callout-predict-label:#D6A6BC;
   --callout-recall-bg:#2C1E12; --callout-recall-border:#BE7038; --callout-recall-label:#E0A36A;
+  --callout-unverified-bg:#2E1810; --callout-unverified-border:#C2603C; --callout-unverified-label:#EC9272;
 
   --shadow-sm:0 1px 2px rgba(0,0,0,.30);
   --shadow-md:0 4px 14px rgba(0,0,0,.45);
@@ -179,6 +181,8 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 .callout-predict .callout-label{color:var(--callout-predict-label)}
 .callout-recall{background:var(--callout-recall-bg);border-color:var(--callout-recall-border)}
 .callout-recall .callout-label{color:var(--callout-recall-label)}
+.callout-unverified{background:var(--callout-unverified-bg);border-color:var(--callout-unverified-border)}
+.callout-unverified .callout-label{color:var(--callout-unverified-label)}
 
 /* Mermaid diagrams */
 .mermaid{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:1rem;margin:1.4rem 0;text-align:center;overflow-x:auto;max-width:100%}
@@ -222,7 +226,14 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    264px width, sticky positioning, and column direction onto it. */
 #sidebar{width:264px;background:var(--surface);border-right:1px solid var(--border);padding:1.6rem 1.4rem;position:sticky;top:0;height:100vh;overflow-y:auto;flex-shrink:0;display:flex;flex-direction:column;z-index:80}
 #sidebar h2{font-family:var(--font-display);font-size:1.05rem;font-weight:600;color:var(--text);margin-bottom:.6rem;line-height:1.25;letter-spacing:-.01em}
-#sidebar .badge{margin-bottom:1.4rem}
+#sidebar .badge{margin-bottom:.7rem}
+#sidebar .provenance{font-size:.78rem;line-height:1.4;color:var(--text-subtle);margin:.25rem 0}
+#sidebar .provenance:last-of-type{margin-bottom:1.4rem}
+#sidebar .provenance.unverified-note{color:var(--callout-unverified-label)}
+#sidebar details.provenance summary{cursor:pointer;color:var(--text-subtle)}
+#sidebar details.provenance ul{list-style:none;margin:.35rem 0 0;padding:0}
+#sidebar details.provenance li{margin:.2rem 0}
+#sidebar details.provenance a{display:block;font-size:.74rem;padding:.2rem .4rem;color:var(--accent);word-break:break-all;line-height:1.35}
 #sidebar ul{list-style:none}
 #sidebar li{margin:.2rem 0}
 #sidebar a{display:block;font-size:.85rem;color:var(--text-subtle);text-decoration:none;padding:.35rem .6rem;border-radius:var(--radius-sm);transition:background var(--transition),color var(--transition)}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -27,6 +27,13 @@ type Tutorial struct {
 	Tags        []string  `json:"tags,omitempty"`
 	Parts       []string  `json:"parts,omitempty"`
 	PendingPart string    `json:"pending_part,omitempty"`
+	// Sources are the URLs the generation skill actually consulted while
+	// researching the tutorial — the research trail behind the prose. They are
+	// distinct from the per-part inline `## Sources` citations in the markdown:
+	// this is the durable, metadata-level record surfaced as provenance in the
+	// web UI. Populated via `lathe store --source` and `lathe extend-commit
+	// --source`; the skill never writes metadata.json directly.
+	Sources []string `json:"sources,omitempty"`
 }
 
 func (t *Tutorial) IsSeries() bool {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -36,6 +36,63 @@ func TestWriteReadMetadata(t *testing.T) {
 	}
 }
 
+func TestMetadataRoundTripSources(t *testing.T) {
+	dir := t.TempDir()
+	srcs := []string{"https://ziglang.org/documentation/master/#comptime", "https://example.com/spec#sec3"}
+	tut := &store.Tutorial{
+		Slug:    "test-tut",
+		Status:  store.StatusUnverified,
+		Sources: srcs,
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if len(got.Sources) != len(srcs) {
+		t.Fatalf("Sources = %v, want %v", got.Sources, srcs)
+	}
+	for i := range srcs {
+		if got.Sources[i] != srcs[i] {
+			t.Errorf("Sources[%d] = %q, want %q", i, got.Sources[i], srcs[i])
+		}
+	}
+}
+
+func TestSourcesOmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "t", Status: store.StatusUnverified}); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "sources") {
+		t.Error("sources should be omitted from JSON when empty")
+	}
+}
+
+func TestNormalizeSources(t *testing.T) {
+	// Trims, drops empties, de-dupes first-seen — but preserves case (URLs are
+	// case-sensitive, unlike tags).
+	got := store.NormalizeSources([]string{" https://A.com/Path ", "", "https://A.com/Path", "https://b.com"})
+	want := []string{"https://A.com/Path", "https://b.com"}
+	if len(got) != len(want) {
+		t.Fatalf("NormalizeSources = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("NormalizeSources[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if store.NormalizeSources([]string{"", "  "}) != nil {
+		t.Error("NormalizeSources of all-empty should be nil (stays omitempty)")
+	}
+}
+
 func TestReadMetadataNotFound(t *testing.T) {
 	_, err := store.ReadMetadata("/nonexistent/path/abc123")
 	if err == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,8 +14,10 @@ import (
 
 // Store copies a tutorial directory into ~/.lathe/tutorials/ and writes its
 // metadata with status=unverified. Verification is opt-in and never auto-runs
-// here — the user triggers it separately via the /lathe-verify skill.
-func Store(srcPath string, tags ...string) (*Tutorial, error) {
+// here — the user triggers it separately via the /lathe-verify skill. sources
+// is the research trail (URLs the skill consulted); both tags and sources are
+// normalized before they land in metadata.
+func Store(srcPath string, tags, sources []string) (*Tutorial, error) {
 	slug := filepath.Base(strings.TrimSuffix(srcPath, string(filepath.Separator)))
 	// The generation skill writes to /tmp/lathe-<slug>/ (the "lathe-" prefix
 	// namespaces the temp dir). Strip it so the prefix doesn't leak into the
@@ -42,6 +44,7 @@ func Store(srcPath string, tags ...string) (*Tutorial, error) {
 		Status:  StatusUnverified,
 		Tags:    NormalizeTags(tags),
 		Parts:   parts,
+		Sources: NormalizeSources(sources),
 	}
 
 	if err := WriteMetadata(destDir, t); err != nil {
@@ -144,6 +147,28 @@ func NormalizeTags(tags []string) []string {
 		}
 		seen[t] = struct{}{}
 		out = append(out, t)
+	}
+	return out
+}
+
+// NormalizeSources cleans a source-URL list: trims surrounding whitespace,
+// drops empties, and removes duplicates while preserving first-seen order.
+// Unlike NormalizeTags it does NOT lowercase — URLs are case-sensitive (paths,
+// query strings, and fragments can all carry meaning). Returns nil for an
+// all-empty input so it stays omitempty in metadata.json.
+func NormalizeSources(sources []string) []string {
+	seen := make(map[string]struct{}, len(sources))
+	var out []string
+	for _, s := range sources {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
 	return out
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -16,7 +16,7 @@ func TestStoreSingleTutorial(t *testing.T) {
 	// Override home so we don't pollute the real ~/.lathe
 	t.Setenv("HOME", t.TempDir())
 
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -40,7 +40,7 @@ func TestStoreStripsLathePrefixFromSlug(t *testing.T) {
 	}
 	t.Setenv("HOME", t.TempDir())
 
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -61,7 +61,7 @@ func TestStoreSeriesTutorial(t *testing.T) {
 	}
 	t.Setenv("HOME", t.TempDir())
 
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -81,7 +81,7 @@ func TestStorePersistsAndNormalizesTags(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	tut, err := store.Store(src, "  Rust ", "audio", "rust", "")
+	tut, err := store.Store(src, []string{"  Rust ", "audio", "rust", ""}, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -119,7 +119,7 @@ func TestStoreDefaultsToUnverified(t *testing.T) {
 	}
 	t.Setenv("HOME", t.TempDir())
 	// Store never auto-verifies; the default status is unverified.
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -136,7 +136,7 @@ func TestStoreDoesNotSpawnVerifier(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}
@@ -156,7 +156,7 @@ func TestDeleteRemovesTutorial(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 
-	tut, err := store.Store(src)
+	tut, err := store.Store(src, nil, nil)
 	if err != nil {
 		t.Fatalf("Store() error = %v", err)
 	}


### PR DESCRIPTION
Lathe targets topics with little training material — exactly where a model
is most likely to confidently invent a flag, default, or signature. Attack
that at three levels:

- Research-first generation: the /lathe skill now runs a mandatory
  search→fetch→read step before drafting, grounds load-bearing claims in
  what it actually read, and degrades gracefully when web tools are absent.
- Mark uncertainty inline: a new [!UNVERIFIED] callout for any load-bearing
  claim the generator couldn't ground in a source — "ground or flag, never
  bluff". Rendered via the existing callout pipeline with rust-toned tokens.
- Source provenance + UI: record the URLs consulted (Tutorial.Sources via
  `lathe store --source` / `extend-commit --source`, de-duped, case-preserved)
  and surface them as "Researched against N sources"; show "Verified <date>"
  from the existing verify-result timestamp and a count of flagged claims.

Skills generate; the CLI owns durable state — provenance flows in through
store-command flags, never a skill writing metadata.json.