### PR TITLE
feat: add a theme-aware SVG favicon to the web UI

### DIFF
--- a/internal/serve/components.html
+++ b/internal/serve/components.html
@@ -13,6 +13,7 @@
 {{define "head"}}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="/_static/favicon.svg">
   <script>
     (function(){
       try {

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -27,6 +27,7 @@ var templateFS embed.FS
 var stylesCSS string
 
 //go:embed static/mermaid.min.js
+//go:embed static/favicon.svg
 //go:embed static/fonts/fraunces.woff2 static/fonts/newsreader.woff2 static/fonts/newsreader-italic.woff2 static/fonts/jetbrains-mono.woff2
 var staticFS embed.FS
 
@@ -78,6 +79,7 @@ func (s *Server) Handler() http.Handler {
 // slash, this is the cheap belt-and-suspenders check.
 var staticAssets = map[string]string{
 	"mermaid.min.js":          "application/javascript; charset=utf-8",
+	"favicon.svg":             "image/svg+xml",
 	"fraunces.woff2":          "font/woff2",
 	"newsreader.woff2":        "font/woff2",
 	"newsreader-italic.woff2": "font/woff2",

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -602,6 +602,30 @@ func TestStaticMermaidAsset(t *testing.T) {
 	}
 }
 
+func TestStaticFaviconAsset(t *testing.T) {
+	dir := t.TempDir()
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/_static/favicon.svg", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /_static/favicon.svg = %d, want %d", w.Code, http.StatusOK)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "image/svg+xml" {
+		t.Errorf("Content-Type = %q, want image/svg+xml", ct)
+	}
+	// Sanity-check it's the real SVG mark, including the dark-mode swap that lets
+	// the favicon follow the OS theme.
+	body := w.Body.String()
+	if !strings.Contains(body, "<svg") {
+		t.Error("favicon body is not an SVG document")
+	}
+	if !strings.Contains(body, "prefers-color-scheme: dark") {
+		t.Error("favicon missing the prefers-color-scheme dark swap")
+	}
+}
+
 func TestStaticFontAssets(t *testing.T) {
 	dir := t.TempDir()
 	srv := serve.NewServer(dir)

--- a/internal/serve/static/favicon.svg
+++ b/internal/serve/static/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!--
+    Lathe mark: concentric arcs "turning" toward a solid spindle dot.
+    Color follows the OS theme (favicons can't read the in-page data-theme
+    toggle): brand terracotta in light, warm sand in dark.
+  -->
+  <style>
+    svg { --accent: #B5451F; }
+    @media (prefers-color-scheme: dark) { svg { --accent: #E89A5C; } }
+    .arc { fill: none; stroke: var(--accent); stroke-width: 2.6; stroke-linecap: round; }
+    .spindle { fill: var(--accent); }
+  </style>
+  <path class="arc" d="M11.76 20.24 A6 6 0 0 1 11.76 11.76"/>
+  <path class="arc" d="M9.28 22.72 A9.5 9.5 0 0 1 9.28 9.28"/>
+  <path class="arc" d="M6.81 25.19 A13 13 0 0 1 6.81 6.81"/>
+  <circle class="spindle" cx="16" cy="16" r="3"/>
+</svg>


### PR DESCRIPTION
## Summary
- The `lathe serve` web UI shipped no favicon, so browsers showed a blank/default tab icon. This adds a single theme-aware SVG favicon — a concentric-arcs "turning" mark with a solid spindle dot in the brand terracotta accent.
- New asset `internal/serve/static/favicon.svg`: 32×32 mark, `#B5451F` (light) / `#E89A5C` (dark) via an embedded `@media (prefers-color-scheme: dark)` swap, transparent background, chunky round strokes so it survives 16px downscaling.
- Served through the existing embedded `/_static/` pipeline: added to the `//go:embed` directive for `staticFS` and to the `staticAssets` whitelist (`"favicon.svg": "image/svg+xml"`), mirroring how `mermaid.min.js` is registered. `handleStatic` and the routes are untouched.
- Linked from the shared `{{define "head"}}` partial in `components.html`, so both the list page and every tutorial/part page emit `<link rel="icon" type="image/svg+xml" href="/_static/favicon.svg">`.
- SVG-only, no binary blobs — stays 100% offline. No PNG/ICO/apple-touch variants or manifest (out of scope).

Note: the favicon follows the OS `prefers-color-scheme` only, not the in-page `data-theme` toggle — favicons can't read the page's localStorage. Accepted limitation.

## Test plan
- `mage check` — gofmt, vet, lint, `go test -race ./...`, build all green.
- New `TestStaticFaviconAsset` asserts `GET /_static/favicon.svg` returns `200` with `Content-Type: image/svg+xml` and that the dark-mode swap is present (parity with `TestStaticMermaidAsset`).
- Manual: `./lathe serve`, confirm the tab icon renders on the list page and a tutorial page; `curl -I /_static/favicon.svg` → `200` + `image/svg+xml`; view-source confirms the `<link rel="icon">` is in `<head>` on both `/` and `/{slug}/`; toggling OS dark mode swaps the icon accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)