### PR TITLE
Feat: Per-tutorial user progress tracking

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -98,8 +98,9 @@ Each component is a class in `styles.css`. Markup it expects:
 | Verify / extend | `.verify-section`, `.extend-section`, `#verifyForm`, `#extendForm` | layout.html |
 | Author byline | `.article-byline`, `.voice-reveal`, `.voice-reveal-body` (+ `code`) | layout.html (under the `.article-header` `<h2>`) |
 | Ask drawer | `#askDrawer`, `.ask-bubble`, `.ask-question`, `.ask-answer` | layout.html |
-| Progress bar | `#progressBar` | layout.html |
+| Reading progress bar | `#progressBar` | layout.html |
 | List cards | `body.list`, `.tutorial`, `.meta`, `.delete-btn`, `.empty` | list.html |
+| List card progress | `.tutorial-progress`, `.tutorial-progress-track`, `.tutorial-progress-segments`, `.tutorial-progress-label` | list.html |
 | Callouts | `.callout.callout-<type>`, `.callout-label` | emitted by `renderer.go` |
 | Code blocks | `pre`, `pre.chroma`, `code` | goldmark + chroma |
 

--- a/internal/serve/card_progress.go
+++ b/internal/serve/card_progress.go
@@ -1,0 +1,62 @@
+package serve
+
+import (
+	"math"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+type CardProgress struct {
+	IsSeries   bool
+	Percent    int
+	PartNumber int
+	TotalParts int
+	Segments   []CardProgressSegment
+}
+
+type CardProgressSegment struct {
+	Number   int
+	Complete bool
+	Current  bool
+}
+
+func cardProgress(tut *store.Tutorial) *CardProgress {
+	if tut.Progress == nil {
+		return nil
+	}
+	if !tut.IsSeries() {
+		return &CardProgress{Percent: percent(tut.Progress.Ratio)}
+	}
+	for i, part := range tut.Parts {
+		if part != tut.Progress.Part {
+			continue
+		}
+		partNumber := i + 1
+		segments := make([]CardProgressSegment, len(tut.Parts))
+		for j := range tut.Parts {
+			number := j + 1
+			segments[j] = CardProgressSegment{
+				Number:   number,
+				Complete: number < partNumber,
+				Current:  number == partNumber,
+			}
+		}
+		return &CardProgress{
+			IsSeries:   true,
+			PartNumber: partNumber,
+			TotalParts: len(tut.Parts),
+			Segments:   segments,
+		}
+	}
+	return nil
+}
+
+func percent(progress float64) int {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	return int(math.Round(progress * 100))
+}

--- a/internal/serve/card_progress.go
+++ b/internal/serve/card_progress.go
@@ -15,8 +15,8 @@ type CardProgress struct {
 }
 
 type CardProgressSegment struct {
-	Complete bool
-	Current  bool
+	Percent int
+	Current bool
 }
 
 func cardProgress(tut *store.Tutorial) *CardProgress {
@@ -31,16 +31,24 @@ func cardProgress(tut *store.Tutorial) *CardProgress {
 			continue
 		}
 		partNumber := i + 1
+		currentPercent := percent(tut.Progress.Ratio)
 		segments := make([]CardProgressSegment, len(tut.Parts))
 		for j := range tut.Parts {
 			number := j + 1
+			segmentPercent := 0
+			if number < partNumber {
+				segmentPercent = 100
+			} else if number == partNumber {
+				segmentPercent = currentPercent
+			}
 			segments[j] = CardProgressSegment{
-				Complete: number < partNumber,
-				Current:  number == partNumber,
+				Percent: segmentPercent,
+				Current: number == partNumber,
 			}
 		}
 		return &CardProgress{
 			IsSeries:   true,
+			Percent:    currentPercent,
 			PartNumber: partNumber,
 			TotalParts: len(tut.Parts),
 			Segments:   segments,

--- a/internal/serve/card_progress.go
+++ b/internal/serve/card_progress.go
@@ -15,7 +15,6 @@ type CardProgress struct {
 }
 
 type CardProgressSegment struct {
-	Number   int
 	Complete bool
 	Current  bool
 }
@@ -36,7 +35,6 @@ func cardProgress(tut *store.Tutorial) *CardProgress {
 		for j := range tut.Parts {
 			number := j + 1
 			segments[j] = CardProgressSegment{
-				Number:   number,
 				Complete: number < partNumber,
 				Current:  number == partNumber,
 			}

--- a/internal/serve/checkpoint.go
+++ b/internal/serve/checkpoint.go
@@ -1,7 +1,82 @@
 package serve
 
-import "net/http"
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+const maxCheckpointBytes = 1024
 
 func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "checkpoint saving is not implemented", http.StatusNotImplemented)
+	if !sameOrigin(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	part := r.PathValue("part")
+	tutDir, ok := s.safeTutorialPath(slug)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if !isKnownPart(tut, part) {
+		http.NotFound(w, r)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxCheckpointBytes)
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "request body too large", http.StatusBadRequest)
+		return
+	}
+	if len(raw) == 0 {
+		http.Error(w, "empty request body", http.StatusBadRequest)
+		return
+	}
+
+	var payload struct {
+		Progress  float64 `json:"progress"`
+		HeadingID string  `json:"heading_id"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	progress := payload.Progress
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+
+	tut.Checkpoint = &store.Checkpoint{
+		Part:      part,
+		Progress:  progress,
+		HeadingID: strings.TrimSpace(payload.HeadingID),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		http.Error(w, "write metadata", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Checkpoint *store.Checkpoint `json:"checkpoint"`
+	}{Checkpoint: tut.Checkpoint})
 }

--- a/internal/serve/checkpoint.go
+++ b/internal/serve/checkpoint.go
@@ -1,0 +1,7 @@
+package serve
+
+import "net/http"
+
+func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "checkpoint saving is not implemented", http.StatusNotImplemented)
+}

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -37,7 +37,6 @@
         {{end}}
       </ul>
     </details>{{end}}</span>
-  <button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>
   {{template "themeToggle" .}}
 </header>
 <div class="layout">
@@ -145,7 +144,10 @@
   {{end}}
 </div>
 <div id="sidebarBackdrop"></div>
-<button type="button" id="askButton" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
+<div id="floatingActions">
+  <button type="button" id="checkpointButton" class="btn btn-ghost btn-pill checkpoint-button" data-checkpoint-save>Save checkpoint</button>
+  <button type="button" id="askButton" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
+</div>
 <p id="checkpointStatus" class="checkpoint-status" aria-live="polite"></p>
 <div id="bottomDock">
   {{template "themeToggle" .}}

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}"><div></div><span id="savedProgressMarker" hidden></span></div>
+<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}" data-saved-heading-id="{{if .CurrentProgress}}{{.CurrentProgress.HeadingID}}{{end}}"><div></div><span id="savedProgressMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -280,13 +280,39 @@
       progress.setAttribute('data-saved-progress', String(clamp(ratio)));
       renderSavedProgressMarker();
     }
+    function setSavedHeadingID(headingID){
+      progress.setAttribute('data-saved-heading-id', headingID || '');
+    }
     function savedProgressRatio(){
       var raw = progress.getAttribute('data-saved-progress');
       if (!raw) return null;
       var ratio = clamp(parseFloat(raw));
       return Number.isNaN(ratio) ? null : ratio;
     }
+    function savedProgressHeadingID(){
+      return progress.getAttribute('data-saved-heading-id') || '';
+    }
+    function currentHeadingID(){
+      var headings = document.querySelectorAll('main h1[id], main h2[id], main h3[id], main h4[id], main h5[id], main h6[id]');
+      var current = '';
+      var scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+      headings.forEach(function(heading){
+        if (!heading.id) return;
+        var headingTop = heading.getBoundingClientRect().top + scrollTop;
+        if (headingTop <= scrollTop + 4) current = heading.id;
+      });
+      return current;
+    }
     function restoreProgress(){
+      var headingID = savedProgressHeadingID();
+      if (headingID) {
+        var heading = document.getElementById(headingID);
+        if (heading) {
+          heading.scrollIntoView({block: 'start', behavior: 'auto'});
+          update();
+          return;
+        }
+      }
       var ratio = savedProgressRatio();
       if (ratio === null) return;
       var doc = document.documentElement;
@@ -305,7 +331,11 @@
       pending = true;
       requestAnimationFrame(update);
     }
-    window.latheReadingProgress.setSavedProgress = setSavedProgress;
+    window.latheReadingProgress.currentHeadingID = currentHeadingID;
+    window.latheReadingProgress.setSavedProgress = function(ratio, headingID){
+      setSavedProgress(ratio);
+      setSavedHeadingID(headingID);
+    };
     renderSavedProgressMarker();
     update();
     window.addEventListener('scroll', onScroll, {passive:true});
@@ -319,7 +349,8 @@
 </script>
 <script>
   // Save progress — explicit user action that persists the current progress
-  // ratio through the local server and updates the marker from the response.
+  // ratio + nearest heading through the local server and updates the marker
+  // from the response.
   (function(){
     var progress = document.getElementById('progressBar');
     var buttons = document.querySelectorAll('[data-progress-save]');
@@ -349,10 +380,11 @@
         setBusy(true);
         setStatus('', false);
         var ratio = reader.currentRatio();
+        var headingID = reader.currentHeadingID ? reader.currentHeadingID() : '';
         fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({ratio: ratio})
+          body: JSON.stringify({ratio: ratio, heading_id: headingID})
         }).then(function(response){
           if (!response.ok) {
             return response.text().then(function(text){
@@ -362,7 +394,8 @@
           return response.json();
         }).then(function(data){
           var saved = data && data.progress ? data.progress.ratio : ratio;
-          if (reader.setSavedProgress) reader.setSavedProgress(saved);
+          var savedHeading = data && data.progress ? data.progress.heading_id : headingID;
+          if (reader.setSavedProgress) reader.setSavedProgress(saved, savedHeading);
           setStatus('Progress saved', false);
         }).catch(function(err){
           setStatus('Progress save failed: ' + (err && err.message ? err.message : 'request failed'), true);

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -37,6 +37,7 @@
         {{end}}
       </ul>
     </details>{{end}}</span>
+  <button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>
   {{template "themeToggle" .}}
 </header>
 <div class="layout">
@@ -147,6 +148,7 @@
 <button type="button" id="askButton" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
 <div id="bottomDock">
   {{template "themeToggle" .}}
+  <button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>
   <button type="button" id="dockAsk" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
 </div>
 <aside id="askDrawer" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" aria-hidden="true">

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-<div id="progressBar" aria-hidden="true" data-checkpoint-progress="{{if .CurrentCheckpoint}}{{.CurrentCheckpoint.Progress}}{{end}}"><div></div><span id="checkpointMarker" hidden></span></div>
+<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-checkpoint-progress="{{if .CurrentCheckpoint}}{{.CurrentCheckpoint.Progress}}{{end}}"><div></div><span id="checkpointMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -146,6 +146,7 @@
 </div>
 <div id="sidebarBackdrop"></div>
 <button type="button" id="askButton" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
+<p id="checkpointStatus" class="checkpoint-status" aria-live="polite"></p>
 <div id="bottomDock">
   {{template "themeToggle" .}}
   <button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>
@@ -273,6 +274,10 @@
       marker.hidden = false;
       marker.style.left = (ratio * 100) + '%';
     }
+    function setCheckpointProgress(ratio){
+      progress.setAttribute('data-checkpoint-progress', String(clamp(ratio)));
+      renderCheckpointMarker();
+    }
     function update(){
       pending = false;
       var ratio = currentRatio();
@@ -283,10 +288,67 @@
       pending = true;
       requestAnimationFrame(update);
     }
+    window.latheReadingProgress.setCheckpointProgress = setCheckpointProgress;
     renderCheckpointMarker();
     update();
     window.addEventListener('scroll', onScroll, {passive:true});
     window.addEventListener('resize', onScroll);
+  })();
+</script>
+<script>
+  // Save checkpoint — explicit user action that persists the current progress
+  // ratio through the local server and updates the marker from the response.
+  (function(){
+    var progress = document.getElementById('progressBar');
+    var buttons = document.querySelectorAll('[data-checkpoint-save]');
+    var status = document.getElementById('checkpointStatus');
+    if (!progress || !buttons.length) return;
+
+    function setStatus(message, error){
+      if (!status) return;
+      status.textContent = message || '';
+      status.dataset.state = error ? 'error' : 'ok';
+      if (message && !error) {
+        setTimeout(function(){
+          if (status.textContent === message) status.textContent = '';
+        }, 1800);
+      }
+    }
+    function setBusy(busy){
+      buttons.forEach(function(button){ button.disabled = busy; });
+    }
+    buttons.forEach(function(button){
+      button.addEventListener('click', function(){
+        var slug = progress.getAttribute('data-slug') || '';
+        var part = progress.getAttribute('data-part') || '';
+        var reader = window.latheReadingProgress;
+        if (!slug || !part || !reader || !reader.currentRatio) return;
+
+        setBusy(true);
+        setStatus('', false);
+        var ratio = reader.currentRatio();
+        fetch('/-/checkpoint/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({progress: ratio})
+        }).then(function(response){
+          if (!response.ok) {
+            return response.text().then(function(text){
+              throw new Error(text || ('HTTP ' + response.status));
+            });
+          }
+          return response.json();
+        }).then(function(data){
+          var saved = data && data.checkpoint ? data.checkpoint.progress : ratio;
+          if (reader.setCheckpointProgress) reader.setCheckpointProgress(saved);
+          setStatus('Checkpoint saved', false);
+        }).catch(function(err){
+          setStatus('Checkpoint failed: ' + (err && err.message ? err.message : 'request failed'), true);
+        }).then(function(){
+          setBusy(false);
+        });
+      });
+    });
   })();
 </script>
 <script>

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -292,6 +292,13 @@
     function savedProgressHeadingID(){
       return progress.getAttribute('data-saved-heading-id') || '';
     }
+    function scrollToRatio(ratio){
+      var doc = document.documentElement;
+      var max = (doc.scrollHeight - doc.clientHeight) || 0;
+      if (max <= 0) return false;
+      window.scrollTo({top: Math.round(max * ratio), behavior: 'auto'});
+      return true;
+    }
     function currentHeadingID(){
       var headings = document.querySelectorAll('main h1[id], main h2[id], main h3[id], main h4[id], main h5[id], main h6[id]');
       var current = '';
@@ -304,6 +311,11 @@
       return current;
     }
     function restoreProgress(){
+      var ratio = savedProgressRatio();
+      if (ratio !== null && scrollToRatio(ratio)) {
+        update();
+        return;
+      }
       var headingID = savedProgressHeadingID();
       if (headingID) {
         var heading = document.getElementById(headingID);
@@ -313,13 +325,6 @@
           return;
         }
       }
-      var ratio = savedProgressRatio();
-      if (ratio === null) return;
-      var doc = document.documentElement;
-      var max = (doc.scrollHeight - doc.clientHeight) || 0;
-      if (max <= 0) return;
-      window.scrollTo({top: Math.round(max * ratio), behavior: 'auto'});
-      update();
     }
     function update(){
       pending = false;

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-checkpoint-progress="{{if .CurrentCheckpoint}}{{.CurrentCheckpoint.Progress}}{{end}}"><div></div><span id="checkpointMarker" hidden></span></div>
+<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}"><div></div><span id="savedProgressMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -145,13 +145,13 @@
 </div>
 <div id="sidebarBackdrop"></div>
 <div id="floatingActions">
-  <button type="button" id="checkpointButton" class="btn btn-ghost btn-pill checkpoint-button" data-checkpoint-save>Save checkpoint</button>
+  <button type="button" id="saveProgressButton" class="btn btn-ghost btn-pill progress-button" data-progress-save>Save progress</button>
   <button type="button" id="askButton" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
 </div>
-<p id="checkpointStatus" class="checkpoint-status" aria-live="polite"></p>
+<p id="progressStatus" class="progress-status" aria-live="polite"></p>
 <div id="bottomDock">
   {{template "themeToggle" .}}
-  <button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>
+  <button type="button" class="btn btn-ghost btn-sm progress-button" data-progress-save>Save progress</button>
   <button type="button" id="dockAsk" class="btn btn-primary btn-pill" data-ask-open aria-label="Ask a question about this tutorial">Ask</button>
 </div>
 <aside id="askDrawer" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" aria-hidden="true">
@@ -251,12 +251,12 @@
 </script>
 <script>
   // Reading-progress bar — RAF-throttled, transform-based to avoid layout thrash.
-  // Exposes the current ratio for checkpoint saves and positions the saved
-  // checkpoint marker when the current part has one.
+  // Exposes the current ratio for progress saves and positions the saved
+  // progress marker when the current part has one.
   (function(){
     var progress = document.getElementById('progressBar');
     var bar = progress && progress.querySelector(':scope > div');
-    var marker = document.getElementById('checkpointMarker');
+    var marker = document.getElementById('savedProgressMarker');
     if (!progress || !bar) return;
     var pending = false;
     function clamp(n){ return Math.min(1, Math.max(0, n)); }
@@ -267,27 +267,27 @@
       return max > 0 ? clamp(scroll / max) : 0;
     }
     window.latheReadingProgress = {currentRatio: currentRatio};
-    function renderCheckpointMarker(){
+    function renderSavedProgressMarker(){
       if (!marker) return;
-      var raw = progress.getAttribute('data-checkpoint-progress');
+      var raw = progress.getAttribute('data-saved-progress');
       if (!raw) return;
       var ratio = clamp(parseFloat(raw));
       if (Number.isNaN(ratio)) return;
       marker.hidden = false;
       marker.style.left = (ratio * 100) + '%';
     }
-    function setCheckpointProgress(ratio){
-      progress.setAttribute('data-checkpoint-progress', String(clamp(ratio)));
-      renderCheckpointMarker();
+    function setSavedProgress(ratio){
+      progress.setAttribute('data-saved-progress', String(clamp(ratio)));
+      renderSavedProgressMarker();
     }
-    function checkpointRatio(){
-      var raw = progress.getAttribute('data-checkpoint-progress');
+    function savedProgressRatio(){
+      var raw = progress.getAttribute('data-saved-progress');
       if (!raw) return null;
       var ratio = clamp(parseFloat(raw));
       return Number.isNaN(ratio) ? null : ratio;
     }
-    function restoreCheckpoint(){
-      var ratio = checkpointRatio();
+    function restoreProgress(){
+      var ratio = savedProgressRatio();
       if (ratio === null) return;
       var doc = document.documentElement;
       var max = (doc.scrollHeight - doc.clientHeight) || 0;
@@ -305,25 +305,25 @@
       pending = true;
       requestAnimationFrame(update);
     }
-    window.latheReadingProgress.setCheckpointProgress = setCheckpointProgress;
-    renderCheckpointMarker();
+    window.latheReadingProgress.setSavedProgress = setSavedProgress;
+    renderSavedProgressMarker();
     update();
     window.addEventListener('scroll', onScroll, {passive:true});
     window.addEventListener('resize', onScroll);
     if (document.readyState === 'complete') {
-      setTimeout(restoreCheckpoint, 0);
+      setTimeout(restoreProgress, 0);
     } else {
-      window.addEventListener('load', function(){ setTimeout(restoreCheckpoint, 0); }, {once:true});
+      window.addEventListener('load', function(){ setTimeout(restoreProgress, 0); }, {once:true});
     }
   })();
 </script>
 <script>
-  // Save checkpoint — explicit user action that persists the current progress
+  // Save progress — explicit user action that persists the current progress
   // ratio through the local server and updates the marker from the response.
   (function(){
     var progress = document.getElementById('progressBar');
-    var buttons = document.querySelectorAll('[data-checkpoint-save]');
-    var status = document.getElementById('checkpointStatus');
+    var buttons = document.querySelectorAll('[data-progress-save]');
+    var status = document.getElementById('progressStatus');
     if (!progress || !buttons.length) return;
 
     function setStatus(message, error){
@@ -349,10 +349,10 @@
         setBusy(true);
         setStatus('', false);
         var ratio = reader.currentRatio();
-        fetch('/-/checkpoint/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
+        fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({progress: ratio})
+          body: JSON.stringify({ratio: ratio})
         }).then(function(response){
           if (!response.ok) {
             return response.text().then(function(text){
@@ -361,11 +361,11 @@
           }
           return response.json();
         }).then(function(data){
-          var saved = data && data.checkpoint ? data.checkpoint.progress : ratio;
-          if (reader.setCheckpointProgress) reader.setCheckpointProgress(saved);
-          setStatus('Checkpoint saved', false);
+          var saved = data && data.progress ? data.progress.ratio : ratio;
+          if (reader.setSavedProgress) reader.setSavedProgress(saved);
+          setStatus('Progress saved', false);
         }).catch(function(err){
-          setStatus('Checkpoint failed: ' + (err && err.message ? err.message : 'request failed'), true);
+          setStatus('Progress save failed: ' + (err && err.message ? err.message : 'request failed'), true);
         }).then(function(){
           setBusy(false);
         });

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-<div id="progressBar" aria-hidden="true"><div></div></div>
+<div id="progressBar" aria-hidden="true" data-checkpoint-progress="{{if .CurrentCheckpoint}}{{.CurrentCheckpoint.Progress}}{{end}}"><div></div><span id="checkpointMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -248,16 +248,34 @@
 </script>
 <script>
   // Reading-progress bar — RAF-throttled, transform-based to avoid layout thrash.
+  // Exposes the current ratio for checkpoint saves and positions the saved
+  // checkpoint marker when the current part has one.
   (function(){
-    var bar = document.querySelector('#progressBar > div');
-    if (!bar) return;
+    var progress = document.getElementById('progressBar');
+    var bar = progress && progress.querySelector(':scope > div');
+    var marker = document.getElementById('checkpointMarker');
+    if (!progress || !bar) return;
     var pending = false;
-    function update(){
-      pending = false;
+    function clamp(n){ return Math.min(1, Math.max(0, n)); }
+    function currentRatio(){
       var doc = document.documentElement;
       var scroll = window.scrollY || doc.scrollTop || 0;
       var max = (doc.scrollHeight - doc.clientHeight) || 1;
-      var ratio = max > 0 ? Math.min(1, Math.max(0, scroll / max)) : 0;
+      return max > 0 ? clamp(scroll / max) : 0;
+    }
+    window.latheReadingProgress = {currentRatio: currentRatio};
+    function renderCheckpointMarker(){
+      if (!marker) return;
+      var raw = progress.getAttribute('data-checkpoint-progress');
+      if (!raw) return;
+      var ratio = clamp(parseFloat(raw));
+      if (Number.isNaN(ratio)) return;
+      marker.hidden = false;
+      marker.style.left = (ratio * 100) + '%';
+    }
+    function update(){
+      pending = false;
+      var ratio = currentRatio();
       bar.style.transform = 'scaleX(' + ratio + ')';
     }
     function onScroll(){
@@ -265,6 +283,7 @@
       pending = true;
       requestAnimationFrame(update);
     }
+    renderCheckpointMarker();
     update();
     window.addEventListener('scroll', onScroll, {passive:true});
     window.addEventListener('resize', onScroll);

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -278,6 +278,21 @@
       progress.setAttribute('data-checkpoint-progress', String(clamp(ratio)));
       renderCheckpointMarker();
     }
+    function checkpointRatio(){
+      var raw = progress.getAttribute('data-checkpoint-progress');
+      if (!raw) return null;
+      var ratio = clamp(parseFloat(raw));
+      return Number.isNaN(ratio) ? null : ratio;
+    }
+    function restoreCheckpoint(){
+      var ratio = checkpointRatio();
+      if (ratio === null) return;
+      var doc = document.documentElement;
+      var max = (doc.scrollHeight - doc.clientHeight) || 0;
+      if (max <= 0) return;
+      window.scrollTo({top: Math.round(max * ratio), behavior: 'auto'});
+      update();
+    }
     function update(){
       pending = false;
       var ratio = currentRatio();
@@ -293,6 +308,11 @@
     update();
     window.addEventListener('scroll', onScroll, {passive:true});
     window.addEventListener('resize', onScroll);
+    if (document.readyState === 'complete') {
+      setTimeout(restoreCheckpoint, 0);
+    } else {
+      window.addEventListener('load', function(){ setTimeout(restoreCheckpoint, 0); }, {once:true});
+    }
   })();
 </script>
 <script>

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -50,9 +50,9 @@
     <div class="tutorial-body">
       <a class="tutorial-link" href="/{{.Slug}}/">{{.Title}}</a>
       <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
-      {{if .Checkpoint}}<div class="tutorial-progress" aria-label="Checkpoint at {{percent .Checkpoint.Progress}}%">
-        <div class="tutorial-progress-track"><span style="width:{{percent .Checkpoint.Progress}}%"></span></div>
-        <span class="tutorial-progress-label">Checkpoint {{percent .Checkpoint.Progress}}%</span>
+      {{if .Progress}}<div class="tutorial-progress" aria-label="Progress at {{percent .Progress.Ratio}}%">
+        <div class="tutorial-progress-track"><span style="width:{{percent .Progress.Ratio}}%"></span></div>
+        <span class="tutorial-progress-label">Progress {{percent .Progress.Ratio}}%</span>
       </div>{{end}}
       {{if .Tools}}<div class="versions">{{range .Tools}}<span class="version">{{.Name}}{{if .Version}} {{.Version}}{{end}}</span>{{end}}</div>{{end}}
       {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -50,13 +50,21 @@
     <div class="tutorial-body">
       <a class="tutorial-link" href="/{{.Slug}}/">{{.Title}}</a>
       <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
-      {{with cardProgress .}}{{if .IsSeries}}<div class="tutorial-progress" aria-label="Saved at part {{.PartNumber}} of {{.TotalParts}}">
-        <div class="tutorial-progress-track tutorial-progress-segments">{{range .Segments}}<span class="segment{{if .Complete}} complete{{end}}{{if .Current}} current{{end}}" aria-hidden="true"></span>{{end}}</div>
+      {{with cardProgress .}}
+      {{if .IsSeries}}
+      <div class="tutorial-progress" aria-label="Saved at part {{.PartNumber}} of {{.TotalParts}}">
+        <div class="tutorial-progress-track tutorial-progress-segments">
+          {{range .Segments}}<span class="segment{{if .Complete}} complete{{end}}{{if .Current}} current{{end}}" aria-hidden="true"></span>{{end}}
+        </div>
         <span class="tutorial-progress-label">Part {{.PartNumber}} of {{.TotalParts}}</span>
-      </div>{{else}}<div class="tutorial-progress" aria-label="Progress at {{.Percent}}%">
+      </div>
+      {{else}}
+      <div class="tutorial-progress" aria-label="Progress at {{.Percent}}%">
         <div class="tutorial-progress-track"><span class="fill" style="width:{{.Percent}}%"></span></div>
         <span class="tutorial-progress-label">Progress {{.Percent}}%</span>
-      </div>{{end}}{{end}}
+      </div>
+      {{end}}
+      {{end}}
       {{if .Tools}}<div class="versions">{{range .Tools}}<span class="version">{{.Name}}{{if .Version}} {{.Version}}{{end}}</span>{{end}}</div>{{end}}
       {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
     </div>

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -50,10 +50,13 @@
     <div class="tutorial-body">
       <a class="tutorial-link" href="/{{.Slug}}/">{{.Title}}</a>
       <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
-      {{if .Progress}}<div class="tutorial-progress" aria-label="Progress at {{percent .Progress.Ratio}}%">
-        <div class="tutorial-progress-track"><span style="width:{{percent .Progress.Ratio}}%"></span></div>
-        <span class="tutorial-progress-label">Progress {{percent .Progress.Ratio}}%</span>
-      </div>{{end}}
+      {{with cardProgress .}}{{if .IsSeries}}<div class="tutorial-progress" aria-label="Saved at part {{.PartNumber}} of {{.TotalParts}}">
+        <div class="tutorial-progress-track tutorial-progress-segments">{{range .Segments}}<span class="segment{{if .Complete}} complete{{end}}{{if .Current}} current{{end}}" aria-hidden="true"></span>{{end}}</div>
+        <span class="tutorial-progress-label">Part {{.PartNumber}} of {{.TotalParts}}</span>
+      </div>{{else}}<div class="tutorial-progress" aria-label="Progress at {{.Percent}}%">
+        <div class="tutorial-progress-track"><span class="fill" style="width:{{.Percent}}%"></span></div>
+        <span class="tutorial-progress-label">Progress {{.Percent}}%</span>
+      </div>{{end}}{{end}}
       {{if .Tools}}<div class="versions">{{range .Tools}}<span class="version">{{.Name}}{{if .Version}} {{.Version}}{{end}}</span>{{end}}</div>{{end}}
       {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
     </div>

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -54,9 +54,9 @@
       {{if .IsSeries}}
       <div class="tutorial-progress" aria-label="Saved at part {{.PartNumber}} of {{.TotalParts}}">
         <div class="tutorial-progress-track tutorial-progress-segments">
-          {{range .Segments}}<span class="segment{{if .Complete}} complete{{end}}{{if .Current}} current{{end}}" aria-hidden="true"></span>{{end}}
+          {{range .Segments}}<span class="segment{{if .Current}} current{{end}}" aria-hidden="true"><span class="fill" style="width:{{.Percent}}%"></span></span>{{end}}
         </div>
-        <span class="tutorial-progress-label">Part {{.PartNumber}} of {{.TotalParts}}</span>
+        <span class="tutorial-progress-label">Part {{.PartNumber}} of {{.TotalParts}} ({{.Percent}}%)</span>
       </div>
       {{else}}
       <div class="tutorial-progress" aria-label="Progress at {{.Percent}}%">

--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -50,6 +50,10 @@
     <div class="tutorial-body">
       <a class="tutorial-link" href="/{{.Slug}}/">{{.Title}}</a>
       <div class="meta">{{if .IsSeries}}{{len .Parts}} parts{{else}}single tutorial{{end}} · {{.Created.Format "Jan 2, 2006"}}{{if .Sources}} · {{len .Sources}} source{{if ne (len .Sources) 1}}s{{end}}{{end}}</div>
+      {{if .Checkpoint}}<div class="tutorial-progress" aria-label="Checkpoint at {{percent .Checkpoint.Progress}}%">
+        <div class="tutorial-progress-track"><span style="width:{{percent .Checkpoint.Progress}}%"></span></div>
+        <span class="tutorial-progress-label">Checkpoint {{percent .Checkpoint.Progress}}%</span>
+      </div>{{end}}
       {{if .Tools}}<div class="versions">{{range .Tools}}<span class="version">{{.Name}}{{if .Version}} {{.Version}}{{end}}</span>{{end}}</div>{{end}}
       {{if .Tags}}<div class="tags">{{range .Tags}}<span class="tag">{{.}}</span>{{end}}</div>{{end}}
     </div>

--- a/internal/serve/progress.go
+++ b/internal/serve/progress.go
@@ -74,19 +74,19 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 		ratio = 1
 	}
 
-	tut.Progress = &store.Progress{
+	progress := &store.Progress{
 		Part:      part,
 		Ratio:     ratio,
 		HeadingID: strings.TrimSpace(payload.HeadingID),
 		UpdatedAt: time.Now().UTC(),
 	}
-	if err := store.WriteMetadata(tutDir, tut); err != nil {
-		http.Error(w, "write metadata", http.StatusInternalServerError)
+	if err := store.SaveProgress(tutDir, progress); err != nil {
+		http.Error(w, "write progress", http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(struct {
 		Progress *store.Progress `json:"progress"`
-	}{Progress: tut.Progress})
+	}{Progress: progress})
 }

--- a/internal/serve/progress.go
+++ b/internal/serve/progress.go
@@ -10,9 +10,9 @@ import (
 	"github.com/devenjarvis/lathe/internal/store"
 )
 
-const maxCheckpointBytes = 1024
+const maxProgressBytes = 1024
 
-func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 	if !sameOrigin(r) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
@@ -36,7 +36,7 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxCheckpointBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, maxProgressBytes)
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "request body too large", http.StatusBadRequest)
@@ -48,25 +48,31 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var payload struct {
-		Progress  float64 `json:"progress"`
-		HeadingID string  `json:"heading_id"`
+		Ratio     *float64 `json:"ratio"`
+		Progress  *float64 `json:"progress"`
+		HeadingID string   `json:"heading_id"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
 
-	progress := payload.Progress
-	if progress < 0 {
-		progress = 0
+	var ratio float64
+	if payload.Ratio != nil {
+		ratio = *payload.Ratio
+	} else if payload.Progress != nil {
+		ratio = *payload.Progress
 	}
-	if progress > 1 {
-		progress = 1
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
 	}
 
-	tut.Checkpoint = &store.Checkpoint{
+	tut.Progress = &store.Progress{
 		Part:      part,
-		Progress:  progress,
+		Ratio:     ratio,
 		HeadingID: strings.TrimSpace(payload.HeadingID),
 		UpdatedAt: time.Now().UTC(),
 	}
@@ -77,6 +83,6 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(struct {
-		Checkpoint *store.Checkpoint `json:"checkpoint"`
-	}{Checkpoint: tut.Checkpoint})
+		Progress *store.Progress `json:"progress"`
+	}{Progress: tut.Progress})
 }

--- a/internal/serve/progress.go
+++ b/internal/serve/progress.go
@@ -56,6 +56,10 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
+	if payload.Ratio == nil && payload.Progress == nil {
+		http.Error(w, "ratio is required", http.StatusBadRequest)
+		return
+	}
 
 	var ratio float64
 	if payload.Ratio != nil {

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -169,10 +169,15 @@ func (s *Server) handleTutorial(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Any tutorial with parts (single or series) lives in part-NN.md files, not
-	// index.md, so redirect to the first part. The index.md fallback is only for
+	// index.md. Prefer a valid checkpoint part when one is saved, otherwise keep
+	// the historical first-part redirect. The index.md fallback is only for
 	// legacy tutorials that were never split into parts.
 	if len(tut.Parts) > 0 {
-		http.Redirect(w, r, fmt.Sprintf("/%s/%s", slug, tut.Parts[0]), http.StatusFound)
+		part := tut.Parts[0]
+		if tut.Checkpoint != nil && isKnownPart(tut, tut.Checkpoint.Part) {
+			part = tut.Checkpoint.Part
+		}
+		http.Redirect(w, r, fmt.Sprintf("/%s/%s", slug, part), http.StatusFound)
 		return
 	}
 	s.renderPart(w, tut, tutDir, "index.md")

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -366,6 +366,8 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		}
 	}
 
+	currentCheckpoint := currentPartCheckpoint(tut, part)
+
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
 		"Title":             tut.Title,
@@ -375,6 +377,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"UnverifiedCount":   unverifiedCount,
 		"VoiceSpec":         voiceSpec,
 		"CurrentPart":       part,
+		"CurrentCheckpoint": currentCheckpoint,
 		"CurrentPartNumber": currentNumber,
 		"Content":           template.HTML(content),
 		"CSS":               s.designCSS,
@@ -408,4 +411,11 @@ func pendingPartNumber(pendingPart string, fallback int) int {
 		return fallback
 	}
 	return n
+}
+
+func currentPartCheckpoint(tut *store.Tutorial, part string) *store.Checkpoint {
+	if tut.Checkpoint == nil || tut.Checkpoint.Part != part {
+		return nil
+	}
+	return tut.Checkpoint
 }

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -72,7 +72,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{slug}/{part}", s.handlePart)
 	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
 	mux.HandleFunc("POST /-/ask/{slug}/{part}", s.handleAsk)
-	mux.HandleFunc("POST /-/checkpoint/{slug}/{part}", s.handleCheckpoint)
+	mux.HandleFunc("POST /-/progress/{slug}/{part}", s.handleProgress)
 	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
 	mux.HandleFunc("POST /-/verify/{slug}", s.handleVerify)
 	return mux
@@ -181,13 +181,13 @@ func (s *Server) handleTutorial(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Any tutorial with parts (single or series) lives in part-NN.md files, not
-	// index.md. Prefer a valid checkpoint part when one is saved, otherwise keep
+	// index.md. Prefer a valid saved-progress part when one is saved, otherwise keep
 	// the historical first-part redirect. The index.md fallback is only for
 	// legacy tutorials that were never split into parts.
 	if len(tut.Parts) > 0 {
 		part := tut.Parts[0]
-		if tut.Checkpoint != nil && isKnownPart(tut, tut.Checkpoint.Part) {
-			part = tut.Checkpoint.Part
+		if tut.Progress != nil && isKnownPart(tut, tut.Progress.Part) {
+			part = tut.Progress.Part
 		}
 		http.Redirect(w, r, fmt.Sprintf("/%s/%s", slug, part), http.StatusFound)
 		return
@@ -378,7 +378,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		}
 	}
 
-	currentCheckpoint := currentPartCheckpoint(tut, part)
+	currentProgress := currentPartProgress(tut, part)
 
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
@@ -389,7 +389,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"UnverifiedCount":   unverifiedCount,
 		"VoiceSpec":         voiceSpec,
 		"CurrentPart":       part,
-		"CurrentCheckpoint": currentCheckpoint,
+		"CurrentProgress":   currentProgress,
 		"CurrentPartNumber": currentNumber,
 		"Content":           template.HTML(content),
 		"CSS":               s.designCSS,
@@ -425,9 +425,9 @@ func pendingPartNumber(pendingPart string, fallback int) int {
 	return n
 }
 
-func currentPartCheckpoint(tut *store.Tutorial, part string) *store.Checkpoint {
-	if tut.Checkpoint == nil || tut.Checkpoint.Part != part {
+func currentPartProgress(tut *store.Tutorial, part string) *store.Progress {
+	if tut.Progress == nil || tut.Progress.Part != part {
 		return nil
 	}
-	return tut.Checkpoint
+	return tut.Progress
 }

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -70,6 +70,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{slug}/{part}", s.handlePart)
 	mux.HandleFunc("POST /-/delete/{slug}", s.handleDelete)
 	mux.HandleFunc("POST /-/ask/{slug}/{part}", s.handleAsk)
+	mux.HandleFunc("POST /-/checkpoint/{slug}/{part}", s.handleCheckpoint)
 	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
 	mux.HandleFunc("POST /-/verify/{slug}", s.handleVerify)
 	return mux

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,8 +43,8 @@ type Server struct {
 
 func NewServer(tutorialsDir string) *Server {
 	funcMap := template.FuncMap{
-		"add":     func(a, b int) int { return a + b },
-		"percent": percent,
+		"add":          func(a, b int) int { return a + b },
+		"cardProgress": cardProgress,
 	}
 	// components.html is parsed into both template sets so its shared partials
 	// ({{define "head"}}, "badge", "themeToggle") are available to each page.
@@ -76,16 +75,6 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
 	mux.HandleFunc("POST /-/verify/{slug}", s.handleVerify)
 	return mux
-}
-
-func percent(progress float64) int {
-	if progress < 0 {
-		progress = 0
-	}
-	if progress > 1 {
-		progress = 1
-	}
-	return int(math.Round(progress * 100))
 }
 
 // staticAssets whitelists the embedded files we expose under /_static/. Keeping

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,7 +44,8 @@ type Server struct {
 
 func NewServer(tutorialsDir string) *Server {
 	funcMap := template.FuncMap{
-		"add": func(a, b int) int { return a + b },
+		"add":     func(a, b int) int { return a + b },
+		"percent": percent,
 	}
 	// components.html is parsed into both template sets so its shared partials
 	// ({{define "head"}}, "badge", "themeToggle") are available to each page.
@@ -74,6 +76,16 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /-/extend/{slug}", s.handleExtend)
 	mux.HandleFunc("POST /-/verify/{slug}", s.handleVerify)
 	return mux
+}
+
+func percent(progress float64) int {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	return int(math.Round(progress * 100))
 }
 
 // staticAssets whitelists the embedded files we expose under /_static/. Keeping

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -244,7 +244,7 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	// Three tutorials with distinct created times — exercises the flat
 	// newest-first list, repo as searchable metadata (data-repo), and version
 	// chips + the Versions filter row.
-	mk := func(slug string, repo string, tools []store.Tool, created time.Time) {
+	mk := func(slug string, repo string, tools []store.Tool, created time.Time, checkpoint *store.Checkpoint) {
 		tutDir := filepath.Join(dir, slug)
 		if err := os.MkdirAll(tutDir, 0755); err != nil {
 			t.Fatal(err)
@@ -253,21 +253,22 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 			t.Fatal(err)
 		}
 		tut := &store.Tutorial{
-			Slug:    slug,
-			Title:   slug,
-			Status:  store.StatusUnverified,
-			Created: created,
-			Repo:    repo,
-			Tools:   tools,
+			Slug:       slug,
+			Title:      slug,
+			Status:     store.StatusUnverified,
+			Created:    created,
+			Repo:       repo,
+			Tools:      tools,
+			Checkpoint: checkpoint,
 		}
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			t.Fatal(err)
 		}
 	}
 	now := time.Now()
-	mk("synth-zig", "github.com/devenjarvis/lathe", []store.Tool{{Name: "zig", Version: "0.13.0"}}, now)
-	mk("compiler-go", "github.com/devenjarvis/lathe", []store.Tool{{Name: "go", Version: "1.22"}}, now.Add(-time.Hour))
-	mk("standalone", "", nil, now.Add(-2*time.Hour))
+	mk("synth-zig", "github.com/devenjarvis/lathe", []store.Tool{{Name: "zig", Version: "0.13.0"}}, now, &store.Checkpoint{Part: "index.md", Progress: 0.42, UpdatedAt: now})
+	mk("compiler-go", "github.com/devenjarvis/lathe", []store.Tool{{Name: "go", Version: "1.22"}}, now.Add(-time.Hour), nil)
+	mk("standalone", "", nil, now.Add(-2*time.Hour), nil)
 
 	srv := serve.NewServer(dir)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -287,6 +288,12 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	}
 	if !strings.Contains(body, `id="versionFilters"`) {
 		t.Error("list page missing the Versions filter row")
+	}
+	if !strings.Contains(body, `aria-label="Checkpoint at 42%"`) {
+		t.Error("list page missing checkpoint progress label")
+	}
+	if !strings.Contains(body, `style="width:42%"`) {
+		t.Error("list page missing checkpoint progress bar width")
 	}
 
 	// All three cards render in one flat list, newest-first.

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -357,19 +357,25 @@ func TestListPageRendersSeriesCardProgress(t *testing.T) {
 	if !strings.Contains(card, `aria-label="Saved at part 2 of 4"`) {
 		t.Error("series card missing part-position aria label")
 	}
-	if !strings.Contains(card, `<span class="tutorial-progress-label">Part 2 of 4</span>`) {
-		t.Error("series card missing Part 2 of 4 progress label")
+	if !strings.Contains(card, `<span class="tutorial-progress-label">Part 2 of 4 (42%)</span>`) {
+		t.Error("series card missing Part 2 of 4 current-part progress label")
 	}
 	if got := strings.Count(card, `class="segment`); got != 4 {
 		t.Errorf("series card segment count = %d, want 4", got)
 	}
-	if !strings.Contains(card, `class="segment complete"`) {
-		t.Error("series card missing completed segment")
+	if got := strings.Count(card, `class="fill"`); got != 4 {
+		t.Errorf("series card fill count = %d, want 4", got)
 	}
 	if !strings.Contains(card, `class="segment current"`) {
 		t.Error("series card missing current segment")
 	}
-	if strings.Contains(card, `Progress 42%`) || strings.Contains(card, `style="width:42%"`) {
+	if !strings.Contains(card, `<span class="segment" aria-hidden="true"><span class="fill" style="width:100%"></span></span>`) {
+		t.Error("series card should fill completed parts")
+	}
+	if !strings.Contains(card, `<span class="segment current" aria-hidden="true"><span class="fill" style="width:42%"></span></span>`) {
+		t.Error("series card should partially fill the saved part")
+	}
+	if strings.Contains(card, `Progress 42%`) || strings.Contains(card, `aria-label="Progress at 42%"`) {
 		t.Error("series card should not render saved part scroll ratio as whole-series percentage")
 	}
 }

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -455,6 +455,14 @@ func TestTutorialPageRendersCurrentProgressData(t *testing.T) {
 	if !strings.Contains(body, `id="savedProgressMarker"`) {
 		t.Error("tutorial page missing progress marker element")
 	}
+	ratioRestore := strings.Index(body, "var ratio = savedProgressRatio();")
+	headingRestore := strings.Index(body, "var headingID = savedProgressHeadingID();")
+	if ratioRestore < 0 || headingRestore < 0 {
+		t.Fatal("tutorial page missing saved progress restore script")
+	}
+	if ratioRestore > headingRestore {
+		t.Error("restore should prefer exact saved ratio before falling back to saved heading")
+	}
 }
 
 func TestBylineShowsModelAndVoiceReveal(t *testing.T) {

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -253,16 +253,20 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 			t.Fatal(err)
 		}
 		tut := &store.Tutorial{
-			Slug:     slug,
-			Title:    slug,
-			Status:   store.StatusUnverified,
-			Created:  created,
-			Repo:     repo,
-			Tools:    tools,
-			Progress: progress,
+			Slug:    slug,
+			Title:   slug,
+			Status:  store.StatusUnverified,
+			Created: created,
+			Repo:    repo,
+			Tools:   tools,
 		}
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			t.Fatal(err)
+		}
+		if progress != nil {
+			if err := store.SaveProgress(tutDir, progress); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	now := time.Now()
@@ -342,13 +346,8 @@ func TestTutorialPage(t *testing.T) {
 func TestTutorialPageRendersCurrentProgressData(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
-	tut, err := store.ReadMetadata(tutDir)
-	if err != nil {
-		t.Fatalf("ReadMetadata: %v", err)
-	}
-	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.42, HeadingID: "next-step", UpdatedAt: time.Now()}
-	if err := store.WriteMetadata(tutDir, tut); err != nil {
-		t.Fatalf("WriteMetadata: %v", err)
+	if err := store.SaveProgress(tutDir, &store.Progress{Part: "part-02.md", Ratio: 0.42, HeadingID: "next-step", UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
 	}
 
 	srv := serve.NewServer(dir)
@@ -900,13 +899,8 @@ func TestSeriesRedirect(t *testing.T) {
 func TestSeriesRedirectUsesProgressPart(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
-	tut, err := store.ReadMetadata(tutDir)
-	if err != nil {
-		t.Fatalf("ReadMetadata: %v", err)
-	}
-	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.5, UpdatedAt: time.Now()}
-	if err := store.WriteMetadata(tutDir, tut); err != nil {
-		t.Fatalf("WriteMetadata: %v", err)
+	if err := store.SaveProgress(tutDir, &store.Progress{Part: "part-02.md", Ratio: 0.5, UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
 	}
 
 	srv := serve.NewServer(dir)
@@ -925,13 +919,8 @@ func TestSeriesRedirectUsesProgressPart(t *testing.T) {
 func TestSeriesRedirectIgnoresStaleProgressPart(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
-	tut, err := store.ReadMetadata(tutDir)
-	if err != nil {
-		t.Fatalf("ReadMetadata: %v", err)
-	}
-	tut.Progress = &store.Progress{Part: "part-99.md", Ratio: 0.5, UpdatedAt: time.Now()}
-	if err := store.WriteMetadata(tutDir, tut); err != nil {
-		t.Fatalf("WriteMetadata: %v", err)
+	if err := store.SaveProgress(tutDir, &store.Progress{Part: "part-99.md", Ratio: 0.5, UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
 	}
 
 	srv := serve.NewServer(dir)

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -244,7 +244,7 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	// Three tutorials with distinct created times — exercises the flat
 	// newest-first list, repo as searchable metadata (data-repo), and version
 	// chips + the Versions filter row.
-	mk := func(slug string, repo string, tools []store.Tool, created time.Time, checkpoint *store.Checkpoint) {
+	mk := func(slug string, repo string, tools []store.Tool, created time.Time, progress *store.Progress) {
 		tutDir := filepath.Join(dir, slug)
 		if err := os.MkdirAll(tutDir, 0755); err != nil {
 			t.Fatal(err)
@@ -253,20 +253,20 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 			t.Fatal(err)
 		}
 		tut := &store.Tutorial{
-			Slug:       slug,
-			Title:      slug,
-			Status:     store.StatusUnverified,
-			Created:    created,
-			Repo:       repo,
-			Tools:      tools,
-			Checkpoint: checkpoint,
+			Slug:     slug,
+			Title:    slug,
+			Status:   store.StatusUnverified,
+			Created:  created,
+			Repo:     repo,
+			Tools:    tools,
+			Progress: progress,
 		}
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			t.Fatal(err)
 		}
 	}
 	now := time.Now()
-	mk("synth-zig", "github.com/devenjarvis/lathe", []store.Tool{{Name: "zig", Version: "0.13.0"}}, now, &store.Checkpoint{Part: "index.md", Progress: 0.42, UpdatedAt: now})
+	mk("synth-zig", "github.com/devenjarvis/lathe", []store.Tool{{Name: "zig", Version: "0.13.0"}}, now, &store.Progress{Part: "index.md", Ratio: 0.42, UpdatedAt: now})
 	mk("compiler-go", "github.com/devenjarvis/lathe", []store.Tool{{Name: "go", Version: "1.22"}}, now.Add(-time.Hour), nil)
 	mk("standalone", "", nil, now.Add(-2*time.Hour), nil)
 
@@ -289,11 +289,11 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	if !strings.Contains(body, `id="versionFilters"`) {
 		t.Error("list page missing the Versions filter row")
 	}
-	if !strings.Contains(body, `aria-label="Checkpoint at 42%"`) {
-		t.Error("list page missing checkpoint progress label")
+	if !strings.Contains(body, `aria-label="Progress at 42%"`) {
+		t.Error("list page missing progress label")
 	}
 	if !strings.Contains(body, `style="width:42%"`) {
-		t.Error("list page missing checkpoint progress bar width")
+		t.Error("list page missing progress bar width")
 	}
 
 	// All three cards render in one flat list, newest-first.
@@ -324,29 +324,29 @@ func TestTutorialPage(t *testing.T) {
 		t.Error("GET /test-tutorial/ response does not contain page content")
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, `id="checkpointButton"`) {
-		t.Error("tutorial page missing floating desktop checkpoint control")
+	if !strings.Contains(body, `id="saveProgressButton"`) {
+		t.Error("tutorial page missing floating desktop progress control")
 	}
-	dockButtonMarkup := `<button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>`
+	dockButtonMarkup := `<button type="button" class="btn btn-ghost btn-sm progress-button" data-progress-save>Save progress</button>`
 	if strings.Count(body, dockButtonMarkup) != 1 {
-		t.Errorf("tutorial page should render one dock checkpoint control; body excerpt:\n%s", body)
+		t.Errorf("tutorial page should render one dock progress control; body excerpt:\n%s", body)
 	}
-	if !strings.Contains(body, `id="checkpointStatus"`) {
-		t.Error("tutorial page missing checkpoint status live region")
+	if !strings.Contains(body, `id="progressStatus"`) {
+		t.Error("tutorial page missing progress status live region")
 	}
 	if !strings.Contains(body, `data-slug="test-tutorial"`) || !strings.Contains(body, `data-part="index.md"`) {
-		t.Error("tutorial page missing checkpoint routing data on progress bar")
+		t.Error("tutorial page missing progress routing data on progress bar")
 	}
 }
 
-func TestTutorialPageRendersCurrentCheckpointData(t *testing.T) {
+func TestTutorialPageRendersCurrentProgressData(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	tut.Checkpoint = &store.Checkpoint{Part: "part-02.md", Progress: 0.42, UpdatedAt: time.Now()}
+	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.42, UpdatedAt: time.Now()}
 	if err := store.WriteMetadata(tutDir, tut); err != nil {
 		t.Fatalf("WriteMetadata: %v", err)
 	}
@@ -361,13 +361,13 @@ func TestTutorialPageRendersCurrentCheckpointData(t *testing.T) {
 	}
 	body := w.Body.String()
 	if !strings.Contains(body, `data-slug="test-series"`) || !strings.Contains(body, `data-part="part-02.md"`) {
-		t.Error("checkpoint progress bar missing current tutorial/part data")
+		t.Error("progress bar missing current tutorial/part data")
 	}
-	if !strings.Contains(body, `data-checkpoint-progress="0.42"`) {
-		t.Error("checkpoint progress bar missing current checkpoint progress")
+	if !strings.Contains(body, `data-saved-progress="0.42"`) {
+		t.Error("progress bar missing current saved progress")
 	}
-	if !strings.Contains(body, `id="checkpointMarker"`) {
-		t.Error("tutorial page missing checkpoint marker element")
+	if !strings.Contains(body, `id="savedProgressMarker"`) {
+		t.Error("tutorial page missing progress marker element")
 	}
 }
 
@@ -894,14 +894,14 @@ func TestSeriesRedirect(t *testing.T) {
 	}
 }
 
-func TestSeriesRedirectUsesCheckpointPart(t *testing.T) {
+func TestSeriesRedirectUsesProgressPart(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	tut.Checkpoint = &store.Checkpoint{Part: "part-02.md", Progress: 0.5, UpdatedAt: time.Now()}
+	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.5, UpdatedAt: time.Now()}
 	if err := store.WriteMetadata(tutDir, tut); err != nil {
 		t.Fatalf("WriteMetadata: %v", err)
 	}
@@ -919,14 +919,14 @@ func TestSeriesRedirectUsesCheckpointPart(t *testing.T) {
 	}
 }
 
-func TestSeriesRedirectIgnoresStaleCheckpointPart(t *testing.T) {
+func TestSeriesRedirectIgnoresStaleProgressPart(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	tut.Checkpoint = &store.Checkpoint{Part: "part-99.md", Progress: 0.5, UpdatedAt: time.Now()}
+	tut.Progress = &store.Progress{Part: "part-99.md", Ratio: 0.5, UpdatedAt: time.Now()}
 	if err := store.WriteMetadata(tutDir, tut); err != nil {
 		t.Fatalf("WriteMetadata: %v", err)
 	}
@@ -1124,138 +1124,138 @@ func TestDeleteEndpointMissingSlug(t *testing.T) {
 	}
 }
 
-func TestCheckpointEndpointSavesMetadata(t *testing.T) {
+func TestProgressEndpointSavesMetadata(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 
 	srv := serve.NewServer(dir)
-	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-02.md", bytes.NewBufferString(`{"progress":0.42,"heading_id":"next-step"}`))
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-02.md", bytes.NewBufferString(`{"ratio":0.42,"heading_id":"next-step"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Origin", "http://localhost:4242")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Fatalf("POST /-/checkpoint/test-series/part-02.md = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+		t.Fatalf("POST /-/progress/test-series/part-02.md = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
 	}
 	var response struct {
-		Checkpoint *store.Checkpoint `json:"checkpoint"`
+		Progress *store.Progress `json:"progress"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("decode checkpoint response: %v", err)
+		t.Fatalf("decode progress response: %v", err)
 	}
-	if response.Checkpoint == nil {
-		t.Fatal("response checkpoint = nil, want saved checkpoint")
+	if response.Progress == nil {
+		t.Fatal("response progress = nil, want saved progress")
 	}
-	if response.Checkpoint.Part != "part-02.md" || response.Checkpoint.Progress != 0.42 || response.Checkpoint.HeadingID != "next-step" {
-		t.Errorf("response checkpoint = %+v, want part/progress/heading to match request", response.Checkpoint)
+	if response.Progress.Part != "part-02.md" || response.Progress.Ratio != 0.42 || response.Progress.HeadingID != "next-step" {
+		t.Errorf("response progress = %+v, want part/ratio/heading to match request", response.Progress)
 	}
 
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if tut.Checkpoint == nil {
-		t.Fatal("metadata checkpoint = nil, want saved checkpoint")
+	if tut.Progress == nil {
+		t.Fatal("metadata progress = nil, want saved progress")
 	}
-	if tut.Checkpoint.Part != "part-02.md" {
-		t.Errorf("metadata checkpoint part = %q, want part-02.md", tut.Checkpoint.Part)
+	if tut.Progress.Part != "part-02.md" {
+		t.Errorf("metadata progress part = %q, want part-02.md", tut.Progress.Part)
 	}
-	if tut.Checkpoint.Progress != 0.42 {
-		t.Errorf("metadata checkpoint progress = %v, want 0.42", tut.Checkpoint.Progress)
+	if tut.Progress.Ratio != 0.42 {
+		t.Errorf("metadata progress ratio = %v, want 0.42", tut.Progress.Ratio)
 	}
-	if tut.Checkpoint.HeadingID != "next-step" {
-		t.Errorf("metadata checkpoint heading = %q, want next-step", tut.Checkpoint.HeadingID)
+	if tut.Progress.HeadingID != "next-step" {
+		t.Errorf("metadata progress heading = %q, want next-step", tut.Progress.HeadingID)
 	}
-	if tut.Checkpoint.UpdatedAt.IsZero() {
-		t.Error("metadata checkpoint updated_at is zero")
+	if tut.Progress.UpdatedAt.IsZero() {
+		t.Error("metadata progress updated_at is zero")
 	}
 }
 
-func TestCheckpointEndpointRejectsForeignOrigin(t *testing.T) {
+func TestProgressEndpointRejectsForeignOrigin(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 
 	srv := serve.NewServer(dir)
-	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(`{"progress":0.5}`))
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{"ratio":0.5}`))
 	req.Header.Set("Origin", "http://evil.example.com")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
-		t.Errorf("foreign-origin checkpoint = %d, want %d", w.Code, http.StatusForbidden)
+		t.Errorf("foreign-origin progress = %d, want %d", w.Code, http.StatusForbidden)
 	}
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if tut.Checkpoint != nil {
-		t.Errorf("foreign-origin checkpoint wrote metadata: %+v", tut.Checkpoint)
+	if tut.Progress != nil {
+		t.Errorf("foreign-origin progress wrote metadata: %+v", tut.Progress)
 	}
 }
 
-func TestCheckpointEndpointRejectsUnknownTutorial(t *testing.T) {
+func TestProgressEndpointRejectsUnknownTutorial(t *testing.T) {
 	dir := t.TempDir()
 	srv := serve.NewServer(dir)
-	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/missing/part-01.md", bytes.NewBufferString(`{"progress":0.5}`))
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/missing/part-01.md", bytes.NewBufferString(`{"ratio":0.5}`))
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
-		t.Errorf("unknown tutorial checkpoint = %d, want %d", w.Code, http.StatusNotFound)
+		t.Errorf("unknown tutorial progress = %d, want %d", w.Code, http.StatusNotFound)
 	}
 }
 
-func TestCheckpointEndpointRejectsUnknownPart(t *testing.T) {
+func TestProgressEndpointRejectsUnknownPart(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 
 	srv := serve.NewServer(dir)
-	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-99.md", bytes.NewBufferString(`{"progress":0.5}`))
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-99.md", bytes.NewBufferString(`{"ratio":0.5}`))
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
-		t.Errorf("unknown part checkpoint = %d, want %d", w.Code, http.StatusNotFound)
+		t.Errorf("unknown part progress = %d, want %d", w.Code, http.StatusNotFound)
 	}
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if tut.Checkpoint != nil {
-		t.Errorf("unknown part checkpoint wrote metadata: %+v", tut.Checkpoint)
+	if tut.Progress != nil {
+		t.Errorf("unknown part progress wrote metadata: %+v", tut.Progress)
 	}
 }
 
-func TestCheckpointEndpointRejectsInvalidJSON(t *testing.T) {
+func TestProgressEndpointRejectsInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
 
 	srv := serve.NewServer(dir)
-	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(`{nope`))
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{nope`))
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
-		t.Errorf("invalid JSON checkpoint = %d, want %d", w.Code, http.StatusBadRequest)
+		t.Errorf("invalid JSON progress = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 	tut, err := store.ReadMetadata(tutDir)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if tut.Checkpoint != nil {
-		t.Errorf("invalid JSON checkpoint wrote metadata: %+v", tut.Checkpoint)
+	if tut.Progress != nil {
+		t.Errorf("invalid JSON progress wrote metadata: %+v", tut.Progress)
 	}
 }
 
-func TestCheckpointEndpointClampsProgress(t *testing.T) {
+func TestProgressEndpointClampsProgress(t *testing.T) {
 	cases := []struct {
 		name string
 		body string
 		want float64
 	}{
-		{"below zero", `{"progress":-0.5}`, 0},
-		{"above one", `{"progress":1.5}`, 1},
+		{"below zero", `{"ratio":-0.5}`, 0},
+		{"above one", `{"ratio":1.5}`, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1263,22 +1263,22 @@ func TestCheckpointEndpointClampsProgress(t *testing.T) {
 			tutDir := makeTestTutorial(t, dir, "test-series", true)
 			srv := serve.NewServer(dir)
 
-			req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(tc.body))
+			req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(tc.body))
 			w := httptest.NewRecorder()
 			srv.Handler().ServeHTTP(w, req)
 
 			if w.Code != http.StatusOK {
-				t.Fatalf("checkpoint save = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+				t.Fatalf("progress save = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
 			}
 			tut, err := store.ReadMetadata(tutDir)
 			if err != nil {
 				t.Fatalf("ReadMetadata: %v", err)
 			}
-			if tut.Checkpoint == nil {
-				t.Fatal("Checkpoint = nil, want saved checkpoint")
+			if tut.Progress == nil {
+				t.Fatal("Progress = nil, want saved progress")
 			}
-			if tut.Checkpoint.Progress != tc.want {
-				t.Errorf("Checkpoint.Progress = %v, want %v", tut.Checkpoint.Progress, tc.want)
+			if tut.Progress.Ratio != tc.want {
+				t.Errorf("Progress.Ratio = %v, want %v", tut.Progress.Ratio, tc.want)
 			}
 		})
 	}

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -62,6 +62,37 @@ func articleHeader(t *testing.T, body string) string {
 	return body[idx : idx+end]
 }
 
+func listPageBody(t *testing.T, dir string) string {
+	t.Helper()
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET / = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+func tutorialCard(t *testing.T, body, slug string) string {
+	t.Helper()
+	slugAttr := `data-slug="` + slug + `"`
+	slugIdx := strings.Index(body, slugAttr)
+	if slugIdx < 0 {
+		t.Fatalf("missing tutorial card for %q; body excerpt:\n%s", slug, body)
+	}
+	start := strings.LastIndex(body[:slugIdx], `<div class="tutorial"`)
+	if start < 0 {
+		t.Fatalf("missing tutorial card wrapper for %q; body excerpt:\n%s", slug, body)
+	}
+	endMarker := "</form>\n    </div>\n  </div>"
+	end := strings.Index(body[slugIdx:], endMarker)
+	if end < 0 {
+		t.Fatalf("tutorial card for %q not closed; body excerpt:\n%s", slug, body[slugIdx:])
+	}
+	return body[start : slugIdx+end+len(endMarker)]
+}
+
 func TestDeleteRejectsForeignOrigin(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "victim", false)
@@ -296,7 +327,7 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	if !strings.Contains(body, `aria-label="Progress at 42%"`) {
 		t.Error("list page missing progress label")
 	}
-	if !strings.Contains(body, `style="width:42%"`) {
+	if !strings.Contains(body, `<span class="fill" style="width:42%"></span>`) {
 		t.Error("list page missing progress bar width")
 	}
 
@@ -309,6 +340,53 @@ func TestListPageRendersCardsAndVersions(t *testing.T) {
 	}
 	if posSynth >= posCompiler || posCompiler >= posStandalone {
 		t.Errorf("cards should render newest-first: synth(%d) < compiler(%d) < standalone(%d)", posSynth, posCompiler, posStandalone)
+	}
+}
+
+func TestListPageRendersSeriesCardProgress(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-series")
+	makeSeriesTutorialWithParts(t, dir, "test-series", 4)
+	if err := store.SaveProgress(tutDir, &store.Progress{Part: "part-02.md", Ratio: 0.42, UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
+	}
+
+	body := listPageBody(t, dir)
+	card := tutorialCard(t, body, "test-series")
+
+	if !strings.Contains(card, `aria-label="Saved at part 2 of 4"`) {
+		t.Error("series card missing part-position aria label")
+	}
+	if !strings.Contains(card, `<span class="tutorial-progress-label">Part 2 of 4</span>`) {
+		t.Error("series card missing Part 2 of 4 progress label")
+	}
+	if got := strings.Count(card, `class="segment`); got != 4 {
+		t.Errorf("series card segment count = %d, want 4", got)
+	}
+	if !strings.Contains(card, `class="segment complete"`) {
+		t.Error("series card missing completed segment")
+	}
+	if !strings.Contains(card, `class="segment current"`) {
+		t.Error("series card missing current segment")
+	}
+	if strings.Contains(card, `Progress 42%`) || strings.Contains(card, `style="width:42%"`) {
+		t.Error("series card should not render saved part scroll ratio as whole-series percentage")
+	}
+}
+
+func TestListPageOmitsStaleSeriesCardProgress(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := filepath.Join(dir, "test-series")
+	makeSeriesTutorialWithParts(t, dir, "test-series", 4)
+	if err := store.SaveProgress(tutDir, &store.Progress{Part: "part-99.md", Ratio: 0.42, UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
+	}
+
+	body := listPageBody(t, dir)
+	card := tutorialCard(t, body, "test-series")
+
+	if strings.Contains(card, `tutorial-progress`) {
+		t.Error("list page should omit card progress for stale series progress part")
 	}
 }
 

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -317,9 +317,12 @@ func TestTutorialPage(t *testing.T) {
 		t.Error("GET /test-tutorial/ response does not contain page content")
 	}
 	body := w.Body.String()
-	buttonMarkup := `<button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>`
-	if strings.Count(body, buttonMarkup) != 2 {
-		t.Errorf("tutorial page should render desktop and dock checkpoint controls; body excerpt:\n%s", body)
+	if !strings.Contains(body, `id="checkpointButton"`) {
+		t.Error("tutorial page missing floating desktop checkpoint control")
+	}
+	dockButtonMarkup := `<button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>`
+	if strings.Count(body, dockButtonMarkup) != 1 {
+		t.Errorf("tutorial page should render one dock checkpoint control; body excerpt:\n%s", body)
 	}
 	if !strings.Contains(body, `id="checkpointStatus"`) {
 		t.Error("tutorial page missing checkpoint status live region")

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1069,6 +1069,118 @@ func TestCheckpointEndpointSavesMetadata(t *testing.T) {
 	}
 }
 
+func TestCheckpointEndpointRejectsForeignOrigin(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(`{"progress":0.5}`))
+	req.Header.Set("Origin", "http://evil.example.com")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("foreign-origin checkpoint = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Checkpoint != nil {
+		t.Errorf("foreign-origin checkpoint wrote metadata: %+v", tut.Checkpoint)
+	}
+}
+
+func TestCheckpointEndpointRejectsUnknownTutorial(t *testing.T) {
+	dir := t.TempDir()
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/missing/part-01.md", bytes.NewBufferString(`{"progress":0.5}`))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown tutorial checkpoint = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestCheckpointEndpointRejectsUnknownPart(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-99.md", bytes.NewBufferString(`{"progress":0.5}`))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown part checkpoint = %d, want %d", w.Code, http.StatusNotFound)
+	}
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Checkpoint != nil {
+		t.Errorf("unknown part checkpoint wrote metadata: %+v", tut.Checkpoint)
+	}
+}
+
+func TestCheckpointEndpointRejectsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(`{nope`))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("invalid JSON checkpoint = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Checkpoint != nil {
+		t.Errorf("invalid JSON checkpoint wrote metadata: %+v", tut.Checkpoint)
+	}
+}
+
+func TestCheckpointEndpointClampsProgress(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want float64
+	}{
+		{"below zero", `{"progress":-0.5}`, 0},
+		{"above one", `{"progress":1.5}`, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tutDir := makeTestTutorial(t, dir, "test-series", true)
+			srv := serve.NewServer(dir)
+
+			req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-01.md", bytes.NewBufferString(tc.body))
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("checkpoint save = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+			}
+			tut, err := store.ReadMetadata(tutDir)
+			if err != nil {
+				t.Fatalf("ReadMetadata: %v", err)
+			}
+			if tut.Checkpoint == nil {
+				t.Fatal("Checkpoint = nil, want saved checkpoint")
+			}
+			if tut.Checkpoint.Progress != tc.want {
+				t.Errorf("Checkpoint.Progress = %v, want %v", tut.Checkpoint.Progress, tc.want)
+			}
+		})
+	}
+}
+
 func TestPathTraversalBlocked(t *testing.T) {
 	dir := t.TempDir()
 	makeTestTutorial(t, dir, "test-tutorial", false)

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1,6 +1,8 @@
 package serve_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1016,6 +1018,54 @@ func TestDeleteEndpointMissingSlug(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("POST /-/delete/nonexistent = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestCheckpointEndpointSavesMetadata(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/checkpoint/test-series/part-02.md", bytes.NewBufferString(`{"progress":0.42,"heading_id":"next-step"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /-/checkpoint/test-series/part-02.md = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var response struct {
+		Checkpoint *store.Checkpoint `json:"checkpoint"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode checkpoint response: %v", err)
+	}
+	if response.Checkpoint == nil {
+		t.Fatal("response checkpoint = nil, want saved checkpoint")
+	}
+	if response.Checkpoint.Part != "part-02.md" || response.Checkpoint.Progress != 0.42 || response.Checkpoint.HeadingID != "next-step" {
+		t.Errorf("response checkpoint = %+v, want part/progress/heading to match request", response.Checkpoint)
+	}
+
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Checkpoint == nil {
+		t.Fatal("metadata checkpoint = nil, want saved checkpoint")
+	}
+	if tut.Checkpoint.Part != "part-02.md" {
+		t.Errorf("metadata checkpoint part = %q, want part-02.md", tut.Checkpoint.Part)
+	}
+	if tut.Checkpoint.Progress != 0.42 {
+		t.Errorf("metadata checkpoint progress = %v, want 0.42", tut.Checkpoint.Progress)
+	}
+	if tut.Checkpoint.HeadingID != "next-step" {
+		t.Errorf("metadata checkpoint heading = %q, want next-step", tut.Checkpoint.HeadingID)
+	}
+	if tut.Checkpoint.UpdatedAt.IsZero() {
+		t.Error("metadata checkpoint updated_at is zero")
 	}
 }
 

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1127,9 +1127,13 @@ func TestDeleteEndpointMissingSlug(t *testing.T) {
 	}
 }
 
-func TestProgressEndpointSavesMetadata(t *testing.T) {
+func TestProgressEndpointSavesProgress(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	before, err := os.ReadFile(filepath.Join(tutDir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile before: %v", err)
+	}
 
 	srv := serve.NewServer(dir)
 	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-02.md", bytes.NewBufferString(`{"ratio":0.42,"heading_id":"next-step"}`))
@@ -1152,6 +1156,13 @@ func TestProgressEndpointSavesMetadata(t *testing.T) {
 	}
 	if response.Progress.Part != "part-02.md" || response.Progress.Ratio != 0.42 || response.Progress.HeadingID != "next-step" {
 		t.Errorf("response progress = %+v, want part/ratio/heading to match request", response.Progress)
+	}
+	after, err := os.ReadFile(filepath.Join(tutDir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile after: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Error("progress save rewrote metadata.json")
 	}
 
 	tut, err := store.ReadMetadata(tutDir)

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -316,6 +316,49 @@ func TestTutorialPage(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "Index") {
 		t.Error("GET /test-tutorial/ response does not contain page content")
 	}
+	body := w.Body.String()
+	buttonMarkup := `<button type="button" class="btn btn-ghost btn-sm checkpoint-button" data-checkpoint-save>Save checkpoint</button>`
+	if strings.Count(body, buttonMarkup) != 2 {
+		t.Errorf("tutorial page should render desktop and dock checkpoint controls; body excerpt:\n%s", body)
+	}
+	if !strings.Contains(body, `id="checkpointStatus"`) {
+		t.Error("tutorial page missing checkpoint status live region")
+	}
+	if !strings.Contains(body, `data-slug="test-tutorial"`) || !strings.Contains(body, `data-part="index.md"`) {
+		t.Error("tutorial page missing checkpoint routing data on progress bar")
+	}
+}
+
+func TestTutorialPageRendersCurrentCheckpointData(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	tut.Checkpoint = &store.Checkpoint{Part: "part-02.md", Progress: 0.42, UpdatedAt: time.Now()}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-series/part-02.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-series/part-02.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `data-slug="test-series"`) || !strings.Contains(body, `data-part="part-02.md"`) {
+		t.Error("checkpoint progress bar missing current tutorial/part data")
+	}
+	if !strings.Contains(body, `data-checkpoint-progress="0.42"`) {
+		t.Error("checkpoint progress bar missing current checkpoint progress")
+	}
+	if !strings.Contains(body, `id="checkpointMarker"`) {
+		t.Error("tutorial page missing checkpoint marker element")
+	}
 }
 
 func TestBylineShowsModelAndVoiceReveal(t *testing.T) {

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -841,6 +841,56 @@ func TestSeriesRedirect(t *testing.T) {
 	}
 }
 
+func TestSeriesRedirectUsesCheckpointPart(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	tut.Checkpoint = &store.Checkpoint{Part: "part-02.md", Progress: 0.5, UpdatedAt: time.Now()}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-series/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("GET /test-series/ = %d, want %d (redirect)", w.Code, http.StatusFound)
+	}
+	if loc := w.Header().Get("Location"); loc != "/test-series/part-02.md" {
+		t.Errorf("redirect Location = %q, want %q", loc, "/test-series/part-02.md")
+	}
+}
+
+func TestSeriesRedirectIgnoresStaleCheckpointPart(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	tut.Checkpoint = &store.Checkpoint{Part: "part-99.md", Progress: 0.5, UpdatedAt: time.Now()}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-series/", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("GET /test-series/ = %d, want %d (redirect)", w.Code, http.StatusFound)
+	}
+	if loc := w.Header().Get("Location"); loc != "/test-series/part-01.md" {
+		t.Errorf("redirect Location = %q, want %q", loc, "/test-series/part-01.md")
+	}
+}
+
 func TestSinglePartRedirect(t *testing.T) {
 	dir := t.TempDir()
 	tutDir := filepath.Join(dir, "single-part")

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1248,6 +1248,27 @@ func TestProgressEndpointRejectsInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestProgressEndpointRejectsMissingRatio(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{"heading_id":"intro"}`))
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing-ratio progress = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Progress != nil {
+		t.Errorf("missing-ratio progress wrote metadata: %+v", tut.Progress)
+	}
+}
+
 func TestProgressEndpointClampsProgress(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -346,7 +346,7 @@ func TestTutorialPageRendersCurrentProgressData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.42, UpdatedAt: time.Now()}
+	tut.Progress = &store.Progress{Part: "part-02.md", Ratio: 0.42, HeadingID: "next-step", UpdatedAt: time.Now()}
 	if err := store.WriteMetadata(tutDir, tut); err != nil {
 		t.Fatalf("WriteMetadata: %v", err)
 	}
@@ -365,6 +365,9 @@ func TestTutorialPageRendersCurrentProgressData(t *testing.T) {
 	}
 	if !strings.Contains(body, `data-saved-progress="0.42"`) {
 		t.Error("progress bar missing current saved progress")
+	}
+	if !strings.Contains(body, `data-saved-heading-id="next-step"`) {
+		t.Error("progress bar missing current saved heading")
 	}
 	if !strings.Contains(body, `id="savedProgressMarker"`) {
 		t.Error("tutorial page missing progress marker element")

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -477,10 +477,8 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
 .tutorial-progress{display:flex;align-items:center;gap:.55rem;margin-top:.45rem;max-width:min(16rem,100%)}
 .tutorial-progress-track{position:relative;flex:1;height:.35rem;border-radius:9999px;background:var(--surface-sunken);overflow:hidden;border:1px solid var(--border)}
 .tutorial-progress-track .fill{display:block;height:100%;background:var(--accent);border-radius:inherit}
-.tutorial-progress-segments{display:flex;gap:2px;padding:1px}
-.tutorial-progress-segments .segment{display:block;flex:1;min-width:.35rem;height:100%;border-radius:9999px;background:var(--surface-sunken)}
-.tutorial-progress-segments .segment.complete{background:var(--accent-soft)}
-.tutorial-progress-segments .segment.current{background:var(--accent)}
+.tutorial-progress-segments{display:flex;gap:2px}
+.tutorial-progress-segments .segment{display:block;flex:1;min-width:.35rem;height:100%;border-radius:9999px;background:var(--surface-sunken);overflow:hidden}
 .tutorial-progress-label{font-family:var(--font-display);font-size:.72rem;font-weight:600;color:var(--text-faint);white-space:nowrap}
 /* Sits above the stretched-link overlay so the badge reads and the × deletes. */
 .tutorial-actions{position:relative;z-index:1;display:flex;align-items:center;gap:.6rem;flex-shrink:0;flex-wrap:wrap}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -476,7 +476,11 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
 .meta{font-size:.8rem;color:var(--text-faint);margin-top:.25rem}
 .tutorial-progress{display:flex;align-items:center;gap:.55rem;margin-top:.45rem;max-width:min(16rem,100%)}
 .tutorial-progress-track{position:relative;flex:1;height:.35rem;border-radius:9999px;background:var(--surface-sunken);overflow:hidden;border:1px solid var(--border)}
-.tutorial-progress-track span{display:block;height:100%;background:var(--accent);border-radius:inherit}
+.tutorial-progress-track .fill{display:block;height:100%;background:var(--accent);border-radius:inherit}
+.tutorial-progress-segments{display:flex;gap:2px;padding:1px}
+.tutorial-progress-segments .segment{display:block;flex:1;min-width:.35rem;height:100%;border-radius:9999px;background:var(--surface-sunken)}
+.tutorial-progress-segments .segment.complete{background:var(--accent-soft)}
+.tutorial-progress-segments .segment.current{background:var(--accent)}
 .tutorial-progress-label{font-family:var(--font-display);font-size:.72rem;font-weight:600;color:var(--text-faint);white-space:nowrap}
 /* Sits above the stretched-link overlay so the badge reads and the × deletes. */
 .tutorial-actions{position:relative;z-index:1;display:flex;align-items:center;gap:.6rem;flex-shrink:0;flex-wrap:wrap}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -340,7 +340,6 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    (see the responsive block) and toggles the ToC drawer. */
 #topBar{display:flex;position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);padding:.55rem .85rem;z-index:50;align-items:center;gap:.7rem}
 #topBar .theme-toggle{margin-left:auto;flex-shrink:0}
-#topBar .checkpoint-button{flex-shrink:0}
 .checkpoint-button{color:var(--accent);border-color:var(--border-strong)}
 .checkpoint-button:hover:not(:disabled){background:var(--accent-soft);color:var(--accent);border-color:var(--accent)}
 #hamburger{display:none;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;cursor:pointer;padding:.3rem .55rem;border-radius:var(--radius-sm);line-height:1;font-size:1.15rem;flex-shrink:0}
@@ -415,10 +414,11 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    style comes from .btn .btn-primary in the markup.) */
 #extendForm .btn{align-self:flex-start}
 
-/* Floating Ask button (wide screens) — .btn .btn-primary .btn-pill in markup;
-   this only adds the fixed positioning, shadow, and lift-on-hover. */
-#askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;box-shadow:var(--shadow-md)}
-#askButton:hover{transform:translateY(-2px)}
+/* Floating reader actions (wide screens) — checkpoint + Ask stay available while
+   reading, matching the fixed affordance the Ask button already used. */
+#floatingActions{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;display:flex;align-items:center;gap:.55rem}
+#floatingActions .btn{box-shadow:var(--shadow-md)}
+#floatingActions .btn:hover{transform:translateY(-2px)}
 .checkpoint-status{position:fixed;right:1.5rem;bottom:4.5rem;z-index:40;max-width:min(18rem,calc(100vw - 2rem));padding:.45rem .7rem;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-sm);color:var(--text-subtle);font-size:.82rem;line-height:1.35;opacity:0;pointer-events:none;transform:translateY(.35rem);transition:opacity var(--transition),transform var(--transition),color var(--transition),border-color var(--transition)}
 .checkpoint-status:not(:empty){opacity:1;transform:translateY(0)}
 .checkpoint-status[data-state="error"]{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
@@ -535,10 +535,10 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
   main{max-width:none;padding-bottom:5.5rem}
   #tocRail{display:none}
   #hamburger{display:inline-flex}
-  #topBar .back-link,#topBar .theme-toggle,#topBar .checkpoint-button{display:none}
+  #topBar .back-link,#topBar .theme-toggle{display:none}
   #bottomDock{display:flex}
   #bottomDock .checkpoint-button{flex:1;min-width:0}
-  #askButton{display:none}
+  #floatingActions{display:none}
   .checkpoint-status{left:.85rem;right:.85rem;bottom:4.25rem;max-width:none;text-align:center}
 }
 

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -116,8 +116,8 @@ body{
 /* Reading-progress bar (fixed, above sticky header, below ask drawer) */
 #progressBar{position:fixed;top:0;left:0;right:0;height:3px;background:transparent;z-index:70;pointer-events:none}
 #progressBar > div{height:100%;background:var(--accent);transform:scaleX(0);transform-origin:left center;will-change:transform}
-#checkpointMarker{position:absolute;top:50%;width:9px;height:9px;border:2px solid var(--surface);border-radius:9999px;background:var(--accent);box-shadow:0 0 0 1px var(--accent),var(--shadow-sm);transform:translate(-50%,-50%)}
-#checkpointMarker[hidden]{display:none}
+#savedProgressMarker{position:absolute;top:50%;width:9px;height:9px;border:2px solid var(--surface);border-radius:9999px;background:var(--accent);box-shadow:0 0 0 1px var(--accent),var(--shadow-sm);transform:translate(-50%,-50%)}
+#savedProgressMarker[hidden]{display:none}
 
 /* Layout shell (reading page) */
 .layout{display:flex;min-height:100vh}
@@ -340,8 +340,8 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    (see the responsive block) and toggles the ToC drawer. */
 #topBar{display:flex;position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);padding:.55rem .85rem;z-index:50;align-items:center;gap:.7rem}
 #topBar .theme-toggle{margin-left:auto;flex-shrink:0}
-.checkpoint-button{color:var(--accent);border-color:var(--border-strong)}
-.checkpoint-button:hover:not(:disabled){background:var(--accent-soft);color:var(--accent);border-color:var(--accent)}
+.progress-button{color:var(--accent);border-color:var(--border-strong)}
+.progress-button:hover:not(:disabled){background:var(--accent-soft);color:var(--accent);border-color:var(--accent)}
 #hamburger{display:none;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;cursor:pointer;padding:.3rem .55rem;border-radius:var(--radius-sm);line-height:1;font-size:1.15rem;flex-shrink:0}
 #hamburger:hover{background:var(--surface-sunken);color:var(--text)}
 /* The crumb is a flex row (overflow:visible) so the part-picker dropdown isn't
@@ -414,14 +414,14 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    style comes from .btn .btn-primary in the markup.) */
 #extendForm .btn{align-self:flex-start}
 
-/* Floating reader actions (wide screens) — checkpoint + Ask stay available while
+/* Floating reader actions (wide screens) — progress + Ask stay available while
    reading, matching the fixed affordance the Ask button already used. */
 #floatingActions{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;display:flex;align-items:center;gap:.55rem}
 #floatingActions .btn{box-shadow:var(--shadow-md)}
 #floatingActions .btn:hover{transform:translateY(-2px)}
-.checkpoint-status{position:fixed;right:1.5rem;bottom:4.5rem;z-index:40;max-width:min(18rem,calc(100vw - 2rem));padding:.45rem .7rem;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-sm);color:var(--text-subtle);font-size:.82rem;line-height:1.35;opacity:0;pointer-events:none;transform:translateY(.35rem);transition:opacity var(--transition),transform var(--transition),color var(--transition),border-color var(--transition)}
-.checkpoint-status:not(:empty){opacity:1;transform:translateY(0)}
-.checkpoint-status[data-state="error"]{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
+.progress-status{position:fixed;right:1.5rem;bottom:4.5rem;z-index:40;max-width:min(18rem,calc(100vw - 2rem));padding:.45rem .7rem;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-sm);color:var(--text-subtle);font-size:.82rem;line-height:1.35;opacity:0;pointer-events:none;transform:translateY(.35rem);transition:opacity var(--transition),transform var(--transition),color var(--transition),border-color var(--transition)}
+.progress-status:not(:empty){opacity:1;transform:translateY(0)}
+.progress-status[data-state="error"]{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
 
 /* Bottom action dock (narrow only) */
 #bottomDock{display:none;position:fixed;left:0;right:0;bottom:0;background:var(--surface);border-top:1px solid var(--border);padding:.55rem .85rem;z-index:50;justify-content:space-between;align-items:center;gap:.7rem}
@@ -541,9 +541,9 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
   #hamburger{display:inline-flex}
   #topBar .back-link,#topBar .theme-toggle{display:none}
   #bottomDock{display:flex}
-  #bottomDock .checkpoint-button{flex:1;min-width:0}
+  #bottomDock .progress-button{flex:1;min-width:0}
   #floatingActions{display:none}
-  .checkpoint-status{left:.85rem;right:.85rem;bottom:4.25rem;max-width:none;text-align:center}
+  .progress-status{left:.85rem;right:.85rem;bottom:4.25rem;max-width:none;text-align:center}
 }
 
 /* Bottom-sheet Ask drawer (≤700px) */

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -116,6 +116,8 @@ body{
 /* Reading-progress bar (fixed, above sticky header, below ask drawer) */
 #progressBar{position:fixed;top:0;left:0;right:0;height:3px;background:transparent;z-index:70;pointer-events:none}
 #progressBar > div{height:100%;background:var(--accent);transform:scaleX(0);transform-origin:left center;will-change:transform}
+#checkpointMarker{position:absolute;top:50%;width:9px;height:9px;border:2px solid var(--surface);border-radius:9999px;background:var(--accent);box-shadow:0 0 0 1px var(--accent),var(--shadow-sm);transform:translate(-50%,-50%)}
+#checkpointMarker[hidden]{display:none}
 
 /* Layout shell (reading page) */
 .layout{display:flex;min-height:100vh}
@@ -339,6 +341,8 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 #topBar{display:flex;position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);padding:.55rem .85rem;z-index:50;align-items:center;gap:.7rem}
 #topBar .theme-toggle{margin-left:auto;flex-shrink:0}
 #topBar .checkpoint-button{flex-shrink:0}
+.checkpoint-button{color:var(--accent);border-color:var(--border-strong)}
+.checkpoint-button:hover:not(:disabled){background:var(--accent-soft);color:var(--accent);border-color:var(--accent)}
 #hamburger{display:none;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;cursor:pointer;padding:.3rem .55rem;border-radius:var(--radius-sm);line-height:1;font-size:1.15rem;flex-shrink:0}
 #hamburger:hover{background:var(--surface-sunken);color:var(--text)}
 /* The crumb is a flex row (overflow:visible) so the part-picker dropdown isn't
@@ -415,6 +419,9 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    this only adds the fixed positioning, shadow, and lift-on-hover. */
 #askButton{position:fixed;bottom:1.5rem;right:1.5rem;z-index:40;box-shadow:var(--shadow-md)}
 #askButton:hover{transform:translateY(-2px)}
+.checkpoint-status{position:fixed;right:1.5rem;bottom:4.5rem;z-index:40;max-width:min(18rem,calc(100vw - 2rem));padding:.45rem .7rem;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--surface);box-shadow:var(--shadow-sm);color:var(--text-subtle);font-size:.82rem;line-height:1.35;opacity:0;pointer-events:none;transform:translateY(.35rem);transition:opacity var(--transition),transform var(--transition),color var(--transition),border-color var(--transition)}
+.checkpoint-status:not(:empty){opacity:1;transform:translateY(0)}
+.checkpoint-status[data-state="error"]{color:var(--badge-failed-text);border-color:var(--badge-failed-text);background:var(--badge-failed-bg)}
 
 /* Bottom action dock (narrow only) */
 #bottomDock{display:none;position:fixed;left:0;right:0;bottom:0;background:var(--surface);border-top:1px solid var(--border);padding:.55rem .85rem;z-index:50;justify-content:space-between;align-items:center;gap:.7rem}
@@ -530,7 +537,9 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
   #hamburger{display:inline-flex}
   #topBar .back-link,#topBar .theme-toggle,#topBar .checkpoint-button{display:none}
   #bottomDock{display:flex}
+  #bottomDock .checkpoint-button{flex:1;min-width:0}
   #askButton{display:none}
+  .checkpoint-status{left:.85rem;right:.85rem;bottom:4.25rem;max-width:none;text-align:center}
 }
 
 /* Bottom-sheet Ask drawer (≤700px) */

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -474,6 +474,10 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
 .tutorial-link::after{content:'';position:absolute;inset:0;z-index:0}
 .tutorial:hover .tutorial-link{color:var(--accent-hover);text-decoration:underline;text-underline-offset:2px}
 .meta{font-size:.8rem;color:var(--text-faint);margin-top:.25rem}
+.tutorial-progress{display:flex;align-items:center;gap:.55rem;margin-top:.45rem;max-width:min(16rem,100%)}
+.tutorial-progress-track{position:relative;flex:1;height:.35rem;border-radius:9999px;background:var(--surface-sunken);overflow:hidden;border:1px solid var(--border)}
+.tutorial-progress-track span{display:block;height:100%;background:var(--accent);border-radius:inherit}
+.tutorial-progress-label{font-family:var(--font-display);font-size:.72rem;font-weight:600;color:var(--text-faint);white-space:nowrap}
 /* Sits above the stretched-link overlay so the badge reads and the × deletes. */
 .tutorial-actions{position:relative;z-index:1;display:flex;align-items:center;gap:.6rem;flex-shrink:0;flex-wrap:wrap}
 .delete-form{margin:0}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -338,6 +338,7 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
    (see the responsive block) and toggles the ToC drawer. */
 #topBar{display:flex;position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);padding:.55rem .85rem;z-index:50;align-items:center;gap:.7rem}
 #topBar .theme-toggle{margin-left:auto;flex-shrink:0}
+#topBar .checkpoint-button{flex-shrink:0}
 #hamburger{display:none;background:transparent;border:1px solid var(--border);color:var(--text-subtle);font:inherit;cursor:pointer;padding:.3rem .55rem;border-radius:var(--radius-sm);line-height:1;font-size:1.15rem;flex-shrink:0}
 #hamburger:hover{background:var(--surface-sunken);color:var(--text)}
 /* The crumb is a flex row (overflow:visible) so the part-picker dropdown isn't
@@ -527,7 +528,7 @@ body.list h1{font-family:var(--font-display);font-size:clamp(1.7rem,1.3rem + 1.4
   main{max-width:none;padding-bottom:5.5rem}
   #tocRail{display:none}
   #hamburger{display:inline-flex}
-  #topBar .back-link,#topBar .theme-toggle{display:none}
+  #topBar .back-link,#topBar .theme-toggle,#topBar .checkpoint-button{display:none}
   #bottomDock{display:flex}
   #askButton{display:none}
 }

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -71,6 +71,17 @@ type Tool struct {
 	Version string `json:"version,omitempty"`
 }
 
+// Checkpoint is a reader-saved position within a tutorial. Part is the rendered
+// markdown file (part-NN.md or legacy index.md), Progress is a 0..1 scroll ratio,
+// HeadingID is an optional best-effort hint, and UpdatedAt records when the
+// checkpoint was last saved.
+type Checkpoint struct {
+	Part      string    `json:"part"`
+	Progress  float64   `json:"progress"`
+	HeadingID string    `json:"heading_id,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 func (t *Tutorial) IsSeries() bool {
 	return len(t.Parts) > 1
 }

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -20,15 +20,15 @@ const (
 )
 
 type Tutorial struct {
-	Slug        string      `json:"slug"`
-	Title       string      `json:"title"`
-	Topic       string      `json:"topic"`
-	Created     time.Time   `json:"created"`
-	Status      Status      `json:"status"`
-	Tags        []string    `json:"tags,omitempty"`
-	Parts       []string    `json:"parts,omitempty"`
-	PendingPart string      `json:"pending_part,omitempty"`
-	Checkpoint  *Checkpoint `json:"checkpoint,omitempty"`
+	Slug        string    `json:"slug"`
+	Title       string    `json:"title"`
+	Topic       string    `json:"topic"`
+	Created     time.Time `json:"created"`
+	Status      Status    `json:"status"`
+	Tags        []string  `json:"tags,omitempty"`
+	Parts       []string  `json:"parts,omitempty"`
+	PendingPart string    `json:"pending_part,omitempty"`
+	Progress    *Progress `json:"progress,omitempty"`
 	// Repo is the canonical identifier (host/org/repo) of the git repository the
 	// tutorial was written for, derived from the repo's origin remote by the
 	// generation skill and normalized by NormalizeRepo. Tutorials with no repo
@@ -72,13 +72,13 @@ type Tool struct {
 	Version string `json:"version,omitempty"`
 }
 
-// Checkpoint is a reader-saved position within a tutorial. Part is the rendered
-// markdown file (part-NN.md or legacy index.md), Progress is a 0..1 scroll ratio,
-// HeadingID is an optional best-effort hint, and UpdatedAt records when the
-// checkpoint was last saved.
-type Checkpoint struct {
+// Progress is a reader-saved position within a tutorial. Part is the rendered
+// markdown file (part-NN.md or legacy index.md), Ratio is a 0..1 scroll ratio,
+// HeadingID is an optional best-effort hint, and UpdatedAt records when progress
+// was last saved.
+type Progress struct {
 	Part      string    `json:"part"`
-	Progress  float64   `json:"progress"`
+	Ratio     float64   `json:"ratio"`
 	HeadingID string    `json:"heading_id,omitempty"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -115,7 +115,18 @@ func ReadMetadata(tutorialDir string) (*Tutorial, error) {
 		return nil, err
 	}
 	var t Tutorial
-	return &t, json.Unmarshal(data, &t)
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, err
+	}
+	if t.Progress == nil {
+		var legacy struct {
+			LegacyProgress *Progress `json:"checkpoint"`
+		}
+		if err := json.Unmarshal(data, &legacy); err == nil {
+			t.Progress = legacy.LegacyProgress
+		}
+	}
+	return &t, nil
 }
 
 func WriteMetadata(tutorialDir string, t *Tutorial) error {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,6 +127,11 @@ func ReadMetadata(tutorialDir string) (*Tutorial, error) {
 			t.Progress = legacy.LegacyProgress
 		}
 	}
+	if progress, err := ReadProgress(tutorialDir); err == nil {
+		t.Progress = progress
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
 	return &t, nil
 }
 
@@ -135,6 +141,26 @@ func WriteMetadata(tutorialDir string, t *Tutorial) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(tutorialDir, "metadata.json"), data, 0644)
+}
+
+func ReadProgress(tutorialDir string) (*Progress, error) {
+	data, err := os.ReadFile(filepath.Join(tutorialDir, "progress.json"))
+	if err != nil {
+		return nil, err
+	}
+	var progress Progress
+	if err := json.Unmarshal(data, &progress); err != nil {
+		return nil, err
+	}
+	return &progress, nil
+}
+
+func SaveProgress(tutorialDir string, progress *Progress) error {
+	data, err := json.MarshalIndent(progress, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(tutorialDir, "progress.json"), data, 0644)
 }
 
 func ReadVerifyResult(tutorialDir string) (*VerifyResult, error) {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -20,14 +20,15 @@ const (
 )
 
 type Tutorial struct {
-	Slug        string    `json:"slug"`
-	Title       string    `json:"title"`
-	Topic       string    `json:"topic"`
-	Created     time.Time `json:"created"`
-	Status      Status    `json:"status"`
-	Tags        []string  `json:"tags,omitempty"`
-	Parts       []string  `json:"parts,omitempty"`
-	PendingPart string    `json:"pending_part,omitempty"`
+	Slug        string      `json:"slug"`
+	Title       string      `json:"title"`
+	Topic       string      `json:"topic"`
+	Created     time.Time   `json:"created"`
+	Status      Status      `json:"status"`
+	Tags        []string    `json:"tags,omitempty"`
+	Parts       []string    `json:"parts,omitempty"`
+	PendingPart string      `json:"pending_part,omitempty"`
+	Checkpoint  *Checkpoint `json:"checkpoint,omitempty"`
 	// Repo is the canonical identifier (host/org/repo) of the git repository the
 	// tutorial was written for, derived from the repo's origin remote by the
 	// generation skill and normalized by NormalizeRepo. Tutorials with no repo

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -119,14 +119,7 @@ func ReadMetadata(tutorialDir string) (*Tutorial, error) {
 	if err := json.Unmarshal(data, &t); err != nil {
 		return nil, err
 	}
-	if t.Progress == nil {
-		var legacy struct {
-			LegacyProgress *Progress `json:"checkpoint"`
-		}
-		if err := json.Unmarshal(data, &legacy); err == nil {
-			t.Progress = legacy.LegacyProgress
-		}
-	}
+	t.Progress = nil
 	if progress, err := ReadProgress(tutorialDir); err == nil {
 		t.Progress = progress
 	} else if !errors.Is(err, os.ErrNotExist) {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -197,7 +197,7 @@ func TestMetadataRoundTripModel(t *testing.T) {
 	}
 }
 
-func TestMetadataRoundTripProgress(t *testing.T) {
+func TestReadMetadataIgnoresEmbeddedProgress(t *testing.T) {
 	dir := t.TempDir()
 	updatedAt := time.Date(2026, 6, 8, 12, 34, 56, 0, time.UTC)
 	tut := &store.Tutorial{
@@ -217,20 +217,8 @@ func TestMetadataRoundTripProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if got.Progress == nil {
-		t.Fatal("Progress = nil, want saved progress")
-	}
-	if got.Progress.Part != "part-02.md" {
-		t.Errorf("Progress.Part = %q, want %q", got.Progress.Part, "part-02.md")
-	}
-	if got.Progress.Ratio != 0.42 {
-		t.Errorf("Progress.Ratio = %v, want %v", got.Progress.Ratio, 0.42)
-	}
-	if got.Progress.HeadingID != "wire-the-parser" {
-		t.Errorf("Progress.HeadingID = %q, want %q", got.Progress.HeadingID, "wire-the-parser")
-	}
-	if !got.Progress.UpdatedAt.Equal(updatedAt) {
-		t.Errorf("Progress.UpdatedAt = %v, want %v", got.Progress.UpdatedAt, updatedAt)
+	if got.Progress != nil {
+		t.Fatalf("Progress = %+v, want nil without progress.json", got.Progress)
 	}
 }
 
@@ -309,7 +297,7 @@ func TestProgressOmittedWhenUnset(t *testing.T) {
 	}
 }
 
-func TestReadMetadataAcceptsLegacyCheckpoint(t *testing.T) {
+func TestReadMetadataIgnoresLegacyCheckpoint(t *testing.T) {
 	dir := t.TempDir()
 	data := `{
   "slug": "legacy",
@@ -327,11 +315,8 @@ func TestReadMetadataAcceptsLegacyCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if got.Progress == nil {
-		t.Fatal("Progress = nil, want legacy checkpoint mapped to progress")
-	}
-	if got.Progress.Part != "part-02.md" || got.Progress.Ratio != 0.42 {
-		t.Errorf("Progress = %+v, want part-02.md at 0.42", got.Progress)
+	if got.Progress != nil {
+		t.Fatalf("Progress = %+v, want nil without progress.json", got.Progress)
 	}
 }
 

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -197,15 +197,15 @@ func TestMetadataRoundTripModel(t *testing.T) {
 	}
 }
 
-func TestMetadataRoundTripCheckpoint(t *testing.T) {
+func TestMetadataRoundTripProgress(t *testing.T) {
 	dir := t.TempDir()
 	updatedAt := time.Date(2026, 6, 8, 12, 34, 56, 0, time.UTC)
 	tut := &store.Tutorial{
 		Slug:   "test-tut",
 		Status: store.StatusUnverified,
-		Checkpoint: &store.Checkpoint{
+		Progress: &store.Progress{
 			Part:      "part-02.md",
-			Progress:  0.42,
+			Ratio:     0.42,
 			HeadingID: "wire-the-parser",
 			UpdatedAt: updatedAt,
 		},
@@ -217,20 +217,20 @@ func TestMetadataRoundTripCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
-	if got.Checkpoint == nil {
-		t.Fatal("Checkpoint = nil, want saved checkpoint")
+	if got.Progress == nil {
+		t.Fatal("Progress = nil, want saved progress")
 	}
-	if got.Checkpoint.Part != "part-02.md" {
-		t.Errorf("Checkpoint.Part = %q, want %q", got.Checkpoint.Part, "part-02.md")
+	if got.Progress.Part != "part-02.md" {
+		t.Errorf("Progress.Part = %q, want %q", got.Progress.Part, "part-02.md")
 	}
-	if got.Checkpoint.Progress != 0.42 {
-		t.Errorf("Checkpoint.Progress = %v, want %v", got.Checkpoint.Progress, 0.42)
+	if got.Progress.Ratio != 0.42 {
+		t.Errorf("Progress.Ratio = %v, want %v", got.Progress.Ratio, 0.42)
 	}
-	if got.Checkpoint.HeadingID != "wire-the-parser" {
-		t.Errorf("Checkpoint.HeadingID = %q, want %q", got.Checkpoint.HeadingID, "wire-the-parser")
+	if got.Progress.HeadingID != "wire-the-parser" {
+		t.Errorf("Progress.HeadingID = %q, want %q", got.Progress.HeadingID, "wire-the-parser")
 	}
-	if !got.Checkpoint.UpdatedAt.Equal(updatedAt) {
-		t.Errorf("Checkpoint.UpdatedAt = %v, want %v", got.Checkpoint.UpdatedAt, updatedAt)
+	if !got.Progress.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("Progress.UpdatedAt = %v, want %v", got.Progress.UpdatedAt, updatedAt)
 	}
 }
 
@@ -248,7 +248,7 @@ func TestModelOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestCheckpointOmittedWhenUnset(t *testing.T) {
+func TestProgressOmittedWhenUnset(t *testing.T) {
 	dir := t.TempDir()
 	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "t", Status: store.StatusUnverified}); err != nil {
 		t.Fatalf("WriteMetadata: %v", err)
@@ -257,8 +257,34 @@ func TestCheckpointOmittedWhenUnset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if strings.Contains(string(data), "checkpoint") {
-		t.Error("\"checkpoint\" should be omitted from JSON when unset")
+	if strings.Contains(string(data), "progress") {
+		t.Error("\"progress\" should be omitted from JSON when unset")
+	}
+}
+
+func TestReadMetadataAcceptsLegacyCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	data := `{
+  "slug": "legacy",
+  "status": "unverified",
+  "checkpoint": {
+    "part": "part-02.md",
+    "ratio": 0.42,
+    "updated_at": "2026-06-08T12:34:56Z"
+  }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(data), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Progress == nil {
+		t.Fatal("Progress = nil, want legacy checkpoint mapped to progress")
+	}
+	if got.Progress.Part != "part-02.md" || got.Progress.Ratio != 0.42 {
+		t.Errorf("Progress = %+v, want part-02.md at 0.42", got.Progress)
 	}
 }
 

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -197,6 +197,43 @@ func TestMetadataRoundTripModel(t *testing.T) {
 	}
 }
 
+func TestMetadataRoundTripCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	updatedAt := time.Date(2026, 6, 8, 12, 34, 56, 0, time.UTC)
+	tut := &store.Tutorial{
+		Slug:   "test-tut",
+		Status: store.StatusUnverified,
+		Checkpoint: &store.Checkpoint{
+			Part:      "part-02.md",
+			Progress:  0.42,
+			HeadingID: "wire-the-parser",
+			UpdatedAt: updatedAt,
+		},
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Checkpoint == nil {
+		t.Fatal("Checkpoint = nil, want saved checkpoint")
+	}
+	if got.Checkpoint.Part != "part-02.md" {
+		t.Errorf("Checkpoint.Part = %q, want %q", got.Checkpoint.Part, "part-02.md")
+	}
+	if got.Checkpoint.Progress != 0.42 {
+		t.Errorf("Checkpoint.Progress = %v, want %v", got.Checkpoint.Progress, 0.42)
+	}
+	if got.Checkpoint.HeadingID != "wire-the-parser" {
+		t.Errorf("Checkpoint.HeadingID = %q, want %q", got.Checkpoint.HeadingID, "wire-the-parser")
+	}
+	if !got.Checkpoint.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("Checkpoint.UpdatedAt = %v, want %v", got.Checkpoint.UpdatedAt, updatedAt)
+	}
+}
+
 func TestModelOmittedWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "t", Status: store.StatusUnverified}); err != nil {
@@ -208,6 +245,20 @@ func TestModelOmittedWhenEmpty(t *testing.T) {
 	}
 	if strings.Contains(string(data), "model") {
 		t.Error("\"model\" should be omitted from JSON when empty")
+	}
+}
+
+func TestCheckpointOmittedWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "t", Status: store.StatusUnverified}); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "checkpoint") {
+		t.Error("\"checkpoint\" should be omitted from JSON when unset")
 	}
 }
 

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -234,6 +234,53 @@ func TestMetadataRoundTripProgress(t *testing.T) {
 	}
 }
 
+func TestSaveProgressDoesNotRewriteMetadata(t *testing.T) {
+	dir := t.TempDir()
+	updatedAt := time.Date(2026, 6, 8, 12, 34, 56, 0, time.UTC)
+	tut := &store.Tutorial{
+		Slug:    "test-tut",
+		Title:   "Test Tutorial",
+		Status:  store.StatusVerified,
+		Tags:    []string{"go"},
+		Created: updatedAt,
+	}
+	if err := store.WriteMetadata(dir, tut); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile before: %v", err)
+	}
+
+	progress := &store.Progress{
+		Part:      "part-02.md",
+		Ratio:     0.42,
+		HeadingID: "wire-the-parser",
+		UpdatedAt: updatedAt,
+	}
+	if err := store.SaveProgress(dir, progress); err != nil {
+		t.Fatalf("SaveProgress: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("ReadFile after: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Error("SaveProgress rewrote metadata.json")
+	}
+
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got.Progress == nil {
+		t.Fatal("Progress = nil, want sidecar progress")
+	}
+	if got.Progress.Part != progress.Part || got.Progress.Ratio != progress.Ratio || got.Progress.HeadingID != progress.HeadingID {
+		t.Errorf("Progress = %+v, want %+v", got.Progress, progress)
+	}
+}
+
 func TestModelOmittedWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "t", Status: store.StatusUnverified}); err != nil {


### PR DESCRIPTION
## Summary

This adds local reading-progress tracking to Lathe’s served tutorial pages.

The reader can save their current position in a tutorial part, and Lathe will restore that position when they come back. For multi-part tutorials, opening the tutorial root will also redirect to the part with saved progress when that saved part is still valid.

## Why

No pressure at all if this is not the direction you want Lathe to take. I made this because I'll personally use it anyway (lathe scratches an itch I’ve had for a few weeks).

I understand this is still a very new project, so this might be too product-y or not aligned with the shape you want. I figured I’d open it as a concrete proposal rather than just describe the idea.

## Implementation Notes

Progress is saved **explicitly** by the reader through the local web UI. The server records:

- the current part
- scroll ratio
- nearest heading id, when available
- update timestamp

I initially put this directly in `metadata.json`, but decided against that while working through the implementation. Reader progress feels more like local personal UI state than durable tutorial metadata, and rewriting the whole metadata object from the web UI also creates unnecessary risk around clobbering changes from commands like verify, extend, or tag.

So this now writes a dedicated `progress.json` sidecar file instead. I’m still not fully satisfied with the shape, but it felt much better than stuffing reader state into tutorial metadata.

## Screenshots

<img width="1396" height="362" alt="image" src="https://github.com/user-attachments/assets/7976c9db-ef75-43ef-8076-c28d0b5ddb56" />

<img width="353" height="373" alt="image" src="https://github.com/user-attachments/assets/a264d32c-d5c3-48f5-92b5-8a42c5016bb6" />


<img width="200" height="102" alt="image" src="https://github.com/user-attachments/assets/717c4048-2704-45b4-8663-137d5b149fa5" />


<img width="378" height="265" alt="screen-recording-2026-06-08-225119" src="https://github.com/user-attachments/assets/ecc86e71-4902-45e0-9638-512129fb3de8" />
