### PR TITLE
UI polish: top-right card actions + breadcrumb part picker

### DIFF
--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -22,7 +22,21 @@
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
-  <span class="crumb"><strong>{{.Tutorial.Title}}</strong>{{if and .Tutorial.IsSeries .CurrentPartNumber}}<span class="sep">›</span>Part {{.CurrentPartNumber}}{{end}}</span>
+  <span class="crumb"><strong>{{.Tutorial.Title}}</strong>{{if and .Tutorial.IsSeries .CurrentPartNumber}}<span class="sep">›</span>
+    <details class="part-picker">
+      <summary>Part {{.CurrentPartNumber}}<span class="caret" aria-hidden="true">▾</span></summary>
+      <ul class="part-menu">
+        {{range .SeriesTOC}}
+        <li>
+          {{if .Current}}
+          <span class="part-menu-current" aria-current="page"><span class="part-num">Part {{.Number}}</span><span class="title">{{.Title}}</span></span>
+          {{else}}
+          <a href="/{{$.Tutorial.Slug}}/{{.Slug}}"><span class="part-num">Part {{.Number}}</span><span class="title">{{.Title}}</span></a>
+          {{end}}
+        </li>
+        {{end}}
+      </ul>
+    </details>{{end}}</span>
   {{template "themeToggle" .}}
 </header>
 <div class="layout">
@@ -205,6 +219,25 @@
       a.addEventListener('click', function(){
         if (window.matchMedia('(max-width:899px)').matches) setOpen(false);
       });
+    });
+  })();
+</script>
+<script>
+  // Part picker — native <details> handles open/close + keyboard toggle (works
+  // with JS off). This only adds the niceties: close any open picker on an
+  // outside-click or Escape, mirroring the sidebar Escape handling above.
+  (function(){
+    var picker = document.querySelector('.part-picker');
+    if (!picker) return;
+    document.addEventListener('click', function(ev){
+      if (picker.open && !picker.contains(ev.target)) picker.open = false;
+    });
+    document.addEventListener('keydown', function(ev){
+      if (ev.key === 'Escape' && picker.open) {
+        picker.open = false;
+        var summary = picker.querySelector('summary');
+        if (summary) summary.focus();
+      }
     });
   })();
 </script>

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -279,7 +279,13 @@ func TestSeriesPartPrevNext(t *testing.T) {
 			}
 			body := w.Body.String()
 
-			wantCrumb := `<span class="sep">›</span>` + tc.wantCrumb
+			// The breadcrumb part segment now lives inside the part-picker's
+			// <summary> (a <details> disclosure listing every part); the ›
+			// separator still precedes it.
+			if !strings.Contains(body, `<span class="sep">›</span>`) {
+				t.Errorf("missing breadcrumb separator for %s", tc.part)
+			}
+			wantCrumb := `<summary>` + tc.wantCrumb
 			if !strings.Contains(body, wantCrumb) {
 				t.Errorf("missing breadcrumb segment %q", wantCrumb)
 			}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -316,9 +316,34 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 #topBar .theme-toggle{margin-left:auto;flex-shrink:0}
 #hamburger{display:none;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;cursor:pointer;padding:.3rem .55rem;border-radius:var(--radius-sm);line-height:1;font-size:1.15rem;flex-shrink:0}
 #hamburger:hover{background:var(--surface-sunken);color:var(--text)}
