### PR TITLE
feat: embed skills and add lathe skills install (PR B of 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15.0
 
-      # Mirrors local `mage check`: fmt-check, vet, lint, test (-race), build.
+      # Mirrors local `mage check`: fmt-check, skills-check, vet, lint, test (-race), build.
       - name: Run checks
         run: mage check

--- a/cmd/skills-install.go
+++ b/cmd/skills-install.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/devenjarvis/lathe/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var (
+	skillsAgent string
+	skillsUser  bool
+)
+
+var skillsInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Write the bundled skills into Claude Code and/or Cursor",
+	Long: `Write the bundled Lathe skills into an agent's skills/commands directory.
+
+Targets (--agent):
+  claude-code   ./.claude/skills/<name>/SKILL.md   (--user: ~/.claude/skills/...)
+  cursor        ./.cursor/commands/<slug>.md       (slash-invoked as /<slug>)
+  all           both of the above
+
+By default skills install into the current project (cwd). Pass --user to install
+Claude Code skills into your home directory instead. Cursor has no standard
+user-level command directory, so --user with cursor warns and falls back to the
+project ./.cursor/commands directory.
+
+Existing files are overwritten (install is idempotent).`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, err := skills.All()
+		if err != nil {
+			return err
+		}
+
+		var agents []string
+		switch skillsAgent {
+		case "claude-code", "cursor":
+			agents = []string{skillsAgent}
+		case "all":
+			agents = []string{"claude-code", "cursor"}
+		default:
+			return fmt.Errorf("invalid --agent %q (want claude-code, cursor, or all)", skillsAgent)
+		}
+
+		out := cmd.OutOrStdout()
+		total := 0
+		for _, agent := range agents {
+			n, err := installForAgent(out, agent, skillsUser, all)
+			if err != nil {
+				return err
+			}
+			total += n
+		}
+		_, _ = fmt.Fprintf(out, "\nInstalled %d skill file(s).\n", total)
+		return nil
+	},
+}
+
+func init() {
+	skillsInstallCmd.Flags().StringVar(&skillsAgent, "agent", "claude-code", "target agent: claude-code, cursor, or all")
+	skillsInstallCmd.Flags().BoolVar(&skillsUser, "user", false, "install into the user home dir (Claude Code only) instead of the project")
+	skillsCmd.AddCommand(skillsInstallCmd)
+}

--- a/cmd/skills-list.go
+++ b/cmd/skills-list.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/devenjarvis/lathe/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the skills bundled into this binary",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, err := skills.All()
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		for _, s := range all {
+			_, _ = fmt.Fprintf(out, "%-14s %s\n", s.Slug, s.Description)
+		}
+		return nil
+	},
+}
+
+func init() {
+	skillsCmd.AddCommand(skillsListCmd)
+}

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/devenjarvis/lathe/internal/skills"
+	"github.com/spf13/cobra"
+)
+
+// skillsCmd groups the bundled-skill commands (install/list, each in its own
+// file per the one-subcommand-per-file convention). The skills themselves are
+// embedded in the binary (internal/skills), so install works after a plain
+// `brew install` / `go install` with no repo clone.
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "Manage the bundled Lathe skills (install into Claude Code / Cursor)",
+}
+
+// installForAgent writes every skill for one agent and returns the file count.
+func installForAgent(out io.Writer, agent string, user bool, all []skills.Skill) (int, error) {
+	switch agent {
+	case "claude-code":
+		dir, err := claudeSkillsDir(user)
+		if err != nil {
+			return 0, err
+		}
+		_, _ = fmt.Fprintf(out, "Claude Code -> %s\n", dir)
+		count := 0
+		for _, s := range all {
+			dst := filepath.Join(dir, s.Slug, "SKILL.md")
+			if err := writeSkillFile(out, dst, s.Raw); err != nil {
+				return count, err
+			}
+			count++
+		}
+		return count, nil
+
+	case "cursor":
+		if user {
+			_, _ = fmt.Fprintln(out, "note: Cursor has no standard user-level command dir; installing into the project instead.")
+		}
+		dir := filepath.Join(".cursor", "commands")
+		_, _ = fmt.Fprintf(out, "Cursor -> %s\n", dir)
+		count := 0
+		for _, s := range all {
+			dst := filepath.Join(dir, skills.CursorFilename(s))
+			if err := writeSkillFile(out, dst, []byte(skills.CursorCommand(s))); err != nil {
+				return count, err
+			}
+			count++
+		}
+		return count, nil
+	}
+	return 0, fmt.Errorf("unknown agent %q", agent)
+}
+
+// claudeSkillsDir returns the project (./.claude/skills) or user
+// (~/.claude/skills) skills directory.
+func claudeSkillsDir(user bool) (string, error) {
+	if !user {
+		return filepath.Join(".claude", "skills"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "skills"), nil
+}
+
+// writeSkillFile creates parent dirs and writes the file, reporting whether it
+// was newly written or updated.
+func writeSkillFile(out io.Writer, dst string, data []byte) error {
+	verb := "wrote"
+	if _, err := os.Stat(dst); err == nil {
+		verb = "updated"
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir for %s: %w", dst, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	_, _ = fmt.Fprintf(out, "  %s %s\n", verb, dst)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(skillsCmd)
+}

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resetSkillsFlags restores the shared flag vars between cases.
+func resetSkillsFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		skillsAgent = "claude-code"
+		skillsUser = false
+	})
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file %s: %v", path, err)
+	}
+}
+
+func TestSkillsInstallClaudeProject(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	resetSkillsFlags(t)
+
+	skillsAgent = "claude-code"
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	for _, slug := range []string{"lathe", "lathe-ask", "lathe-extend", "lathe-tag", "lathe-verify"} {
+		mustExist(t, filepath.Join(dir, ".claude", "skills", slug, "SKILL.md"))
+	}
+}
+
+func TestSkillsInstallClaudeUser(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Also chdir somewhere clean so a stray project dir can't mask a bug.
+	t.Chdir(t.TempDir())
+	resetSkillsFlags(t)
+
+	skillsAgent = "claude-code"
+	skillsUser = true
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install --user: %v", err)
+	}
+	mustExist(t, filepath.Join(home, ".claude", "skills", "lathe", "SKILL.md"))
+}
+
+func TestSkillsInstallCursorStripsFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	resetSkillsFlags(t)
+
+	skillsAgent = "cursor"
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install cursor: %v", err)
+	}
+	path := filepath.Join(dir, ".cursor", "commands", "lathe.md")
+	mustExist(t, path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if strings.HasPrefix(body, "---") {
+		t.Errorf("cursor command should not start with YAML frontmatter:\n%s", body[:80])
+	}
+	if !strings.Contains(body, "# /lathe") {
+		t.Errorf("expected /lathe header in cursor command")
+	}
+}
+
+func TestSkillsInstallCursorUserFallsBackToProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	resetSkillsFlags(t)
+
+	var buf strings.Builder
+	skillsInstallCmd.SetOut(&buf)
+	t.Cleanup(func() { skillsInstallCmd.SetOut(nil) })
+
+	skillsAgent = "cursor"
+	skillsUser = true
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install cursor --user: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no standard user-level") {
+		t.Errorf("expected a cursor --user warning, got:\n%s", buf.String())
+	}
+	// Falls back to the project dir, not the user home.
+	mustExist(t, filepath.Join(dir, ".cursor", "commands", "lathe.md"))
+	if _, err := os.Stat(filepath.Join(home, ".cursor")); err == nil {
+		t.Errorf("cursor --user should not write into the home dir")
+	}
+}
+
+func TestSkillsInstallAll(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	resetSkillsFlags(t)
+
+	skillsAgent = "all"
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("install all: %v", err)
+	}
+	mustExist(t, filepath.Join(dir, ".claude", "skills", "lathe", "SKILL.md"))
+	mustExist(t, filepath.Join(dir, ".cursor", "commands", "lathe.md"))
+}
+
+func TestSkillsInstallInvalidAgent(t *testing.T) {
+	t.Chdir(t.TempDir())
+	resetSkillsFlags(t)
+	skillsAgent = "vim"
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err == nil {
+		t.Error("expected error for invalid --agent")
+	}
+}
+
+func TestSkillsInstallIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	resetSkillsFlags(t)
+
+	skillsAgent = "claude-code"
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	// Second run must overwrite without error.
+	if err := skillsInstallCmd.RunE(skillsInstallCmd, nil); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	mustExist(t, filepath.Join(dir, ".claude", "skills", "lathe", "SKILL.md"))
+}
+
+func TestSkillsList(t *testing.T) {
+	var sb strings.Builder
+	skillsListCmd.SetOut(&sb)
+	t.Cleanup(func() { skillsListCmd.SetOut(nil) })
+	if err := skillsListCmd.RunE(skillsListCmd, nil); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := sb.String()
+	for _, slug := range []string{"lathe", "lathe-ask", "lathe-extend", "lathe-tag", "lathe-verify"} {
+		if !strings.Contains(out, slug) {
+			t.Errorf("list output missing %q:\n%s", slug, out)
+		}
+	}
+}

