### PR TITLE
feat: backfill the four documented Lathe companion skills

### DIFF
--- a/.claude/skills/lathe-ask/SKILL.md
+++ b/.claude/skills/lathe-ask/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: lathe-ask
+description: Answer a reader's question about a specific part of a Lathe tutorial, in session. Use when the user invokes /lathe-ask with a slug and part like "/lathe-ask digital-synth-zig part-02.md" followed by the question on the next line (the "Ask" button in `lathe serve` pastes exactly this).
+---
+
+# Lathe — Ask About a Part
+
+Answer a reader's question about one part of a stored tutorial, grounded in what that tutorial actually built. Triggered by:
+
+```
+/lathe-ask <slug> <part-NN.md>
+<the reader's question>
+```
+
+The web "Ask" button pastes exactly that: the slug and part on the command line, the question on the next line. Parse all three.
+
+## Protocol
+
+1. **Read the part** at `~/.lathe/tutorials/<slug>/<part-NN.md>`. Read sibling parts (`part-NN.md` in the same dir) when the question reaches across parts or depends on earlier setup — continuity matters here too.
+
+2. **Answer grounded in this tutorial's concrete artifact** — the same controlling example, the same numbers, the same voice the tutorial used. The reader is asking about *their* synth / *their* key-value store, not the topic in the abstract. Don't re-teach the whole topic from scratch.
+
+3. **Point at the tutorial, don't re-derive it.** Prefer "look at the `process_buffer` loop in §3 — the modulo there is doing X" over a fresh ground-up explanation. You're a guide standing next to them at the page they're reading.
+
+4. **Be honest about gaps.** If the question exposes something the tutorial got wrong, glossed over, or left under a `[!UNVERIFIED]` flag, say so plainly — don't paper over it. That's more useful than a confident hand-wave.
+
+5. **Stay engaged** for follow-ups. This is a conversation, not a one-shot reply.
+
+## Boundaries — read-only, conversational
+
+- **There is no `lathe ask` command.** This skill writes nothing and calls back into no CLI command — ask is deliberately conversation-only.
+- **No state mutation:** don't touch `metadata.json`, `verify-result.json`, or the part markdown. Don't verify, don't extend, don't tag.
+- Keep answers specific to this tutorial's concrete artifact, in its voice.