-#topBar .crumb{font-size:.85rem;color:var(--text-subtle);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;min-width:0}
-#topBar .crumb strong{color:var(--text);font-weight:600;font-family:var(--font-display)}
-#topBar .crumb .sep{margin:0 .35rem;color:var(--text-faint)}
+/* The crumb is a flex row (overflow:visible) so the part-picker dropdown isn't
+   clipped; the ellipsis moves onto the title <strong> so the title still
+   truncates while the picker stays fully visible beside it. */
+#topBar .crumb{display:flex;align-items:center;gap:.15rem;font-size:.85rem;color:var(--text-subtle);overflow:visible;flex:1;min-width:0}
+#topBar .crumb strong{color:var(--text);font-weight:600;font-family:var(--font-display);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
+#topBar .crumb .sep{margin:0 .35rem;color:var(--text-faint);flex-shrink:0}
+
+/* Part picker — the sticky breadcrumb "Part N" becomes a native <details>
+   disclosure listing every part of the series. The default summary triangle is
+   removed (same trick as .repo-group-summary); a ▾ caret rotates on open. The
+   menu is an absolutely-positioned panel on the .series-toc / part-num vocabulary
+   for brand consistency, lifted above the #topBar content and scrollable for
+   long series. */
+.part-picker{position:relative;flex-shrink:0}
+.part-picker > summary{display:inline-flex;align-items:center;gap:.25rem;list-style:none;cursor:pointer;color:var(--text-subtle);padding:.1rem .15rem;border-radius:var(--radius-sm);white-space:nowrap}
+.part-picker > summary::-webkit-details-marker{display:none}
+.part-picker > summary:hover{color:var(--text)}
+.part-picker > summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.part-picker .caret{font-size:.7rem;color:var(--text-faint);transition:transform var(--transition)}
+.part-picker[open] > summary .caret{transform:rotate(180deg)}
+.part-menu{position:absolute;top:calc(100% + .35rem);left:0;z-index:60;min-width:14rem;max-width:min(22rem,90vw);max-height:min(70vh,24rem);overflow-y:auto;margin:0;padding:.35rem;list-style:none;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);box-shadow:var(--shadow-md)}
+.part-menu li{margin:0}
+.part-menu a,.part-menu .part-menu-current{display:flex;gap:.55rem;align-items:baseline;padding:.45rem .6rem;border-radius:var(--radius-sm);text-decoration:none;color:var(--text-subtle);font-size:.85rem;line-height:1.35;transition:color var(--transition),background var(--transition)}
+.part-menu a:hover{color:var(--accent);background:var(--surface-sunken)}
+.part-menu .part-menu-current{color:var(--accent);background:var(--accent-soft);font-weight:600}
+.part-menu .part-num{font-family:var(--font-display);font-size:.68rem;font-weight:700;letter-spacing:.05em;color:var(--text-faint);text-transform:uppercase;flex-shrink:0;min-width:3.2rem}
+.part-menu .part-menu-current .part-num{color:var(--accent)}
+.part-menu .title{min-width:0}
 
 /* Series TOC at bottom of part */
 .series-toc{margin-top:3rem;padding-top:1.6rem;border-top:1px solid var(--border)}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -410,7 +410,7 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
    whole card so a click anywhere opens the tutorial, while .tutorial-actions is
    lifted above it (z-index) so the delete button still works. Denser padding +
    margins than the reading shell to make the index scan quickly. */
-.tutorial{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:.7rem 1rem;margin:.5rem 0;display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;transition:border-color var(--transition),box-shadow var(--transition)}
+.tutorial{position:relative;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:.7rem 1rem;margin:.5rem 0;display:flex;justify-content:space-between;align-items:flex-start;gap:1rem;flex-wrap:wrap;transition:border-color var(--transition),box-shadow var(--transition)}
 .tutorial:hover{border-color:var(--border-strong);box-shadow:var(--shadow-sm)}
 .tutorial-body{min-width:0;flex:1 1 14rem}
 .tutorial-link{text-decoration:none;color:var(--accent);font-family:var(--font-display);font-weight:600;font-size:1.08rem;display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis}


### PR DESCRIPTION
## Summary

Two presentation-only tweaks to `lathe serve` (no Go/`server.go` changes — the templates already received the needed data):

- **`fix:` card actions hug the top-right.** On the list page, cards with version/tag chips grow tall, leaving the verification badge + delete `×` floating in the vertical middle. `.tutorial` now uses `align-items:flex-start` so the actions pin to the upper-right corner, aligned with the title's first line. The stretched-link overlay, delete form, and the `≤419px` stacked layout are untouched.
- **`feat:` breadcrumb becomes a part picker.** The sticky `#topBar` "Part N" crumb is now a native `<details class="part-picker">` disclosure — a `Part N ▾` summary opens a `.part-menu` listing every part of the series (current one highlighted with `aria-current="page"`, others linked). Any part is reachable from any scroll position without loading part 1 and scrolling to the bottom "In this series" list (which stays, along with prev/next nav). The crumb is now a flex row with `overflow:visible` so the dropdown isn't clipped, with the ellipsis moved onto the title `<strong>`. A small script closes the picker on outside-click / Escape; native `<details>` keeps it working with JS off.

## Test plan

- `mage check` green (gofmt, vet, lint, race tests, build).
- `TestSeriesPartPrevNext` updated to assert the new `<summary>`-based breadcrumb markup.
- Manual against `./lathe serve` with a multi-part series:
  - **List page:** on a card with tags/version chips, badge + `×` sit top-right and stay pinned as the card grows; hover still reveals delete, card click still opens, `×` still deletes.
  - **Part page:** from any scroll position, `Part N ▾` opens a menu of all parts (current marked); selecting another navigates there; dropdown isn't clipped; long series scrolls within the menu; Escape / outside-click closes.
  - Long titles still truncate with an ellipsis beside the picker; narrow viewport (<900px) keeps the picker reachable; JS-off `<details>` still opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)