### PR TITLE
Refresh tutorial dashboard UI

### DIFF
--- a/internal/serve/components.html
+++ b/internal/serve/components.html
@@ -26,15 +26,17 @@
   <style>{{.CSS}}{{.HighlightCSS}}</style>
 {{end}}
 
-{{/* badge — renders a status pill. Dot (.) is a store.Status. Unverified (and
-     any unknown value) renders nothing, matching the terminal statusBadge in
-     cmd/list.go. Keep the emoji+word vocabulary in sync with it. */}}
+{{/* badge — renders a quiet status marker: a colored dot + a muted serif label
+     (no emoji). Dot (.) is a store.Status. Unverified (and any unknown value)
+     renders nothing — the calm default — matching the terminal statusBadge in
+     cmd/list.go. The outer class="badge <status>" is a CSS + test hook; the
+     dot color comes from the per-status .badge-dot rules in styles.css. */}}
 {{define "badge"}}
-{{- if eq . "verified"}}<span class="badge verified">✅ Verified</span>
-{{- else if eq . "verifying"}}<span class="badge verifying">⏳ Verifying…</span>
-{{- else if eq . "failed"}}<span class="badge failed">❌ Failed</span>
-{{- else if eq . "skipped"}}<span class="badge skipped">⚠️ Skipped</span>
-{{- else if eq . "extending"}}<span class="badge extending">⏳ Extending…</span>
+{{- if eq . "verified"}}<span class="badge verified"><span class="badge-dot"></span>Verified</span>
+{{- else if eq . "verifying"}}<span class="badge verifying"><span class="badge-dot"></span>Verifying…</span>
+{{- else if eq . "failed"}}<span class="badge failed"><span class="badge-dot"></span>Failed</span>
+{{- else if eq . "skipped"}}<span class="badge skipped"><span class="badge-dot"></span>Skipped</span>
+{{- else if eq . "extending"}}<span class="badge extending"><span class="badge-dot"></span>Extending…</span>
 {{- end}}
 {{end}}
 

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -14,34 +14,37 @@
 </div>
 {{if .Tutorials}}
 <div class="controls">
-  <div class="controls-row">
+  <div class="toolbar">
     <input type="search" id="searchInput" class="search-input" placeholder="Search by title, topic, or tag…" aria-label="Search tutorials" autocomplete="off">
     <select id="sortSelect" class="sort-select" aria-label="Sort tutorials">
       <option value="newest">Newest</option>
       <option value="oldest">Oldest</option>
       <option value="title">Title A–Z</option>
     </select>
+    <button type="button" id="filterToggle" class="filter-toggle" aria-expanded="false" aria-controls="filterPanel">Filters</button>
   </div>
-  <div class="filter-row" id="statusFilters">
-    <span class="filter-label">Status</span>
-    <button type="button" class="filter-pill" aria-pressed="false" data-status="verified">✅ Verified</button>
-    <button type="button" class="filter-pill" aria-pressed="false" data-status="failed">❌ Failed</button>
-    <button type="button" class="filter-pill" aria-pressed="false" data-status="skipped">⚠️ Skipped</button>
-    <button type="button" class="filter-pill" aria-pressed="false" data-status="unverified">Unverified</button>
-  </div>
-  <div class="filter-row" id="typeFilters">
-    <span class="filter-label">Type</span>
-    <button type="button" class="filter-pill" aria-pressed="false" data-series="false">Single</button>
-    <button type="button" class="filter-pill" aria-pressed="false" data-series="true">Series</button>
-  </div>
-  <div class="filter-row" id="tagFilters" hidden>
-    <span class="filter-label">Tags</span>
+  <div class="filter-panel" id="filterPanel">
+    <div class="filter-row" id="statusFilters">
+      <span class="filter-label">Status</span>
+      <button type="button" class="filter-pill" aria-pressed="false" data-status="verified">Verified</button>
+      <button type="button" class="filter-pill" aria-pressed="false" data-status="failed">Failed</button>
+      <button type="button" class="filter-pill" aria-pressed="false" data-status="skipped">Skipped</button>
+      <button type="button" class="filter-pill" aria-pressed="false" data-status="unverified">Unverified</button>
+    </div>
+    <div class="filter-row" id="typeFilters">
+      <span class="filter-label">Type</span>
+      <button type="button" class="filter-pill" aria-pressed="false" data-series="false">Single</button>
+      <button type="button" class="filter-pill" aria-pressed="false" data-series="true">Series</button>
+    </div>
+    <div class="filter-row" id="tagFilters" hidden>
+      <span class="filter-label">Tags</span>
+    </div>
   </div>
 </div>
 {{range .Tutorials}}
 <div class="tutorial" data-title="{{.Title}}" data-slug="{{.Slug}}" data-topic="{{.Topic}}" data-tags="{{range .Tags}}{{.}},{{end}}" data-status="{{.Status}}" data-created="{{.Created.Format "2006-01-02T15:04:05Z07:00"}}" data-series="{{.IsSeries}}">