--- a/.claude/skills/lathe-extend/SKILL.md
+++ b/.claude/skills/lathe-extend/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: lathe-extend
+description: Write the next part of an existing Lathe tutorial, in session. Use when the user invokes /lathe-extend with a slug like "/lathe-extend digital-synth-zig" (the "Add a new part" button in `lathe serve` hands you that command), optionally followed by guidance for where the part should go.
+---
+
+# Lathe — Extend a Tutorial
+
+Add the next part to a stored tutorial. Triggered by `/lathe-extend <slug> [guidance…]`. The new part must continue *that* tutorial — its example, its numbers, its voice — not a fresh generic one. Everything about shape, voice, research discipline, and callouts comes from the **`lathe`** skill; read it and apply it. This skill only adds what's different about extending: continuity and the `extend-start → write → extend-commit` handshake.
+
+## Protocol
+
+1. **Absorb the existing tutorial.** Read every part in `~/.lathe/tutorials/<slug>/` (`part-NN.md`). You need the load-bearing context before you write a word:
+   - The **controlling example** and the **fixed numbers** (sample rate, page size, buffer size) — reuse them exactly; don't invent new ones.
+   - The **controlling metaphor**, if any, and whether a prior part already retired it (if retired, don't resurrect it).
+   - The **voice** and the level of the reader.
+   - Where the previous part's **"What's next"** pointed — that's your mandate for this part unless the user's guidance redirects it.
+
+2. **Research first.** Same discipline as the `lathe` skill's "Research first" step: actually open 3–8 authoritative sources for whatever this new part introduces, take notes with URLs beside the load-bearing facts, and ground or `[!UNVERIFIED]`-flag every load-bearing claim. New material gets the same scrutiny as Part 1 did. No web access? Say so in one line and write conservatively, flagging the load-bearing unknowns.
+
+3. **Reserve the part.** Run:
+   ```bash
+   lathe extend-start <slug>
+   ```
+   It prints a single filename (e.g. `part-02.md`) and sets status `extending`. **Capture that exact filename.** If it errors with "already extending or verifying", stop and tell the user — something is mid-flight; don't force it.
+
+4. **Write the part** to `~/.lathe/tutorials/<slug>/<printed-filename>`.
+   - **This is the one allowed content write.** The skill writes the part markdown directly into the tutorial dir at the reserved path — that is required and deliberate, because `lathe extend-commit` `os.Stat`s the file there before registering it. (Future reader: don't "fix" this by routing it through a CLI command. There is no such command; the binary owns *metadata*, the skill writes the *part body*.)
+   - Follow the full **Tutorial shape** from the `lathe` skill — hook, `## What you'll build`, prerequisites, specific section titles, `## Checkpoint`, `## What's next`, `## Exercises`, `## Sources`. Each part stands alone and ends with a Checkpoint.
+   - Because this is **Part N ≥ 2**, open with a `> [!RECALL]` spaced-retrieval beat: one question on a load-bearing concept from a prior part, phrased so the reader must reconstruct the answer (not just recognize it). See the `lathe` skill's recall before/after.
+   - **One file, this part only.** Don't write `index.md`, don't touch earlier parts, don't write more than one part.
+
+5. **Commit the part.** Run:
+   ```bash
+   lathe extend-commit <slug> <printed-filename> [--source <url> …]
+   ```
+   Pass `--source` once for each source you newly consulted for this part — it folds them into the tutorial's research trail (de-duped). This registers the part, clears the pending marker, and resets status to `unverified`.
+
+6. **Tell the user** it's added: how to view it (`lathe serve`), and that verification is opt-in (`/lathe-verify <slug>` — the "Verify this tutorial" button hands you that command). Then stay in session for follow-ups.
+
+## Boundaries
+
+- The **only durable-state writes** are `lathe extend-start` and `lathe extend-commit`. Never edit `metadata.json` directly.
+- Writing the reserved part-content file into the tutorial dir is the sole content write — and it's required (step 4).
+- Don't verify, don't write `index.md`, don't write multiple parts, don't edit existing parts.
+
+## Stay in session
+
+You're still their expert guide. Stay available for "make this part harder", "why did we structure it this way", "how'd I do on the checkpoint".

--- a/.claude/skills/lathe-tag/SKILL.md
+++ b/.claude/skills/lathe-tag/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: lathe-tag
+description: Pick or backfill the search tags on a stored Lathe tutorial, in session. Use when the user invokes /lathe-tag with a slug like "/lathe-tag digital-synth-zig" to choose good tags for the `lathe serve` search and tag filters, or to backfill tags on a tutorial that has none.
+---
+
+# Lathe — Tag a Tutorial
+
+Choose the tags that make a stored tutorial findable in `lathe serve`'s search and tag filters. Triggered by `/lathe-tag <slug>`.
+
+## Protocol
+
+1. **Read the tutorial** at `~/.lathe/tutorials/<slug>/` to understand what it actually teaches.
+
+2. **Pick 2–5 lowercase, reusable tags.** Same vocabulary guidance as the `lathe` skill's tag step: cover, where they apply —
+   - the **language/runtime** — `zig`, `rust`, `go`;
+   - the **domain** — `audio`, `compilers`, `databases`;
+   - the **core technique** — `parsing`, `dsp`, `concurrency`.
+
+   Prefer short, reusable tags that will group naturally with other tutorials over hyper-specific one-offs. Don't pre-lowercase or de-dupe defensively — `store.NormalizeTags` is the one place that canonicalizes (trim, lowercase, de-dupe), so just pass sensible tags and let it normalize.
+
+3. **Persist them.** To set the whole tag list (the usual case — choosing or replacing tags):
+   ```bash
+   lathe tag <slug> --set zig --set audio --set dsp
+   ```
+   For incremental edits to an existing set, use `--add` / `--remove` instead:
+   ```bash
+   lathe tag <slug> --add embedded
+   lathe tag <slug> --remove misc
+   ```
+   `--set` replaces the entire list; `--add`/`--remove` edit it in place. All three are repeatable and accept comma-separated values.
+
+4. **Report the resulting tag set** to the user (the command prints it).
+
+## Boundaries
+
+- Only touches tags, and only via `lathe tag`. Never edit `metadata.json` directly.
+- No generation, verification, or extension — just tags.

--- a/.claude/skills/lathe-verify/SKILL.md
+++ b/.claude/skills/lathe-verify/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: lathe-verify
+description: Verify that a stored Lathe tutorial actually works by following it end to end in a fresh scratch dir, in session. Use when the user invokes /lathe-verify with a slug like "/lathe-verify digital-synth-zig" (the "Verify this tutorial" button in `lathe serve` hands you that command).
+---
+
+# Lathe — Verify a Tutorial
+
+Follow a stored tutorial exactly as a reader would, in a throwaway directory, and record whether it actually works. Triggered by `/lathe-verify <slug>`. Isolation is **by instruction** — a fresh `mktemp -d`, under the user's normal interactive permissions. No sandbox-exec, no Docker.
+
+This skill is **read-only with respect to the tutorial**: never edit the parts or the metadata. The only writes are status updates through `lathe verify-result`.
+
+## Protocol
+
+1. **Mark it in-flight first:**
+   ```bash
+   lathe verify-result <slug> --status verifying
+   ```
+   This sets the spinner badge in the web UI. If it errors with "cannot verify while it is extending", stop — a part is mid-flight; don't verify on top of it.
+
+2. **Make a fresh scratch dir and work there:**
+   ```bash
+   cd "$(mktemp -d)"
+   ```
+   Everything the tutorial tells the reader to create happens here, not in the user's project. (Status is set by *this skill*, never by the web/CLI button — so an unclicked button can never strand a tutorial at `verifying`.)
+
+3. **Follow each part in order.** Read `~/.lathe/tutorials/<slug>/part-NN.md` from `part-01` up. Install the prerequisites, create the files and paste the code blocks exactly as written, in order, then run the `## Checkpoint` command and compare against the stated expected output.
+   - **Skip the pedagogical and provenance callouts** — `> [!PREDICT]`, `> [!RECALL]`, and `> [!UNVERIFIED]` are not verifiable steps. They prompt the reader or flag uncertainty; there's nothing to execute.
+   - Treat the Checkpoint commands and code blocks as the executable surface.
+
+4. **Record the terminal result** with the matching command:
+   - **Everything works** → `lathe verify-result <slug> --status verified`
+   - **A required tool isn't installed** → `lathe verify-result <slug> --status skipped`
+     This is **not a failure** — it's the ⚠️ Skipped badge, meaning "couldn't run it here," not "the tutorial is wrong." Use it whenever the toolchain the tutorial needs (compiler, runtime, SDK) is missing locally.
+   - **Something genuinely breaks** (wrong output, code doesn't compile, a step contradicts itself) →
+     ```bash
+     lathe verify-result <slug> --status failed \
+       --part <part-NN.md> \
+       --failed-step <1-indexed step number within that part> \
+       --error "<the error message or mismatched output>"
+     ```
+
+5. **Report to the user** what happened — verified clean, skipped (and which tool was missing), or where exactly it failed.
+
+## Boundaries
+
+- **Read-only on the tutorial.** Never edit a `part-NN.md`, `metadata.json`, or `verify-result.json` directly — the only state writes are via `lathe verify-result`.
+- **No OS sandboxing.** Isolation is the `mktemp -d` scratch dir plus instruction, under the user's normal permission model. Don't reach for sandbox-exec or Docker.
+- **Skipped ≠ failed.** A missing toolchain is `skipped`. Reserve `failed` for the tutorial being genuinely broken.
+- Status is always set by this skill, never by the handoff button.


### PR DESCRIPTION
## Summary

`CLAUDE.md` and the Go CLI document five Lathe skills — `lathe`, `lathe-verify`, `lathe-extend`, `lathe-ask`, `lathe-tag` — but only `.claude/skills/lathe/SKILL.md` actually existed. Every handoff button (web "Add a new part" / "Verify" / "Ask" and the `lathe verify`/`lathe extend` CLI commands) resolved to a missing skill. This backfills the four missing `SKILL.md` files so the repo matches its own documentation.

No Go, no `CLAUDE.md` changes — pure skill authoring + symlinks. The CLI plumbing (`lathe extend-start`/`extend-commit`, `lathe verify-result`, `lathe tag`) already existed and is unchanged.

Each skill mirrors the existing `lathe` skill's voice/shape and the strict boundary: **skills do model work; the Go binary is the sole writer of durable state** (`metadata.json`, `verify-result.json`).

- **`lathe-extend`** (`/lathe-extend <slug> [guidance]`) — absorbs continuity from existing parts, researches, then `extend-start` → write the reserved part file → `extend-commit [--source]`. Opens Part N≥2 with a `[!RECALL]` beat. Notes that writing the reserved part file is the one allowed content write (required — `extend-commit` stat's it).
- **`lathe-ask`** (`/lathe-ask <slug> <part>` + question line) — read-only, conversational; no state mutation, no CLI callback.
- **`lathe-verify`** (`/lathe-verify <slug>`) — `verifying` → run in a `mktemp -d` scratch dir → terminal status with exact flags; skips `[!PREDICT]`/`[!RECALL]`/`[!UNVERIFIED]`; skipped ≠ failed.
- **`lathe-tag`** (`/lathe-tag <slug>`) — 2–5 reusable lowercase tags via `lathe tag --set` / `--add` / `--remove`.

Force-added because `.claude/` is gitignored (matches the existing `lathe/SKILL.md` precedent).

## Test plan

- Each `SKILL.md` has valid frontmatter (`name:` matching the skill, "Use when…/triggered by /lathe-…" description) — confirmed the harness lists all four.
- Every flag the skills tell the model to run was cross-checked against the binary's `--help`: `extend-commit --source`, `verify-result --status {verifying,verified,failed,skipped} [--part --failed-step --error]`, `tag --set/--add/--remove`.
- Four symlinks created in `~/.claude/skills/` resolving into the repo (local only; not part of this PR).
- `mage check` is green (gofmt, vet, golangci-lint, `go test -race`, build) — no Go changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)