--- a/internal/skills/cursor.go
+++ b/internal/skills/cursor.go
@@ -1,0 +1,59 @@
+package skills
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CursorCommand renders a skill as a Cursor command file.
+//
+// Cursor invokes the file at .cursor/commands/<slug>.md as the slash command
+// /<slug>. Cursor does not use Claude Code's YAML frontmatter, so we strip it
+// and prepend a plain Markdown title + description header. The body (the bash
+// `lathe ...` calls and prose guidance) is preserved verbatim -- it reads fine
+// as Cursor instructions. We deliberately do not port the interactive-handoff
+// runtime model here; trigger + body only (see CLAUDE.md / the install caveats).
+func CursorCommand(s Skill) string {
+	body := stripFrontmatter(string(s.Raw))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# /%s\n\n", s.Slug)
+	if s.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", s.Description)
+	}
+	b.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// CursorFilename maps a skill slug to its Cursor command filename.
+func CursorFilename(s Skill) string {
+	return s.Slug + ".md"
+}
+
+// stripFrontmatter removes a leading "---"-delimited YAML block (if present) and
+// returns the remaining body with leading blank lines trimmed.
+func stripFrontmatter(s string) string {
+	// strings.Split always returns at least one element, so lines[0] is safe.
+	lines := strings.Split(s, "\n")
+	// The first line must be exactly the opening fence (tolerate a trailing \r).
+	if strings.TrimRight(lines[0], "\r") != "---" {
+		return s
+	}
+	// Find the closing fence after the opening one.
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end == -1 {
+		// Malformed frontmatter: leave the content untouched.
+		return s
+	}
+	body := strings.Join(lines[end+1:], "\n")
+	return strings.TrimLeft(body, "\n")
+}