-  <div>
-    <a href="/{{.Slug}}/">{{.Title}}</a>
+  <div class="tutorial-body">
+    <a class="tutorial-link" href="/{{.Slug}}/">{{.Title}}</a>
     <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
     {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
   </div>
@@ -100,11 +103,21 @@
     if (!cards.length) return;
     var search = document.getElementById('searchInput');
     var sortSel = document.getElementById('sortSelect');
+    var filterToggle = document.getElementById('filterToggle');
+    var filterPanel = document.getElementById('filterPanel');
     var statusRow = document.getElementById('statusFilters');
     var typeRow = document.getElementById('typeFilters');
     var tagRow = document.getElementById('tagFilters');
     var noResults = document.getElementById('noResults');
     var container = cards[0].parentNode;
+
+    // Collapse the filter panel by default — calmer first view. Doing this in JS
+    // (not via a static `hidden`) keeps every pill visible when JS is off.
+    filterPanel.classList.add('collapsed');
+    filterToggle.addEventListener('click', function(){
+      var open = filterPanel.classList.toggle('collapsed') === false;
+      filterToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
 
     function cardTags(card){
       return (card.dataset.tags || '').split(',').map(function(s){return s.trim();}).filter(Boolean);
@@ -149,6 +162,11 @@
         if (show) visible++;
       });
       noResults.hidden = visible !== 0;
+      // Surface how many pill filters are active so collapsing the panel never
+      // hides that filtering is on.
+      var active = statuses.length + types.length + tags.length;
+      filterToggle.textContent = active ? 'Filters · ' + active : 'Filters';
+      filterToggle.classList.toggle('has-active', active > 0);
     }
 
     function sort(){

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -93,11 +93,26 @@ func TestListPageRendersTagsAndControls(t *testing.T) {
 	if !strings.Contains(body, `id="sortSelect"`) {
 		t.Error("list page missing the sort control")
 	}
+	if !strings.Contains(body, `id="filterToggle"`) {
+		t.Error("list page missing the collapsible Filters toggle")
+	}
 	if !strings.Contains(body, `data-tags="rust,audio,"`) {
 		t.Error("list page card missing data-tags attribute for search/filter")
 	}
 	if !strings.Contains(body, `<span class="tag">rust</span>`) {
 		t.Error("list page missing rendered tag pill")
+	}
+	// Whole-card stretched link: the title anchor carries .tutorial-link and
+	// points at the tutorial; the overlay (::after) makes the card clickable.
+	if !strings.Contains(body, `class="tutorial-link" href="/tagged-tutorial/"`) {
+		t.Error("list page card missing the stretched .tutorial-link anchor")
+	}
+	// Badge is now a quiet dot + serif label — no emoji pill.
+	if !strings.Contains(body, `<span class="badge-dot"></span>`) {
+		t.Error("list page badge missing the dot marker (dot + label restyle)")
+	}
+	if strings.Contains(body, "✅") || strings.Contains(body, "❌") {
+		t.Error("list page badge still renders emoji; expected dot + label")
 	}
 }
 

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -191,13 +191,22 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 
 /* ---- 4. Components ------------------------------------------------------- */
 
-/* Status badge (shared: sidebar + list cards) */
-.badge{display:inline-block;font-family:var(--font-display);font-size:.7rem;font-weight:600;letter-spacing:.01em;padding:.2rem .5rem;border-radius:var(--radius-sm);line-height:1.4}
-.badge.verified{background:var(--badge-verified-bg);color:var(--badge-verified-text)}
-.badge.verifying{background:var(--badge-verifying-bg);color:var(--badge-verifying-text)}
-.badge.failed{background:var(--badge-failed-bg);color:var(--badge-failed-text)}
-.badge.extending{background:var(--badge-extending-bg);color:var(--badge-extending-text)}
-.badge.skipped{background:var(--badge-skipped-bg);color:var(--badge-skipped-text)}
+/* Status badge (shared: sidebar + list cards). Quiet by design — a colored dot
+   + a muted serif label, no filled pill. The dot carries the semantics via the
+   existing --badge-<status>-text tokens (contrast-correct in both themes); the
+   label stays --text-faint so it reads as calm metadata next to the title. The
+   --badge-*-bg tokens are intentionally left defined-but-unused. */
+.badge{display:inline-flex;align-items:center;gap:.4rem;font-family:var(--font-display);font-size:.7rem;font-weight:600;letter-spacing:.01em;line-height:1.4;color:var(--text-faint)}
+.badge-dot{width:.5rem;height:.5rem;border-radius:9999px;flex-shrink:0;background:var(--text-faint)}
+.badge.verified .badge-dot{background:var(--badge-verified-text)}
+.badge.verifying .badge-dot{background:var(--badge-verifying-text)}
+.badge.failed .badge-dot{background:var(--badge-failed-text)}
+.badge.extending .badge-dot{background:var(--badge-extending-text)}
+.badge.skipped .badge-dot{background:var(--badge-skipped-text)}
+/* In-flight states get a gentle pulse; stilled for reduced-motion users. */
+.badge.verifying .badge-dot,.badge.extending .badge-dot{animation:badge-pulse 1.6s ease-in-out infinite}
+@keyframes badge-pulse{0%,100%{opacity:1}50%{opacity:.35}}
+@media (prefers-reduced-motion:reduce){.badge.verifying .badge-dot,.badge.extending .badge-dot{animation:none}}
 
 /* Button — the one button primitive. Variants: primary (accent fill), ghost
    (outline), danger (failed tint). Modifiers: pill (rounded), sm (compact).
@@ -345,14 +354,20 @@ body.list{max-width:46rem;margin:clamp(1.5rem,.9rem + 2vw,3rem) auto;padding:0 c
 body.list .header{display:flex;justify-content:space-between;align-items:flex-start;gap:1rem;flex-wrap:wrap}
 body.list .header > div{min-width:0;flex:1 1 auto}
 body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4vw,2.2rem);margin-bottom:.35rem;line-height:1.15;letter-spacing:-.015em}
-.subtitle{color:var(--text-faint);margin-bottom:2.25rem;font-size:.98rem;font-style:italic}
-.tutorial{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:1rem 1.25rem;margin:.75rem 0;display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;transition:border-color var(--transition),box-shadow var(--transition)}
+.subtitle{color:var(--text-faint);margin-bottom:1.75rem;font-size:.98rem;font-style:italic}
+/* Cards use the stretched-link pattern: the title's ::after overlay covers the
+   whole card so a click anywhere opens the tutorial, while .tutorial-actions is
+   lifted above it (z-index) so the delete button still works. Denser padding +
+   margins than the reading shell to make the index scan quickly. */
+.tutorial{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:.7rem 1rem;margin:.5rem 0;display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;transition:border-color var(--transition),box-shadow var(--transition)}
 .tutorial:hover{border-color:var(--border-strong);box-shadow:var(--shadow-sm)}
-.tutorial > div:first-child{min-width:0;flex:1 1 14rem}
-.tutorial a{text-decoration:none;color:var(--accent);font-family:var(--font-display);font-weight:600;font-size:1.08rem;display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis}
-.tutorial a:hover{color:var(--accent-hover);text-decoration:underline;text-underline-offset:2px}
+.tutorial-body{min-width:0;flex:1 1 14rem}
+.tutorial-link{text-decoration:none;color:var(--accent);font-family:var(--font-display);font-weight:600;font-size:1.08rem;display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis}
+.tutorial-link::after{content:'';position:absolute;inset:0;z-index:0}
+.tutorial:hover .tutorial-link{color:var(--accent-hover);text-decoration:underline;text-underline-offset:2px}
 .meta{font-size:.8rem;color:var(--text-faint);margin-top:.25rem}
-.tutorial-actions{display:flex;align-items:center;gap:.6rem;flex-shrink:0;flex-wrap:wrap}
+/* Sits above the stretched-link overlay so the badge reads and the × deletes. */
+.tutorial-actions{position:relative;z-index:1;display:flex;align-items:center;gap:.6rem;flex-shrink:0;flex-wrap:wrap}
 .delete-form{margin:0}
 .delete-btn{background:transparent;border:1px solid var(--border);color:var(--text-faint);font:inherit;font-size:1rem;line-height:1;min-width:32px;min-height:32px;padding:.15rem .55rem;border-radius:var(--radius-sm);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;transition:color var(--transition),border-color var(--transition),background var(--transition)}
 .delete-btn:hover{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
@@ -360,14 +375,26 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
 .empty code{background:var(--code-bg);color:var(--code-text);padding:.1rem .35rem;border-radius:var(--radius-sm);font-family:var(--font-mono);font-size:.85em;font-style:normal}
 
 /* List controls — client-side search, sort, and tag/status filters. Pure
-   progressive enhancement: without JS every card stays visible (.hidden is only
-   ever set by the list page script). */
-.controls{margin:0 0 1.25rem;display:flex;flex-direction:column;gap:.7rem}
-.controls-row{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}
+   progressive enhancement: without JS every card and every filter stays visible
+   (.hidden / .collapsed are only ever set by the list page script). The toolbar
+   row (search + sort + Filters toggle) is always shown; the pill rows live in a
+   panel the toggle collapses on load. */
+.controls{margin:0 0 1.25rem;display:flex;flex-direction:column;gap:.6rem}
+.toolbar{display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}
 .search-input{flex:1 1 14rem;min-width:0;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-md);padding:.55rem .75rem;font-family:var(--font-body);font-size:.95rem;line-height:1.4}
 .search-input:focus{outline:2px solid var(--accent);outline-offset:1px}
 .sort-select{background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-md);padding:.5rem .65rem;font-family:var(--font-display);font-size:.85rem;font-weight:600;cursor:pointer}
 .sort-select:focus{outline:2px solid var(--accent);outline-offset:1px}
+/* Filters toggle — shares the sort-select / filter-pill vocabulary. .has-active
+   tints it with the accent soft so an active filter set reads even when the
+   panel is collapsed. */
+.filter-toggle{background:var(--surface);color:var(--text-subtle);border:1px solid var(--border);border-radius:var(--radius-md);padding:.5rem .8rem;font-family:var(--font-display);font-size:.85rem;font-weight:600;cursor:pointer;transition:background var(--transition),color var(--transition),border-color var(--transition)}
+.filter-toggle:hover{background:var(--surface-sunken);color:var(--text)}
+.filter-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.filter-toggle[aria-expanded="true"]{background:var(--surface-sunken);color:var(--text);border-color:var(--border-strong)}
+.filter-toggle.has-active{color:var(--accent);border-color:var(--accent);background:var(--accent-soft)}
+.filter-panel{display:flex;flex-direction:column;gap:.55rem;padding-top:.15rem}
+.filter-panel.collapsed{display:none}
 .filter-row{display:flex;gap:.4rem;flex-wrap:wrap;align-items:center}
 .filter-label{font-family:var(--font-display);font-size:.75rem;font-weight:600;color:var(--text-faint);margin-right:.15rem}
 .filter-pill{font-family:var(--font-display);font-size:.78rem;font-weight:600;color:var(--text-subtle);background:transparent;border:1px solid var(--border);padding:.3rem .7rem;border-radius:9999px;cursor:pointer;transition:background var(--transition),color var(--transition),border-color var(--transition)}


### PR DESCRIPTION
## Summary

A presentation-only refresh of the tutorial dashboard (the list/index page at `/`) to carry the same editorial warmth as the reading pages. The Go handler, the `Tutorial` data, and the client-side search/filter/sort *logic* are unchanged — only markup/CSS/JS presentation.

- **Badge → quiet dot + label.** Emoji pills (✅ Verified, ❌ Failed) replaced with a colored status dot + muted serif label. Applied to the shared `{{define "badge"}}`, so the reading-page sidebar updates automatically and stays cohesive. Dot colors reuse the existing `--badge-<status>-text` tokens; subtle pulse on `verifying`/`extending` is guarded by `prefers-reduced-motion`. `unverified` still renders no badge.
- **Cards → whole-card clickable + denser.** Stretched-link pattern (`.tutorial-link::after { inset:0 }`) makes the whole card the click target; `.tutorial-actions` is lifted above the overlay so the × delete button still works (and still prompts). Padding/margins tightened for a faster scan.
- **Collapsible filter bar.** The four stacked control rows become a persistent toolbar (search + sort + a **Filters** toggle) over a collapsible panel holding the status/type/tag pill rows. The panel is collapsed *by JS on load* (so JS-off keeps everything visible), and the toggle shows an active-filter count (e.g. "Filters · 2").

No new tokens, fonts, or colors — existing design-system tokens only.

## Test plan

- `go test ./...` — green, including new assertions in `server_test.go` for the stretched `class="tutorial-link"` link, the `badge-dot` marker (no emoji), and `id="filterToggle"`. Pinned assertions (`sortSelect`, `data-tags="rust,audio,"`, `<span class="tag">rust</span>`, `badge extending`) still pass.
- `mage check` — green (gofmt, vet, lint, `test -race`, build).
- Manual: `./lathe serve`, load `/` —
  - Toolbar shows search + sort + **Filters** by default; pills hidden until toggled; count updates as filters activate.
  - Clicking anywhere on a card opens the tutorial; × still deletes (and prompts).
  - Badges read as dot + serif label in both light and dark themes; `unverified` shows no badge.
  - Open a tutorial → reading-sidebar badge matches the new dot+label style.
  - Disable JS → all cards and all filter pills remain visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)