### PR TITLE
feat: render GFM tables in served tutorials

### DIFF
--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
@@ -69,6 +70,9 @@ func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 					chromahtml.WithClasses(true),
 				),
 			),
+			// GFM tables — without this, pipe-delimited tables fall through as
+			// literal text. styles.css already styles <table>/<th>/<td>.
+			extension.Table,
 		),
 		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
 		goldmark.WithRendererOptions(

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -33,6 +33,29 @@ func TestRenderMarkdown(t *testing.T) {
 	}
 }
 
+func TestRenderTable(t *testing.T) {
+	src := []byte("intro\n\n| Approach | Composes | Needs OS |\n|---|---|---|\n| Blocking | no | no |\n| Scheduler | yes | no |\n\noutro\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+
+	if !strings.Contains(html, "<table>") {
+		t.Errorf("GFM table not rendered as <table>, got:\n%s", html)
+	}
+	if !strings.Contains(html, "<th>Approach</th>") {
+		t.Errorf("table header cell missing, got:\n%s", html)
+	}
+	if !strings.Contains(html, "<td>Scheduler</td>") {
+		t.Errorf("table body cell missing, got:\n%s", html)
+	}
+	// The raw pipe-delimited markup must not leak as literal text.
+	if strings.Contains(html, "|---|") {
+		t.Errorf("raw table delimiter row leaked into output, got:\n%s", html)
+	}
+}
+
 func TestRenderMermaidBlock(t *testing.T) {
 	src := []byte("intro paragraph\n\n```mermaid\nflowchart LR\n  A --> B\n  B --> C\n```\n\noutro paragraph\n")
 


### PR DESCRIPTION
## Summary
- Markdown tables were rendering as verbatim pipe-delimited text in `lathe serve` because goldmark defaults to plain CommonMark, which has no table support.
- Registers the goldmark `Table` extension in `internal/serve/renderer.go`. `styles.css` already styled `<table>`/`<th>`/`<td>` (the styling had been anticipated), so no CSS change was needed.
- Existing stored tutorials with tables now render correctly — markdown is rendered fresh per request, so no re-store is needed.

## Test plan
- Added `TestRenderTable` asserting a GFM table renders to `<table>`/`<th>`/`<td>` and the raw `|---|` delimiter row does not leak into output.
- `go test ./...`, `go build ./...`, `go vet ./...`, and `gofmt` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)