### PR TITLE
feat: stamp a version into the lathe binary (PR A of 3)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,12 +3,21 @@ package cmd
 import (
 	"os"
 
+	"github.com/devenjarvis/lathe/internal/buildinfo"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "lathe",
-	Short: "Generate and manage hands-on technical tutorials",
+	Use:     "lathe",
+	Short:   "Generate and manage hands-on technical tutorials",
+	Version: buildinfo.Resolve(),
+}
+
+func init() {
+	// rootCmd.Version (above) enables cobra's --version flag; the template
+	// controls what it prints. buildinfo.String() folds in commit/date when
+	// they were stamped at build time, so --version shows the full provenance.
+	rootCmd.SetVersionTemplate("lathe " + buildinfo.String() + "\n")
 }
 
 func Execute() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/devenjarvis/lathe/internal/buildinfo"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd is a friendly alias for `lathe --version`. It prints the same
+// resolved version (plus commit/date when stamped) that the --version flag does.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the lathe version",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "lathe %s\n", buildinfo.String())
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,60 @@
+// Package buildinfo carries the version metadata stamped into the lathe binary.
+//
+// The exported vars are overridden at link time via -ldflags "-X ...=value"
+// (the local mage build and the GoReleaser release pipeline both do this). When
+// they are left at their zero/dev defaults -- e.g. a plain `go install` -- we
+// fall back to the module version reported by runtime/debug.ReadBuildInfo so
+// installed binaries still show something useful (like v0.1.0) instead of "dev".
+//
+// This package deliberately has no cobra import so internal/ stays cobra-free
+// (see CLAUDE.md conventions).
+package buildinfo
+
+import "runtime/debug"
+
+// These are overridden via -ldflags at build time. Keep the fully-qualified
+// path in sync with magefile.go and .goreleaser.yaml:
+//
+//	-X github.com/devenjarvis/lathe/internal/buildinfo.Version=...
+var (
+	// Version is the semantic version (e.g. "v0.1.0"), or "dev" for an
+	// un-stamped build.
+	Version = "dev"
+	// Commit is the short git SHA the binary was built from.
+	Commit = ""
+	// Date is the build timestamp (RFC3339 from GoReleaser).
+	Date = ""
+)
+
+// Resolve returns the best available version string.
+//
+// Precedence: an ldflags-injected Version (anything other than the "dev"
+// default) wins; otherwise we consult the module build info so `go install`ed
+// binaries report their module version; finally we fall back to "dev".
+func Resolve() string {
+	if Version != "" && Version != "dev" {
+		return Version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
+}
+
+// String returns a human-friendly one-line description including the commit and
+// build date when those are known.
+func String() string {
+	s := Resolve()
+	if Commit != "" {
+		s += " (commit " + Commit
+		if Date != "" {
+			s += ", built " + Date
+		}
+		s += ")"
+	} else if Date != "" {
+		s += " (built " + Date + ")"
+	}
+	return s
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,52 @@
+package buildinfo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolvePrefersInjectedVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "v1.2.3"
+	if got := Resolve(); got != "v1.2.3" {
+		t.Fatalf("Resolve() = %q, want injected version v1.2.3", got)
+	}
+}
+
+func TestResolveFallsBackFromDev(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	// With the bare "dev" default, Resolve must not return "" -- it either
+	// reports the module version (under `go test` that is usually empty/devel,
+	// so it lands on "dev") or "dev". The contract is "never empty".
+	Version = "dev"
+	if got := Resolve(); got == "" {
+		t.Fatal("Resolve() returned empty string for dev default")
+	}
+}
+
+func TestStringIncludesCommitAndDate(t *testing.T) {
+	origV, origC, origD := Version, Commit, Date
+	t.Cleanup(func() { Version, Commit, Date = origV, origC, origD })
+
+	Version, Commit, Date = "v0.1.0", "abc1234", "2026-06-05T00:00:00Z"
+	got := String()
+	for _, want := range []string{"v0.1.0", "abc1234", "2026-06-05T00:00:00Z"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestStringBareVersion(t *testing.T) {
+	origV, origC, origD := Version, Commit, Date
+	t.Cleanup(func() { Version, Commit, Date = origV, origC, origD })
+
+	Version, Commit, Date = "v0.1.0", "", ""
+	if got := String(); got != "v0.1.0" {
+		t.Fatalf("String() = %q, want bare v0.1.0", got)
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -61,9 +61,34 @@ func Test() error {
 	return run("go", "test", "-race", "./...")
 }
 
-// Build compiles the self-contained binary (embedded assets included).
+// Build compiles the self-contained binary (embedded assets included), stamping
+// in a git-derived version so a locally built `./lathe --version` reports a real
+// version instead of "dev". The fully-qualified ldflags path must match
+// internal/buildinfo and .goreleaser.yaml.
 func Build() error {
-	return run("go", "build", "-o", "lathe")
+	const pkg = "github.com/devenjarvis/lathe/internal/buildinfo"
+	version := gitDescribe()
+	ldflags := fmt.Sprintf("-X %s.Version=%s -X %s.Commit=%s", pkg, version, pkg, gitCommit())
+	return run("go", "build", "-ldflags", ldflags, "-o", "lathe")
+}
+
+// gitDescribe returns `git describe --tags --always --dirty`, or "dev" if git
+// is unavailable (so Build never fails just because there are no tags yet).
+func gitDescribe() string {
+	out, err := exec.Command("git", "describe", "--tags", "--always", "--dirty").Output()
+	if v := strings.TrimSpace(string(out)); err == nil && v != "" {
+		return v
+	}
+	return "dev"
+}
+
+// gitCommit returns the short HEAD SHA, or "" if git is unavailable.
+func gitCommit() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // Check runs the full gate: fmt check, vet, lint, test, build. This is what CI


### PR DESCRIPTION
**Stacked PR 1 of 3** — Versioning → Embedded skills → Release pipeline. Merge order: this (A) → B (#embedded-skills) → C (#release-pipeline). This one is independent and can merge first.

## Summary
- Add `internal/buildinfo` with ldflags-injectable `Version`/`Commit`/`Date` vars (default `Version="dev"`). `Resolve()` prefers an injected version, else falls back to `runtime/debug.ReadBuildInfo().Main.Version` (so `go install`ed binaries show their module version, not `dev`); `String()` adds commit/date. No cobra import (keeps `internal/` cobra-free).
- Wire it into `rootCmd.Version` + a version template, and add a friendly `lathe version` subcommand.
- `mage build` now stamps a git-derived version via ldflags.

The fully-qualified ldflags path (`github.com/devenjarvis/lathe/internal/buildinfo`) is what PR C's `.goreleaser.yaml` targets.

## Test plan
- `mage build && ./lathe --version` → git-derived version (not `dev`); `lathe version` prints the same.
- `mage check` green (`internal/buildinfo` unit tests cover ldflags / go-install / bare-build cases).