--- a/internal/skills/cursor_test.go
+++ b/internal/skills/cursor_test.go
@@ -1,0 +1,66 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCursorCommandStripsFrontmatterKeepsBody(t *testing.T) {
+	s := Skill{
+		Slug:        "lathe",
+		Name:        "lathe",
+		Description: "Generate hands-on technical tutorials.",
+		Raw: []byte("---\nname: lathe\ndescription: Generate.\n---\n\n" +
+			"# Lathe\n\nRun `lathe store --tag foo`.\n"),
+	}
+	out := CursorCommand(s)
+
+	if strings.Contains(out, "---") {
+		t.Errorf("Cursor output should not contain YAML frontmatter fences:\n%s", out)
+	}
+	if !strings.HasPrefix(out, "# /lathe\n") {
+		t.Errorf("expected a /lathe title header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Generate hands-on technical tutorials.") {
+		t.Errorf("expected the description header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "lathe store --tag foo") {
+		t.Errorf("body bash invocation was dropped:\n%s", out)
+	}
+}
+
+func TestCursorCommandRealSkillsPreserveInvocations(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+	byslug := map[string]Skill{}
+	for _, s := range all {
+		byslug[s.Slug] = s
+	}
+
+	// Spot-check that key CLI handoffs survive translation.
+	checks := map[string]string{
+		"lathe":        "lathe store",
+		"lathe-verify": "lathe verify-result",
+	}
+	for slug, want := range checks {
+		s, ok := byslug[slug]
+		if !ok {
+			t.Fatalf("skill %q not found", slug)
+		}
+		out := CursorCommand(s)
+		if strings.HasPrefix(out, "---") {
+			t.Errorf("%s: frontmatter not stripped", slug)
+		}
+		if !strings.Contains(out, want) {
+			t.Errorf("%s: expected %q in Cursor output", slug, want)
+		}
+	}
+}
+
+func TestCursorFilename(t *testing.T) {
+	if got := CursorFilename(Skill{Slug: "lathe-ask"}); got != "lathe-ask.md" {
+		t.Errorf("CursorFilename = %q, want lathe-ask.md", got)
+	}
+}

--- a/internal/skills/data/lathe-ask/SKILL.md
+++ b/internal/skills/data/lathe-ask/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: lathe-ask
+description: Answer a reader's question about a specific part of a Lathe tutorial, in session. Use when the user invokes /lathe-ask with a slug and part like "/lathe-ask digital-synth-zig part-02.md" followed by the question on the next line (the "Ask" button in `lathe serve` pastes exactly this).
+---
+
+# Lathe — Ask About a Part
+
+Answer a reader's question about one part of a stored tutorial, grounded in what that tutorial actually built. Triggered by:
+
+```
+/lathe-ask <slug> <part-NN.md>
+<the reader's question>
+```
+
+The web "Ask" button pastes exactly that: the slug and part on the command line, the question on the next line. Parse all three.
+
+## Protocol
+
+1. **Read the part** at `~/.lathe/tutorials/<slug>/<part-NN.md>`. Read sibling parts (`part-NN.md` in the same dir) when the question reaches across parts or depends on earlier setup — continuity matters here too.
+
+2. **Answer grounded in this tutorial's concrete artifact** — the same controlling example, the same numbers, the same voice the tutorial used. The reader is asking about *their* synth / *their* key-value store, not the topic in the abstract. Don't re-teach the whole topic from scratch.
+
+3. **Point at the tutorial, don't re-derive it.** Prefer "look at the `process_buffer` loop in §3 — the modulo there is doing X" over a fresh ground-up explanation. You're a guide standing next to them at the page they're reading.
+
+4. **Be honest about gaps.** If the question exposes something the tutorial got wrong, glossed over, or left under a `[!UNVERIFIED]` flag, say so plainly — don't paper over it. That's more useful than a confident hand-wave.
+
+5. **Stay engaged** for follow-ups. This is a conversation, not a one-shot reply.
+
+## Boundaries — read-only, conversational
+
+- **There is no `lathe ask` command.** This skill writes nothing and calls back into no CLI command — ask is deliberately conversation-only.
+- **No state mutation:** don't touch `metadata.json`, `verify-result.json`, or the part markdown. Don't verify, don't extend, don't tag.
+- Keep answers specific to this tutorial's concrete artifact, in its voice.

--- a/internal/skills/data/lathe-extend/SKILL.md
+++ b/internal/skills/data/lathe-extend/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: lathe-extend
+description: Write the next part of an existing Lathe tutorial, in session. Use when the user invokes /lathe-extend with a slug like "/lathe-extend digital-synth-zig" (the "Add a new part" button in `lathe serve` hands you that command), optionally followed by guidance for where the part should go.
+---
+
+# Lathe — Extend a Tutorial
+
+Add the next part to a stored tutorial. Triggered by `/lathe-extend <slug> [guidance…]`. The new part must continue *that* tutorial — its example, its numbers, its voice — not a fresh generic one. Everything about shape, voice, research discipline, and callouts comes from the **`lathe`** skill; read it and apply it. This skill only adds what's different about extending: continuity and the `extend-start → write → extend-commit` handshake.
+
+## Protocol
+
+1. **Absorb the existing tutorial.** Read every part in `~/.lathe/tutorials/<slug>/` (`part-NN.md`). You need the load-bearing context before you write a word:
+   - The **controlling example** and the **fixed numbers** (sample rate, page size, buffer size) — reuse them exactly; don't invent new ones.
+   - The **controlling metaphor**, if any, and whether a prior part already retired it (if retired, don't resurrect it).
+   - The **voice** and the level of the reader.
+   - The **repo and pinned tool versions** in `metadata.json` (`repo`, `repo_branch`, `tools`) — the new part *inherits* them. Write against the same versions; don't silently bump to a newer toolchain. (If the reader explicitly wants to move the tutorial to a new version, that's a heads-up that it may be time for a fresh tutorial, not a quiet drift — flag it rather than re-pinning here.)
+   - Where the previous part's **"What's next"** pointed — that's your mandate for this part unless the user's guidance redirects it.
+
+2. **Research first.** Same discipline as the `lathe` skill's "Research first" step: actually open 3–8 authoritative sources for whatever this new part introduces, take notes with URLs beside the load-bearing facts, and ground or `[!UNVERIFIED]`-flag every load-bearing claim. New material gets the same scrutiny as Part 1 did. No web access? Say so in one line and write conservatively, flagging the load-bearing unknowns.
+
+3. **Reserve the part.** Run:
+   ```bash
+   lathe extend-start <slug>
+   ```
+   It prints a single filename (e.g. `part-02.md`) and sets status `extending`. **Capture that exact filename.** If it errors with "already extending or verifying", stop and tell the user — something is mid-flight; don't force it.
+
+4. **Write the part** to `~/.lathe/tutorials/<slug>/<printed-filename>`.
+   - **This is the one allowed content write.** The skill writes the part markdown directly into the tutorial dir at the reserved path — that is required and deliberate, because `lathe extend-commit` `os.Stat`s the file there before registering it. (Future reader: don't "fix" this by routing it through a CLI command. There is no such command; the binary owns *metadata*, the skill writes the *part body*.)
+   - Follow the full **Tutorial shape** from the `lathe` skill — hook, `## What you'll build`, prerequisites, specific section titles, `## Checkpoint`, `## What's next`, `## Exercises`, `## Sources`. Each part stands alone and ends with a Checkpoint.
+   - Because this is **Part N ≥ 2**, open with a `> [!RECALL]` spaced-retrieval beat: one question on a load-bearing concept from a prior part, phrased so the reader must reconstruct the answer (not just recognize it). See the `lathe` skill's recall before/after.
+   - **One file, this part only.** Don't write `index.md`, don't touch earlier parts, don't write more than one part.
+
+5. **Commit the part.** Run:
+   ```bash
+   lathe extend-commit <slug> <printed-filename> [--source <url> …]
+   ```
+   Pass `--source` once for each source you newly consulted for this part — it folds them into the tutorial's research trail (de-duped). This registers the part, clears the pending marker, and resets status to `unverified`.
+
+6. **Tell the user** it's added: how to view it (`lathe serve`), and that verification is opt-in (`/lathe-verify <slug>` — the "Verify this tutorial" button hands you that command). Then stay in session for follow-ups.
+
+## Boundaries
+
+- The **only durable-state writes** are `lathe extend-start` and `lathe extend-commit`. Never edit `metadata.json` directly.
+- Writing the reserved part-content file into the tutorial dir is the sole content write — and it's required (step 4).
+- Don't verify, don't write `index.md`, don't write multiple parts, don't edit existing parts.
+
+## Stay in session
+
+You're still their expert guide. Stay available for "make this part harder", "why did we structure it this way", "how'd I do on the checkpoint".

--- a/internal/skills/data/lathe-tag/SKILL.md
+++ b/internal/skills/data/lathe-tag/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: lathe-tag
+description: Pick or backfill the search tags on a stored Lathe tutorial, in session. Use when the user invokes /lathe-tag with a slug like "/lathe-tag digital-synth-zig" to choose good tags for the `lathe serve` search and tag filters, or to backfill tags on a tutorial that has none.
+---
+
+# Lathe — Tag a Tutorial
+
+Choose the tags that make a stored tutorial findable in `lathe serve`'s search and tag filters. Triggered by `/lathe-tag <slug>`.
+
+## Protocol
+
+1. **Read the tutorial** at `~/.lathe/tutorials/<slug>/` to understand what it actually teaches.
+
+2. **Pick 2–5 lowercase, reusable tags.** Same vocabulary guidance as the `lathe` skill's tag step: cover, where they apply —
+   - the **language/runtime** — `zig`, `rust`, `go`;
+   - the **domain** — `audio`, `compilers`, `databases`;
+   - the **core technique** — `parsing`, `dsp`, `concurrency`.
+
+   Prefer short, reusable tags that will group naturally with other tutorials over hyper-specific one-offs. Don't pre-lowercase or de-dupe defensively — `store.NormalizeTags` is the one place that canonicalizes (trim, lowercase, de-dupe), so just pass sensible tags and let it normalize.
+
+3. **Persist them.** To set the whole tag list (the usual case — choosing or replacing tags):
+   ```bash
+   lathe tag <slug> --set zig --set audio --set dsp
+   ```
+   For incremental edits to an existing set, use `--add` / `--remove` instead:
+   ```bash
+   lathe tag <slug> --add embedded
+   lathe tag <slug> --remove misc
+   ```
+   `--set` replaces the entire list; `--add`/`--remove` edit it in place. All three are repeatable and accept comma-separated values.
+
+4. **Report the resulting tag set** to the user (the command prints it).
+
+## Boundaries
+
+- Only touches tags, and only via `lathe tag`. Never edit `metadata.json` directly.
+- No generation, verification, or extension — just tags.

--- a/internal/skills/data/lathe-verify/SKILL.md
+++ b/internal/skills/data/lathe-verify/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: lathe-verify
+description: Verify that a stored Lathe tutorial actually works by following it end to end in a fresh scratch dir, in session. Use when the user invokes /lathe-verify with a slug like "/lathe-verify digital-synth-zig" (the "Verify this tutorial" button in `lathe serve` hands you that command).
+---
+
+# Lathe — Verify a Tutorial
+
+Follow a stored tutorial exactly as a reader would, in a throwaway directory, and record whether it actually works. Triggered by `/lathe-verify <slug>`. Isolation is **by instruction** — a fresh `mktemp -d`, under the user's normal interactive permissions. No sandbox-exec, no Docker.
+
+This skill is **read-only with respect to the tutorial**: never edit the parts or the metadata. The only writes are status updates through `lathe verify-result`.
+
+## Protocol
+
+1. **Mark it in-flight first:**
+   ```bash
+   lathe verify-result <slug> --status verifying
+   ```
+   This sets the spinner badge in the web UI. If it errors with "cannot verify while it is extending", stop — a part is mid-flight; don't verify on top of it.
+
+2. **Make a fresh scratch dir and work there:**
+   ```bash
+   cd "$(mktemp -d)"
+   ```
+   Everything the tutorial tells the reader to create happens here, not in the user's project. (Status is set by *this skill*, never by the web/CLI button — so an unclicked button can never strand a tutorial at `verifying`.)
+
+3. **Follow each part in order.** Read `~/.lathe/tutorials/<slug>/part-NN.md` from `part-01` up. Install the prerequisites, create the files and paste the code blocks exactly as written, in order, then run the `## Checkpoint` command and compare against the stated expected output.
+   - **Skip the pedagogical and provenance callouts** — `> [!PREDICT]`, `> [!RECALL]`, and `> [!UNVERIFIED]` are not verifiable steps. They prompt the reader or flag uncertainty; there's nothing to execute.
+   - Treat the Checkpoint commands and code blocks as the executable surface.
+
+4. **Record the terminal result** with the matching command:
+   - **Everything works** → `lathe verify-result <slug> --status verified`
+   - **A required tool isn't installed** → `lathe verify-result <slug> --status skipped`
+     This is **not a failure** — it's the ⚠️ Skipped badge, meaning "couldn't run it here," not "the tutorial is wrong." Use it whenever the toolchain the tutorial needs (compiler, runtime, SDK) is missing locally.
+   - **Something genuinely breaks** (wrong output, code doesn't compile, a step contradicts itself) →
+     ```bash
+     lathe verify-result <slug> --status failed \
+       --part <part-NN.md> \
+       --failed-step <1-indexed step number within that part> \
+       --error "<the error message or mismatched output>"
+     ```
+
+5. **Report to the user** what happened — verified clean, skipped (and which tool was missing), or where exactly it failed.
+
+## Boundaries
+
+- **Read-only on the tutorial.** Never edit a `part-NN.md`, `metadata.json`, or `verify-result.json` directly — the only state writes are via `lathe verify-result`.
+- **No OS sandboxing.** Isolation is the `mktemp -d` scratch dir plus instruction, under the user's normal permission model. Don't reach for sandbox-exec or Docker.
+- **Skipped ≠ failed.** A missing toolchain is `skipped`. Reserve `failed` for the tutorial being genuinely broken.
+- Status is always set by this skill, never by the handoff button.

--- a/internal/skills/data/lathe/SKILL.md
+++ b/internal/skills/data/lathe/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: lathe
+description: Generate hands-on technical tutorials for any topic on demand. Use when the user invokes /lathe with a topic like "/lathe build a digital synth in Zig" or "/lathe how to build a compiler in Rust".
+---
+
+# Lathe — Tutorial Generator
+
+Generate hands-on technical tutorials for any topic on demand. The bar is the writing of Robert Nystrom (Crafting Interpreters), Sam Who, Julia Evans, Bartosz Ciechanowski. Match it.
+
+## When invoked
+
+The user says something like `/lathe build a digital synth in Zig` or `/lathe how to build a compiler in Rust`. Extract the topic from their message.
+
+1. Ask: **"What's your experience level going in — beginner, some familiarity, or experienced in adjacent areas?"**
+2. If the topic is genuinely ambiguous (language? scale? embedded vs. server?), ask **one** clarifying question. Otherwise skip.
+3. **Pin the repo and toolchain versions** (see "Pin the repo and versions" below) — do this *before* you research or write, so the tutorial is rooted in the exact versions the reader will use.
+4. **Research the topic first** (see below) — this is the single most important step for accuracy. Lathe exists to teach things with little training material behind them, which is exactly where recalled "knowledge" is most likely to be invented. Don't skip it.
+5. Run the **Pre-flight** in your head — silently. Don't ask the user to approve the choices.
+6. Write Part 1.
+7. Hand off to the CLI — clear the **pre-store gate** in "After writing" (state repo, versions, tags, sources or a justified opt-out) *before* running `lathe store`.
+
+## Pin the repo and versions (before research)
+
+Lathe is for **programming tutorials**, and a tutorial is only as trustworthy as the versions it's rooted in. Settle two things before you research or write, then pass them to `lathe store` (see "After writing"). Both flow into `lathe serve`: tutorials are grouped by repo, and the versions show as chips with their own filter — so an old tutorial written against a stale toolchain is identifiable at a glance.
+
+**1. The repo (auto-detect, then confirm).** If this session is inside a git repo the tutorial is *for*, capture it. Detect it:
+
+```bash
+git -C "$PWD" remote get-url origin 2>/dev/null   # the remote (preferred grouping key)
+git -C "$PWD" branch --show-current 2>/dev/null    # the branch
+```
+
+Show the reader what you found — e.g. *"This looks like it's for **devenjarvis/lathe** (branch `main`) — group it there?"* — and let them confirm, correct, or say it's a standalone tutorial with no repo. If there's no remote, no git repo, or the reader says it's standalone, skip the repo (it lands in the "No repo" group). `lathe store` canonicalizes whatever URL you pass to `host/org/repo`, so the raw `origin` URL is fine.
+
+**2. The toolchain versions (detect, then confirm).** Figure out which languages/tools the tutorial will lean on, probe the versions actually installed, and **confirm the target with the reader before you write** — getting this wrong means the whole tutorial teaches against the wrong version. Probe whatever's relevant:
+
+```bash
+zig version            # → 0.13.0
+go version             # → go1.22.3
+node --version         # → v20.11.0
+rustc --version        # → 1.75.0
+```
+
+Propose them — *"I'll write this against **Zig 0.13.0** and **LLVM 18** — sound right, or do you want a different target?"* — and adjust to whatever the reader says (they may want an older version on purpose). These pinned versions are now a constraint on your prose: cite version-specific behavior accordingly, and if a fact is version-sensitive, anchor it to the pinned version.
+
+## Research first (do this before drafting)
+
+Before you write a single sentence, **go read**. Use your web search and fetch tools to find and *actually open* 3–8 authoritative sources for this topic — official docs, specs/RFCs, primary papers, source code, well-regarded deep-dives. Don't reconstruct them from memory.
+
+- **Read for the load-bearing facts** you'll commit to in the tutorial: exact API/function signatures, default values, flag names, version numbers, sample rates, page sizes, semantic guarantees, error messages, historical claims. Take notes with the URL beside each fact — deep-link to the section or anchor, not the homepage.
+- **Ground the prose in what you read, not what you recall.** When a source contradicts your memory, the source wins. When you can't find a source for a load-bearing claim, that's not a green light to assert it confidently — mark it with `[!UNVERIFIED]` (see Callouts) and tell the reader what to check.
+- **Keep the list of URLs you consulted.** You'll cite the load-bearing ones inline, list them in each part's `## Sources`, and pass them to `lathe store --source` (see "After writing") so the research trail is recorded as provenance.
+- **No web tools in this session?** Say so to the user in one line ("Heads up — I don't have web access here, so I'm working from training knowledge; I've marked the load-bearing claims I couldn't confirm"). Then write more conservatively: claim fewer exact numbers, prefer "check your version's docs" over a guessed default, and `[!UNVERIFIED]`-flag the load-bearing unknowns (still only the load-bearing ones — don't paper the page with caveats).
+
+## Always write Part 1 only
+
+Every `/lathe` invocation produces exactly one file: `part-01.md`. Never write multiple parts in one shot and never write `index.md`. Readers add more parts via the "Add a new part" button in `lathe serve`, which gives them full control over pacing and direction.
+
+## Pre-flight (private — do not ask the user)
+
+Before writing a single sentence, settle these in your head. They are constraints on your prose, not user-facing artifacts.
+
+- **Research and sources.** You've already done the **Research first** step above — by now you've actually read 3–8 authoritative sources and have URLs beside the load-bearing facts. Hold those notes in front of you as you write: cite the load-bearing ones inline, list them in `## Sources`, and `[!UNVERIFIED]`-mark anything you couldn't confirm. A load-bearing claim — a number, a default, a semantic guarantee, a historical fact — is either grounded in a source you read or flagged; it is never asserted from recall as if settled.
+- **The controlling example.** Pick one concrete artifact and stay with it. Crafting Interpreters has Lox. You might have *"a 4-voice subtractive synth playing a sustained A minor triad"* or *"a key-value store called `pebble` that survives `kill -9`"*. Don't switch examples mid-tutorial.
+- **Specific numbers.** Sample rate, buffer size, page size, table cardinality, latency budget — whatever the domain offers. Numbers are how you earn the reader's trust. Decide them now so they're consistent across parts.
+- **One controlling metaphor (optional but powerful).** A mountain. A factory line. A kitchen. If you adopt one, deploy it across at least three section transitions, then *explicitly retire it* with a wink (Nystrom: *"Henceforth, I promise to tone down the whole mountain metaphor thing."*). Don't mix metaphors silently.
+- **The closing send-off.** What do you want the reader ready to do *beyond* what you taught? Sketch the "go climb your own mountain" beat now so the body builds toward it.
+- **3–5 exercises.** Each specific enough that a motivated reader could start it in 30 seconds.
+
+## Tutorial shape
+
+Every tutorial (or series part) follows this shape, but section *titles* must be specific to the domain. Never `## Step 1: Setup`. Title the thing the section makes: `## A scanner that recognises one-character tokens`.
+
+```
+# [Title]
+
+[Hook — 2 to 4 paragraphs. See "Openings".]
+
+## What you'll build
+
+One paragraph. The concrete end state, named with the controlling example.
+
+## Prerequisites
+
+Bullets: tools to install, what the reader should already roughly know.
+
+## [Specific section title — name what this section makes]
+
+Why this exists. Then code, in small blocks, each with an insertion point.
+Aside or design note where it earns its keep.
+
+## [...]
+
+## Checkpoint
+
+> [!PREDICT]
+> Before you run this: what output do you expect to see?
+
+**Run this to verify your work so far:**
+\`\`\`bash
+<the exact command>
+\`\`\`
+
+Expected output:
+\`\`\`
+<what they should see>
+\`\`\`
+
+**Likely errors:**
+- If you see `<exact error text>`, you probably <short causal explanation, e.g. "skipped the import in §2">.
+- If you see `<exact error text>`, you probably <short causal explanation>.
+
+## What's next
+
+One paragraph naming the unanswered question a future part will answer. Include in every part — it invites the reader to continue.
+
+## Exercises
+
+1. <specific>
+2. <specific>
+3. <specific>
+
+## Sources
+
+1. [Title](url) — one sentence on why this source matters for the topic.
+2. ...
+
+(Numbered list. Only sources cited inline. Each entry: `[Title](url) — one sentence`. Group by primary docs / papers / deep-dives if more than ~5 entries.)
+```
+
+Every part opens with *"By the end of this part, you'll have [specific, concrete thing]"* and closes with a Checkpoint. Every part stands alone with its own `## Exercises` and `## Sources` — since any part may become the last one the reader sees, each must be independently complete.
+
+## Openings
+
+The first sentence has one job: prove this won't be another "in this tutorial we will" page. Pick one of:
+
+- **Concrete scene.** *"It's 3 a.m., production just went vertical, and the only graph still climbing is p99 latency."* Earn the rest by being equally specific from sentence two onward.
+- **A claim worth fact-checking.** *"A modern CPU runs roughly a billion arithmetic operations in the time it takes to read one byte from main memory."* Then make that fact matter to what you're building.
+- **Epigraph.** A short, attributed quote that frames the chapter. Use sparingly — once per series at most.
+- **The reader's confusion, named as a statement.** *"If you've read about hash tables and walked away unsure when 'open addressing' is supposed to beat chaining — this is for you."* Don't phrase it as a question.
+
+**Banned first sentences:**
+
+- "In this tutorial, we will…"
+- "This post explains…"
+- "Have you ever wondered…"
+- "Welcome to…"
+- "Let's dive in."
+
+## Voice
+
+You are not a docs page. You are a friend who has done this before, sitting next to the reader at the keyboard, with *opinions*. Warm, specific, a little wry — never corporate, never breathless. The energy of a really good conference talk: confident, informal, surprisingly honest about where things get weird.
+
+### Discipline moves — do these
+
+- **Have a point of view.** *"The official docs gloss over this; the reason X is awkward is…"*. Pick a side on tradeoffs. Don't both-sides everything.
+- **Name the trapdoors before they fall in.** *"Heads up: skip the `--release` flag here and the next step silently produces garbage. You'll spend an hour wondering why."*
+- **Show the obviously-wrong version first, then the fix.** Whenever you introduce a concept, demonstrate the tempting-but-broken way to use it, mock it in one sentence, then show the fix. The reader needs to *feel* why the fix matters, not be told. (Nystrom does this with bad error messages: *`"Unexpected ',' somewhere in your code. Good luck finding it!"`* — *"That's not very helpful,"* — and then the version with column info.)
+- **Define a term, then immediately give the insider name.** *"**Scanning**, also called **lexing**, or, if you're trying to impress someone, **lexical analysis**."* Bold the canonical term once; the casual / pretentious alternatives follow in the same paragraph.
+- **Real names from the domain. Never `foo` / `bar`.** A `Synth` has an `oscillator` and an `envelope`, not a `Foo` with a `bar`. Concrete names make the mental model land.
+- **Specific numbers, every time.** *"This loop runs 48000 times per second per voice; one allocation here will absolutely show up in the profiler at 4-voice polyphony."* "Slow" is forgettable. `48000` isn't.
+- **Iterate code; don't dump it.** Show 3–15 line blocks. When the block modifies earlier code, name the seam: *"Inside `process_buffer`, just after the `for voice in voices` loop, add:"*. Never paste a 60-line file in one shot.
+- **Admit the cut.** At least once per major section, name something you're *not* doing and the boring/ugly/over-engineered reason — in first person. *"I tried a generic ring buffer first; tore it out three days later because the indirection cost more than I saved."* Beats *"this approach was rejected."*
+- **Specify weird input.** Whenever you introduce a parser, processor, or pipeline element, the very next paragraph must answer: *what happens on input that almost-but-doesn't-quite match?* In body text, not a footnote. *"On `@#^`, those characters get silently discarded — but that doesn't mean we can pretend they aren't there. Here's how we report them."*
+- **Em-dashed self-correction.** Roughly once per 800 words, visibly second-guess yourself. *"It pains me to skip the proof, but —"*. *"I went back and forth on this — the answer that won was —"*. This is what makes prose feel written *to* a reader, not *at* one.
+- **Forward-pointing endings, not recaps.** End each section by naming the question the next section answers. The reader was just there; don't summarise.
+- **Cite inline the first time a load-bearing fact lands.** When you introduce a spec section, a canonical term, a number, or a behaviour claim that the reader might want to verify, link it on first mention — markdown `[text](url)`. Deep-link to the exact section or anchor, not the homepage. Every source used inline must appear in `## Sources`.
+- **Ground or flag — never bluff.** Every load-bearing claim has exactly one of two fates: a source you actually read (cite it inline) or, if you couldn't find one, an `[!UNVERIFIED]` callout that names what to check. The failure mode this kills is the confident-but-invented default, flag, or signature — the thing the reader copies, runs, and loses an hour to. On a sparse-data topic that risk is highest; treat "I'm fairly sure it's X" as a flag, not a fact.
+
+### Avoid
+
+- LinkedIn voice. No *leverage, robust, powerful, seamless(ly), in today's fast-paced world, we're excited to*.
+- Hype words that don't carry information: *amazing, awesome, simply, just, easy, effortless*. If something is easy, the reader will discover that themselves; if you tell them and it isn't, you've lost them.
+- Throat-clearing intros. Cut *In this tutorial…*, *Let's dive in*, *Welcome*.
+- Hedging tics: *you might want to consider perhaps possibly*. Just say it.
+- Bot tells: bulleted lists of three sibling sentences each starting with the same verb; the phrase *Let's dive in*; emojis that aren't already in the codebase.
+- Empty cheerleading. *"You've got this!"* wastes the reader's time.
+
+### Voice calibration — before / after
+
+> ❌ "In this section, we will leverage Zig's powerful comptime system to seamlessly generate efficient lookup tables."
+>
+> ✅ "We're going to build the sine table at compile time. Zig's `comptime` is the right tool — it runs ordinary Zig code during compilation, so the table ends up baked into the binary as a static array, no init cost. The first time you see it, it feels like cheating."
+
+> ❌ "Let's now create our oscillator. This is an important step!"
+>
+> ✅ "Now the oscillator. This is the part that actually makes sound — everything before now has been plumbing."
+
+> ❌ "We've now built the oscillator and the filter."
+>
+> ✅ "The filter sounds like a filter — but with one note held it whines forever, which is what envelopes are for."
+
+**Inline citation — before / after:**
+
+> ❌ "Zig's `comptime` runs code at compile time, producing zero runtime overhead."
+> *(Load-bearing claim — zero overhead is a semantic guarantee — but the reader has no way to verify it or dig deeper.)*
+>
+> ✅ "Zig's [`comptime`](https://ziglang.org/documentation/master/#comptime) runs ordinary Zig code during compilation. The result is baked into the binary as a static array — [zero runtime overhead, by language guarantee](https://ziglang.org/documentation/master/#comptime). The first time you see it, it feels like cheating."
+> *(Same voice, same warmth — but the load-bearing claims carry a link. A sceptical reader can follow either one and land in the actual spec.)*
+
+**Prediction beat — before / after:**
+
+> ❌ *(no prediction; reader runs the command cold and either succeeds or is confused)*
+>
+> ✅
+> ```markdown
+> > [!PREDICT]
+> > Before you run this: the sine table has 1024 entries. What will `@sizeOf(@TypeOf(sine_table))` print?
+> ```
+> *(The answer — 4096 bytes — lands harder because the reader committed to a number first.)*
+
+**Recall beat — before / after (Part 2 opening):**
+
+> ❌ "In Part 2 we'll add the filter. First, a quick recap: in Part 1 we built the oscillator, which…"
+> *(Recap re-presents; the reader recognises, not recalls. No retrieval benefit.)*
+>
+> ✅
+> ```markdown
+> > [!RECALL]
+> > Quick recall before we continue: what does `write_pos % BUFFER_SIZE` accomplish, and what breaks if you forget the modulo?
+> ```
+> *(The reader must reconstruct the answer — if they can't, that's signal. If they can, the retrieval strengthens the memory.)*
+
+**Faded scaffolding — before / after:**
+
+> ❌ "Now add the Release stage:" *(followed by a fully worked block)*
+> *(Reader copies. Nothing to think about. Forgotten by tomorrow.)*
+>
+> ✅ "You've seen how `Attack` ramps from 0 to 1 over `attack_samples`. The `Release` stage does the mirror image — ramp from 1 back to 0 over `release_samples`. Write it now, using the same loop shape, then run the Checkpoint below."
+> *(One step ahead of what was shown. Pattern is in front of them. Effort is real but not punishing.)*
+
+**Closing reflection — before / after:**
+
+> ❌ "Great work! You've built a ring buffer, an oscillator, and a filter."
+> *(Cheerleading. The reader knows what they built.)*
+>
+> ✅ "Before you try the exercises: in two sentences, why does the ring buffer beat a `sync.Mutex`-guarded slice here? Write the answer that would satisfy a sceptical colleague."
+> *(Forces construction, not recognition. Surfaces gaps before the reader walks away.)*
+
+## Asides and design notes
+
+Two distinct sidebar types, two different jobs. Lathe renders both as styled callouts.
+
+**Aside** — short, inline, one or two sentences. Etymology, war story, a "by the way", a one-line joke that earns its keep. Lives next to the prose that triggered it.
+
+````markdown
+> [!ASIDE]
+> "Lex" is from the Greek *lexis*, meaning "word." Stash that for the next time someone smugly explains "lexical scope."
+````
+
+**Design note** — multi-paragraph digression on *why this is the way it is*: cross-language survey, a tradeoff explored honestly, "how the grown-ups do it." Lives at the **end** of a section, never mid-step.
+
+````markdown
+> [!DESIGN-NOTE]
+> **Why ring buffers and not channels?**
+>
+> A few words on the alternative …
+````
+
+Other callout types:
+
+- `> [!HEADS-UP]` — trapdoors. Things that will break in 20 minutes if the reader isn't warned now.
+- `> [!NOTE]` — neutral side info.
+- `> [!TIP]` — handy shortcut, not load-bearing.
+- `> [!PREDICT]` — prediction prompt before a Checkpoint or surprising output. One line only.
+- `> [!RECALL]` — spaced-retrieval prompt at the top of Part N≥2. One question, load-bearing concept only.
+- `> [!UNVERIFIED]` — a **genuinely load-bearing** claim you could not ground in a source you read: one the reader will *act on* and that would cost them real time if it's wrong (a default they'll rely on, a flag they'll type, a signature they'll call). State what you believe and, in the same breath, what to check. *"The default ring-buffer size is 4096 frames — I'm working from memory here and couldn't find this in the docs; confirm it with `default_config()` before you rely on it."* Reserve it for those; not for ordinary hedging or background colour you're merely unsure about. If a claim isn't load-bearing, either confirm it or cut it — don't flag it.
+
+Use them sparingly — `[!UNVERIFIED]` included. Reach for it only when a load-bearing unknown genuinely warrants it (a little more often when you had no web access, but still only for the load-bearing ones). One or two of the others per part, max; a page peppered with caveats reads as low-confidence and is its own kind of clutter. `[!PREDICT]` and `[!RECALL]` are pedagogical, and `[!UNVERIFIED]` is a provenance signal — the verifier skips all three.
+
+## Visual artifacts
+
+Diagrams earn their keep when they show something prose can't:
+
+- A *transformation* (input shape → output shape).
+- A *pipeline* (who hands off to whom).
+- A *relationship between sets* (Venn-style, taxonomy).
+
+**Don't diagram a sequence of steps.** That's what numbered prose is for.
+
+Tools, by job:
+
+- **Mermaid `flowchart` / `graph`** — pipelines, decision branches, architecture.
+- **Mermaid `sequenceDiagram`** — request/response, message passing.
+- **Mermaid `stateDiagram-v2`** — protocol states, parser modes, lifecycles.
+- **Mermaid `erDiagram`** — schemas and table relationships.
+- **Markdown tables** — comparing 2–5 alternatives across a few axes ("which allocation strategy when?"). Tables beat prose for this.
+- **ASCII art in a code block** — memory layouts, byte structures, tree shapes that need column alignment.
+
+Aim for **one diagram per part**, only when a moment in that part genuinely benefits. Place it next to the prose that explains it; never drop one in cold without a sentence framing what to look at first. Cap nodes at ~10 — split or convert to a table if larger.
+
+````markdown
+```mermaid
+flowchart LR
+  Source[MIDI input] --> Parser
+  Parser --> Voice[Voice allocator]
+  Voice --> Osc[Oscillator]
+  Osc --> Filter
+  Filter --> Out[Audio buffer]
+```
+````
+
+## Code
+
+- One sentence before every block, telling the reader what to look at first.
+- Blocks are 3–15 lines, except for full small files. Larger means split.
+- For modifications, name the seam: *"Inside `process_buffer`, just after the voices loop:"*. The reader has to find where to splice.
+- No unexplained `...` ellipses. If you elide, name what's elided and why.
+- Code is complete enough to run as shown. The reader copies, saves, and sees something predictable happen.
+
+**Faded scaffolding:** The first code block in each part (or tutorial) is fully worked — reader copies, saves, runs, sees output. The last one or two code blocks shift to fill-the-seam: name the pattern the reader has seen, then ask them to write the next instance. *"You've seen how the `Attack` stage ramps from 0 to 1. Using the same pattern, write the `Release` stage — it ramps from 1 back to 0 over `release_time` samples. Then run the Checkpoint."* This is not an open exercise: the reader has the template in front of them and takes exactly one step ahead of where you stopped.
+
+## Endings
+
+Every major section ends with a one-sentence forward-pointer naming the question the next section answers.
+
+Every part ends with **four** things:
+
+1. **A send-off (or forward hook).** For the final part: one short paragraph inviting the reader to leave the path you took. For non-final parts: a single forward-pointing sentence naming the question the next part will answer — lean into the cliffhanger.
+2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in this part and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
+3. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
+4. **`## Sources`**, numbered, one entry per source used inline in *this part*. Format: `[Title](url) — one sentence on why this source matters`. Group by primary docs / papers / deep-dives if more than ~5 entries.
+
+## Output files
+
+Write to `/tmp/lathe-<slug>/`. Slug is the topic in kebab-case.
+
+- "build a digital synth in Zig" → `/tmp/lathe-digital-synth-zig/`
+- Always: `part-01.md` — one file, zero-padded so it sorts cleanly.
+
+Decide the slug before writing. Never write `index.md` or multiple parts.
+
+## After writing
+
+> [!HEADS-UP]
+> **STOP — pre-store gate. Fill this in before you run `lathe store`.** Repo and
+> versions get silently dropped when the store call is reached without them, so
+> every store *must* state a concrete value or an explicit, justified opt-out for
+> all four flag groups. Omission without a stated reason is not allowed:
+>
+> - **Repo (`--repo` / `--repo-branch`)** → the repo + branch you pinned in
+>   "Pin the repo and versions" above, e.g. `--repo <origin-url> --repo-branch <branch>`.
+>   Opt-out only with a reason: *"standalone tutorial, no repo"*.
+> - **Versions (`--tool name:version`)** → one `--tool` per toolchain version you
+>   pinned in that same step, e.g. `--tool zig:0.13.0 --tool llvm:18`.
+>   Opt-out only with a reason: *"no specific toolchain applies"*.
+> - **Tags (`--tag`)** → 2–5 lowercase tags (see below).
+> - **Sources (`--source`)** → one per authoritative source you read, or the
+>   stated reason *"no web access this session"*.
+>
+> Carry the repo/version values straight over from the upfront pinning step — if
+> you find you never pinned them, go back and do it now rather than storing blank.
+
+Run:
+
+```bash
+lathe store /tmp/lathe-<slug> \
+  --tag <a> --tag <b> --tag <c> \
+  --repo <origin-url> --repo-branch <branch> \
+  --tool <name>:<version> --tool <name>:<version> \
+  --source <url> --source <url>
+```
+
+Choose **2–5** lowercase tags so the tutorial is findable in `lathe serve`'s
+search and tag filters. Cover, where they apply: the language/runtime (`zig`,
+`rust`, `go`), the domain (`audio`, `compilers`, `databases`), and the core
+technique (`parsing`, `dsp`, `concurrency`). Prefer short, reusable tags that
+will group naturally with other tutorials over hyper-specific one-offs.
+
+Pass `--repo` and `--repo-branch` with the repo you pinned (see "Pin the repo
+and versions"). Give `--repo` the raw `origin` URL — `lathe store` canonicalizes
+it to `host/org/repo` for grouping. A standalone tutorial with no repo is a
+legitimate case, but dropping these flags is a *deliberate, stated* choice
+surfaced by the pre-store gate above (*"standalone tutorial, no repo"*) — never a
+quiet default. **Don't put versions in tags**: pass each tool you pinned in that
+same step as `--tool name:version` (repeatable, e.g. `--tool zig:0.13.0 --tool
+llvm:18`) — these come from the pinned toolchain and must be passed, not folded
+into tags. Lathe stores them as structured versions, shows them as chips on the
+card, and gives them their own filter — keeping the tag vocabulary clean.
+
+Pass `--source <url>` once for each authoritative source you consulted during
+the **Research first** step — the research trail, not just the ones you cited
+inline. Lathe records them as provenance: the reading page shows "Researched
+against N sources" with the list, and the list page marks how many sources back
+each tutorial. If you genuinely had no web access, omit `--source`.
+
+Then tell the user:
+
+- "**Tutorial saved.** Run `lathe serve` to open it at http://localhost:4242."
+- "This is Part 1. To add more parts, run `/lathe-extend <slug>` in your Claude Code session (the **'Add a new part'** button in `lathe serve` hands you that command) — give guidance or let it continue naturally."
+- "Verification is opt-in: run `/lathe-verify <slug>` in your Claude Code session (the **Verify this tutorial** button in the web UI hands you that command). It needs the tutorial's toolchain installed locally; if a required tool is missing it shows a ⚠️ Skipped badge (not a failure)."
+- "Reading in `lathe serve`? The **Ask** button hands you `/lathe-ask <slug> <part>` to ask questions about a part right here in this session."
+
+## Stay in session
+
+Don't end the session. Stay available for:
+
+- *"Why did we structure it this way?"*
+- *"Make Part 2 more advanced."*
+- *"How'd I do on the checkpoint?"*
+- *"What if the buffer overflows?"*
+
+You are their expert guide for this topic. Stay engaged.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,101 @@
+// Package skills bundles the Lathe Claude Code skills into the binary so
+// `lathe skills install` can write them out with no repo clone.
+//
+// The embedded copies under data/ are generated from the human-edited source at
+// .claude/skills by `mage skills`; a `mage skillsCheck` parity gate (wired into
+// `mage check`) keeps the two from drifting. go:embed cannot reach paths that
+// begin with "." (so it can't read .claude/skills directly) -- that is the whole
+// reason the data/ mirror exists.
+package skills
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed data
+var dataFS embed.FS
+
+// Skill is one bundled skill: its slug (directory name), the raw SKILL.md bytes
+// (Claude Code frontmatter included), and the name/description parsed from the
+// YAML frontmatter.
+type Skill struct {
+	Slug        string
+	Name        string
+	Description string
+	Raw         []byte
+}
+
+// All returns every bundled skill, sorted by slug. It returns an error only if
+// the embedded tree is malformed (which would be a build-time bug).
+func All() ([]Skill, error) {
+	entries, err := fs.ReadDir(dataFS, "data")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded skills: %w", err)
+	}
+	var out []Skill
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slug := e.Name()
+		raw, err := dataFS.ReadFile("data/" + slug + "/SKILL.md")
+		if err != nil {
+			return nil, fmt.Errorf("read embedded skill %q: %w", slug, err)
+		}
+		name, desc := parseFrontmatter(raw)
+		if name == "" {
+			name = slug
+		}
+		out = append(out, Skill{Slug: slug, Name: name, Description: desc, Raw: raw})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
+	return out, nil
+}
+
+// parseFrontmatter pulls name: and description: out of a leading YAML
+// frontmatter block delimited by "---" lines. The Lathe skills only use those
+// two scalar keys, so a tiny line scanner beats pulling in a YAML dependency.
+//
+// If there is no well-formed frontmatter block (no leading fence, or an
+// unclosed one), it returns empty strings rather than harvesting key-looking
+// lines from the body -- this mirrors stripFrontmatter in cursor.go.
+func parseFrontmatter(raw []byte) (name, description string) {
+	// strings.Split always returns at least one element, so lines[0] is safe.
+	lines := strings.Split(string(raw), "\n")
+	// The first line must be exactly the opening fence (tolerate a trailing \r).
+	if strings.TrimRight(lines[0], "\r") != "---" {
+		return "", ""
+	}
+	closed := false
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			closed = true
+			break
+		}
+		if v, ok := frontmatterValue(line, "name"); ok {
+			name = v
+		} else if v, ok := frontmatterValue(line, "description"); ok {
+			description = v
+		}
+	}
+	if !closed {
+		return "", ""
+	}
+	return name, description
+}
+
+// frontmatterValue returns the value for "key:" on a frontmatter line, trimming
+// whitespace and surrounding quotes.
+func frontmatterValue(line, key string) (string, bool) {
+	prefix := key + ":"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	v := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	v = strings.Trim(v, `"'`)
+	return v, true
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,73 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAllReturnsEverySkillWithMetadata(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+	const want = 5
+	if len(all) != want {
+		t.Fatalf("All() returned %d skills, want %d", len(all), want)
+	}
+
+	wantSlugs := map[string]bool{
+		"lathe":        false,
+		"lathe-ask":    false,
+		"lathe-extend": false,
+		"lathe-tag":    false,
+		"lathe-verify": false,
+	}
+	for _, s := range all {
+		if _, ok := wantSlugs[s.Slug]; !ok {
+			t.Errorf("unexpected slug %q", s.Slug)
+			continue
+		}
+		wantSlugs[s.Slug] = true
+		if s.Name == "" {
+			t.Errorf("skill %q has empty name", s.Slug)
+		}
+		if strings.TrimSpace(s.Description) == "" {
+			t.Errorf("skill %q has empty description", s.Slug)
+		}
+		if len(s.Raw) == 0 {
+			t.Errorf("skill %q has empty raw bytes", s.Slug)
+		}
+	}
+	for slug, found := range wantSlugs {
+		if !found {
+			t.Errorf("missing expected skill %q", slug)
+		}
+	}
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	raw := []byte("---\nname: lathe\ndescription: Generate tutorials.\n---\n\n# Body\n")
+	name, desc := parseFrontmatter(raw)
+	if name != "lathe" {
+		t.Errorf("name = %q, want lathe", name)
+	}
+	if desc != "Generate tutorials." {
+		t.Errorf("description = %q", desc)
+	}
+}
+
+func TestParseFrontmatterNoFrontmatter(t *testing.T) {
+	name, desc := parseFrontmatter([]byte("# Just a heading\n"))
+	if name != "" || desc != "" {
+		t.Errorf("expected empty name/desc, got %q / %q", name, desc)
+	}
+}
+
+func TestParseFrontmatterUnclosedFenceIsIgnored(t *testing.T) {
+	// Opening fence but no closing one: must not harvest body lines.
+	raw := []byte("---\nname: real\n\n# Body\nname: not-frontmatter\n")
+	name, desc := parseFrontmatter(raw)
+	if name != "" || desc != "" {
+		t.Errorf("unclosed frontmatter should yield empty name/desc, got %q / %q", name, desc)
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -12,10 +12,19 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+)
+
+// skillsSrcDir is the human-edited source of truth for skills; skillsDataDir is
+// the tracked, embeddable copy (go:embed cannot reach paths starting with ".").
+const (
+	skillsSrcDir  = ".claude/skills"
+	skillsDataDir = "internal/skills/data"
 )
 
 // Default target when `mage` is run with no arguments.
@@ -66,15 +75,102 @@ func Build() error {
 	return run("go", "build", "-o", "lathe")
 }
 
-// Check runs the full gate: fmt check, vet, lint, test, build. This is what CI
-// runs and what you should run before opening a PR. It stops at the first
-// failure.
+// Skills regenerates the embeddable copy of the skills under internal/skills/data
+// from the human-edited source at .claude/skills. The generated copy is tracked
+// in git so `go build`/`go install` work without mage.
+func Skills() error {
+	names, err := skillNames()
+	if err != nil {
+		return err
+	}
+	// Wipe and rebuild the data dir so deletions/renames in the source are
+	// reflected (and never leave stale skills behind).
+	if err := os.RemoveAll(skillsDataDir); err != nil {
+		return fmt.Errorf("clear %s: %w", skillsDataDir, err)
+	}
+	for _, name := range names {
+		src := filepath.Join(skillsSrcDir, name, "SKILL.md")
+		dst := filepath.Join(skillsDataDir, name, "SKILL.md")
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", dst, err)
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+	}
+	fmt.Printf("synced %d skills into %s\n", len(names), skillsDataDir)
+	return nil
+}
+
+// SkillsCheck fails if the embedded copy under internal/skills/data has drifted
+// from the source at .claude/skills (mirrors FmtCheck: read-only, CI-safe).
+func SkillsCheck() error {
+	names, err := skillNames()
+	if err != nil {
+		return err
+	}
+	var drift []string
+	seen := map[string]bool{}
+	for _, name := range names {
+		seen[name] = true
+		src := filepath.Join(skillsSrcDir, name, "SKILL.md")
+		dst := filepath.Join(skillsDataDir, name, "SKILL.md")
+		want, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		got, err := os.ReadFile(dst)
+		if err != nil {
+			drift = append(drift, fmt.Sprintf("%s (missing in data)", name))
+			continue
+		}
+		if !bytes.Equal(want, got) {
+			drift = append(drift, fmt.Sprintf("%s (content differs)", name))
+		}
+	}
+	// Catch stale skills that exist in data/ but no longer in the source.
+	if entries, err := os.ReadDir(skillsDataDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() && !seen[e.Name()] {
+				drift = append(drift, fmt.Sprintf("%s (stale in data)", e.Name()))
+			}
+		}
+	}
+	if len(drift) > 0 {
+		return fmt.Errorf("embedded skills are out of date:\n  %s\nrun `mage skills`", strings.Join(drift, "\n  "))
+	}
+	return nil
+}
+
+// skillNames lists the skill directory names under the source dir.
+func skillNames() ([]string, error) {
+	entries, err := os.ReadDir(skillsSrcDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", skillsSrcDir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// Check runs the full gate: fmt check, skills parity check, vet, lint, test,
+// build. This is what CI runs and what you should run before opening a PR. It
+// stops at the first failure.
 func Check() error {
 	for _, step := range []struct {
 		name string
 		fn   func() error
 	}{
 		{"fmt-check", FmtCheck},
+		{"skills-check", SkillsCheck},
 		{"vet", Vet},
 		{"lint", Lint},
 		{"test", Test},


### PR DESCRIPTION
**Stacked PR 2 of 3** — Versioning (#30) → this (B) → Release pipeline. Independent of A; merge after A so the docs/install path in C line up. No conflicts between A and B.

## Summary
Bundle the 5 `SKILL.md` files into the binary so they can be installed with no repo clone.

- `go:embed` can't reach `.claude/skills` (paths starting with `.`), so `.claude/skills/` stays the human-edited source of truth and `mage skills` generates a tracked, embeddable mirror under `internal/skills/data/`. A read-only `mage skillsCheck` (wired into `mage check`) fails if the two drift.
- `internal/skills` embeds `data/` and exposes a typed catalog (`All()`, parsing the `name:`/`description:` frontmatter with no new deps) plus a Cursor translation (`cursor.go`: strip frontmatter, prepend a `/<slug>` header).
- `lathe skills install` writes Claude Code skills (`./.claude/skills/<name>/SKILL.md`, or `~/…` with `--user`) and/or Cursor commands (`./.cursor/commands/<slug>.md`); `--agent claude-code|cursor|all`. `lathe skills list` prints the catalog. Writes only into the chosen agent dirs, never `~/.lathe/`.
- Commands are split one-per-file (`skills.go` parent + helpers, `skills-install.go`, `skills-list.go`) per repo convention.

## Test plan
- `mage skills` then `mage skillsCheck` → parity; introduce drift → `mage check` fails on the gate.
- In a scratch dir: `lathe skills install` → 5 files under `./.claude/skills/`; `--user` → `~/.claude/skills/`; `--agent cursor` → `./.cursor/commands/*.md` with frontmatter stripped; `lathe skills list` → 5 skills.
- `mage check` green.