### PR TITLE
feat: implement dwell-time monotonic auto-saving

### DIFF
--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -385,14 +385,25 @@
   })();
 </script>
 <script>
-  // Save progress — explicit user action that persists the current progress
-  // ratio + nearest heading through the local server and updates the marker
-  // from the response.
+  // Save progress — persists the reading progress ratio + nearest heading.
+  // Performs automatic background saves when the user dwells on a section
+  // for at least 3 seconds, ensuring progress is saved monotonically (only forward).
+  // Clicking the manual "Save progress" button triggers an immediate save.
   (function(){
     var progress = document.getElementById('progressBar');
     var buttons = document.querySelectorAll('[data-progress-save]');
     var status = document.getElementById('progressStatus');
     if (!progress || !buttons.length) return;
+
+    var lastSavedRatio = null;
+    function initSavedRatio() {
+      var raw = progress.getAttribute('data-saved-progress');
+      if (raw) {
+        var val = parseFloat(raw);
+        if (!isNaN(val)) lastSavedRatio = val;
+      }
+    }
+    initSavedRatio();
 
     function setStatus(message, error){
       if (!status) return;
@@ -407,40 +418,120 @@
     function setBusy(busy){
       buttons.forEach(function(button){ button.disabled = busy; });
     }
-    buttons.forEach(function(button){
-      button.addEventListener('click', function(){
-        var slug = progress.getAttribute('data-slug') || '';
-        var part = progress.getAttribute('data-part') || '';
-        var reader = window.latheReadingProgress;
-        if (!slug || !part || !reader || !reader.currentRatio) return;
 
+    function triggerSave(ratio, headingID, isAuto) {
+      var slug = progress.getAttribute('data-slug') || '';
+      var part = progress.getAttribute('data-part') || '';
+      if (!slug || !part) return;
+
+      // Monotonic guard: auto-save only moves progress forward
+      if (isAuto && lastSavedRatio !== null && ratio <= lastSavedRatio + 0.02) {
+        return;
+      }
+
+      if (!isAuto) {
         setBusy(true);
         setStatus('', false);
+      } else {
+        setStatus('Auto-saving...', false);
+      }
+
+      fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ratio: ratio, heading_id: headingID})
+      }).then(function(response){
+        if (!response.ok) {
+          return response.text().then(function(text){
+            throw new Error(text || ('HTTP ' + response.status));
+          });
+        }
+        return response.json();
+      }).then(function(data){
+        var saved = data && data.progress ? data.progress.ratio : ratio;
+        var savedHeading = data && data.progress ? data.progress.heading_id : headingID;
+        lastSavedRatio = saved;
+        
+        var reader = window.latheReadingProgress;
+        if (reader && reader.setSavedProgress) {
+          reader.setSavedProgress(saved, savedHeading);
+        }
+        setStatus(isAuto ? 'Progress auto-saved' : 'Progress saved', false);
+      }).catch(function(err){
+        if (!isAuto) {
+          setStatus('Progress save failed: ' + (err && err.message ? err.message : 'request failed'), true);
+        } else {
+          console.warn('Lathe auto-save failed:', err);
+          setStatus('', false);
+        }
+      }).then(function(){
+        if (!isAuto) {
+          setBusy(false);
+        }
+      });
+    }
+
+    // Manual save button trigger
+    buttons.forEach(function(button){
+      button.addEventListener('click', function(){
+        var reader = window.latheReadingProgress;
+        if (!reader || !reader.currentRatio) return;
         var ratio = reader.currentRatio();
         var headingID = reader.currentHeadingID ? reader.currentHeadingID() : '';
-        fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({ratio: ratio, heading_id: headingID})
-        }).then(function(response){
-          if (!response.ok) {
-            return response.text().then(function(text){
-              throw new Error(text || ('HTTP ' + response.status));
-            });
-          }
-          return response.json();
-        }).then(function(data){
-          var saved = data && data.progress ? data.progress.ratio : ratio;
-          var savedHeading = data && data.progress ? data.progress.heading_id : headingID;
-          if (reader.setSavedProgress) reader.setSavedProgress(saved, savedHeading);
-          setStatus('Progress saved', false);
-        }).catch(function(err){
-          setStatus('Progress save failed: ' + (err && err.message ? err.message : 'request failed'), true);
-        }).then(function(){
-          setBusy(false);
-        });
+        triggerSave(ratio, headingID, false);
       });
     });
+
+    // Dwell-time active viewport tracker for auto-saving
+    var currentHeading = '';
+    var dwellTimer = null;
+    var lastCheckedRatio = 0;
+
+    function handleHeadingChange(newHeading) {
+      if (dwellTimer) {
+        clearTimeout(dwellTimer);
+        dwellTimer = null;
+      }
+
+      currentHeading = newHeading;
+      
+      var reader = window.latheReadingProgress;
+      if (!reader || !reader.currentRatio) return;
+      var ratio = reader.currentRatio();
+
+      // Start a 3-second dwell timer for the active section
+      dwellTimer = setTimeout(function() {
+        var currentReader = window.latheReadingProgress;
+        if (!currentReader || !currentReader.currentRatio) return;
+        
+        var freshRatio = currentReader.currentRatio();
+        var freshHeading = currentReader.currentHeadingID ? currentReader.currentHeadingID() : '';
+        
+        // Confirm the user is still on the same heading/section
+        if (freshHeading === currentHeading) {
+          triggerSave(freshRatio, freshHeading, true);
+        }
+      }, 3000);
+    }
+
+    // Monitor active section changes on scroll
+    window.addEventListener('scroll', function() {
+      var reader = window.latheReadingProgress;
+      if (!reader || !reader.currentHeadingID) return;
+      
+      var newHeading = reader.currentHeadingID();
+      if (newHeading !== currentHeading) {
+        handleHeadingChange(newHeading);
+      }
+    }, {passive: true});
+
+    // Initial check on load
+    setTimeout(function() {
+      var reader = window.latheReadingProgress;
+      if (reader && reader.currentHeadingID) {
+        handleHeadingChange(reader.currentHeadingID());
+      }
+    }, 500);
   })();
 </script>
 <script>


### PR DESCRIPTION
Hi! Thank you so much for building and maintaining Lathe. I use it regularly to manage and read generated tutorials, and it's been an incredibly useful tool!

I noticed that we have to manually click the save button to record reading progress, which can be easily forgotten. This PR implements a **Dwell-Time Viewport Tracker** that automatically saves reading progress in the background as the user scrolls.

### Changes:
- **Monotonic Guard**: Compares current scrolling ratio against the last saved progress (`data-saved-progress`). Auto-save will never decrease progress when scrolling back up.
- **Active Section Dwell Gate**: Tracks active sections (`currentHeadingID()`) and runs a 3-second debounce check. It only saves progress once the user has paused/dwelled on a heading for 3 seconds, avoiding API call spam during rapid scrolling.
- **Visual Feedback**: The layout updates scroll indicators smoothly in the background when a save event completes.

### Verification & Testing
- Ran all Go tests successfully (`go test ./...` passes cleanly).
- Verified the local server builds and runs correctly.
- Manually tested scroll-based progress updates.

<img width="1464" height="820" alt="Screenshot 2026-06-10 at 9 05 15 PM" src="https://github.com/user-attachments/assets/c30a6fcb-7420-4ee9-a07f-2a3294dda57d" />
