### PR TITLE
fix: refresh progress cards on back navigation (bfcache)

### DIFF
--- a/internal/serve/list.html
+++ b/internal/serve/list.html
@@ -235,6 +235,71 @@
     sort();   // default ordering (newest) for the flat list
     apply();
   })();
+  
+  // Refresh progress cards in place if navigating back via browser back button (bfcache).
+  window.addEventListener('pageshow', function(event) {
+    if (event.persisted) {
+      fetch('/', {
+        headers: { 'Accept': 'application/json' }
+      })
+      .then(function(res) { return res.json(); })
+      .then(function(data) {
+        if (!Array.isArray(data)) return;
+        data.forEach(function(item) {
+          var card = document.querySelector('.tutorial[data-slug="' + item.slug + '"]');
+          if (!card) return;
+          var body = card.querySelector('.tutorial-body');
+          if (!body) return;
+          
+          var progEl = body.querySelector('.tutorial-progress');
+          var p = item.progress;
+          
+          if (!p) {
+            if (progEl) progEl.remove();
+            return;
+          }
+          
+          var html = '';
+          if (p.IsSeries) {
+            var segmentsHtml = '';
+            if (p.Segments) {
+              p.Segments.forEach(function(seg) {
+                var currentClass = seg.Current ? ' current' : '';
+                segmentsHtml += '<span class="segment' + currentClass + '" aria-hidden="true">' +
+                  '<span class="fill" style="width:' + seg.Percent + '%"></span></span>';
+              });
+            }
+            html = '<div class="tutorial-progress-track tutorial-progress-segments">' + segmentsHtml + '</div>' +
+              '<span class="tutorial-progress-label">Part ' + p.PartNumber + ' of ' + p.TotalParts + ' (' + p.Percent + '%)</span>';
+          } else {
+            html = '<div class="tutorial-progress-track"><span class="fill" style="width:' + p.Percent + '%"></span></div>' +
+              '<span class="tutorial-progress-label">Progress ' + p.Percent + '%</span>';
+          }
+          
+          if (!progEl) {
+            progEl = document.createElement('div');
+            progEl.className = 'tutorial-progress';
+            var meta = body.querySelector('.meta');
+            if (meta && meta.nextSibling) {
+              body.insertBefore(progEl, meta.nextSibling);
+            } else {
+              body.appendChild(progEl);
+            }
+          }
+          
+          if (p.IsSeries) {
+            progEl.setAttribute('aria-label', 'Saved at part ' + p.PartNumber + ' of ' + p.TotalParts);
+          } else {
+            progEl.setAttribute('aria-label', 'Progress at ' + p.Percent + '%');
+          }
+          progEl.innerHTML = html;
+        });
+      })
+      .catch(function(err) {
+        console.error('Failed to update progress cards:', err);
+      });
+    }
+  });
 </script>
 </body>
 </html>

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -160,6 +161,22 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 	sort.SliceStable(tutorials, func(a, b int) bool {
 		return tutorials[a].Created.After(tutorials[b].Created)
 	})
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		type ProgressJSON struct {
+			Slug     string        `json:"slug"`
+			Progress *CardProgress `json:"progress"`
+		}
+		var list []ProgressJSON
+		for _, tut := range tutorials {
+			list = append(list, ProgressJSON{
+				Slug:     tut.Slug,
+				Progress: cardProgress(tut),
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(list)
+		return
+	}
 	var buf bytes.Buffer
 	if err := s.listTmpl.Execute(&buf, map[string]any{
 		"Tutorials":    tutorials,


### PR DESCRIPTION
Hi! Thank you so much for building and maintaining Lathe. I use it regularly to manage and read generated tutorials, and it's been an incredibly useful tool!

I noticed an annoying bug where returning to the main list page (`/`) via the browser's back button loads it from the back-forward cache (bfcache), showing stale progress cards unless manually refreshed.

This PR implements a smooth, in-place AJAX progress card refresh to resolve it:

### Changes:
- **Server-Side Content Negotiation**: Enhanced the main list endpoint (`GET /`) to support `Accept: application/json`. When requested, it returns a lightweight JSON list of tutorial slugs and their calculated card progress values, avoiding heavy HTML renders.
- **Client-Side `pageshow` Update**: Added a handler in `list.html` that triggers when the page is loaded from bfcache (`event.persisted`). It fetches the JSON progress list and updates or inserts the progress elements on the cards in-place.
- **Preserves Page State**: Because it updates in-place, the reader's active filters, typed search queries, and scroll position on the list page are completely preserved.

### Verification & Testing
- Ran all Go tests successfully (`go test ./...` passes cleanly).
- Verified the local server builds and runs correctly.
- Manually tested that back navigation immediately and smoothly refreshes the progress cards on Chrome, Safari, and Firefox.
