### PR TITLE
feat: cross-part monotonic auto-saving with manual save override

### DIFF
--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}" data-saved-heading-id="{{if .CurrentProgress}}{{.CurrentProgress.HeadingID}}{{end}}"><div></div><span id="savedProgressMarker" hidden></span></div>
+<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}" data-saved-heading-id="{{if .CurrentProgress}}{{.CurrentProgress.HeadingID}}{{end}}" data-current-part-number="{{.CurrentPartNumber}}" data-saved-part-number="{{.SavedPartNumber}}" data-total-parts="{{.TotalParts}}"><div></div><span id="savedProgressMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -424,7 +424,16 @@
       var part = progress.getAttribute('data-part') || '';
       if (!slug || !part) return;
 
-      // Monotonic guard: auto-save only moves progress forward
+      // Cross-part monotonic guard: auto-save never regresses to an earlier part.
+      if (isAuto) {
+        var currentPartNum = parseInt(progress.getAttribute('data-current-part-number'), 10) || 0;
+        var savedPartNum = parseInt(progress.getAttribute('data-saved-part-number'), 10) || 0;
+        if (currentPartNum > 0 && savedPartNum > 0 && currentPartNum < savedPartNum) {
+          return;
+        }
+      }
+
+      // Within-part monotonic guard: auto-save only moves progress forward
       if (isAuto && lastSavedRatio !== null && ratio <= lastSavedRatio + 0.02) {
         return;
       }
@@ -439,7 +448,7 @@
       fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ratio: ratio, heading_id: headingID})
+        body: JSON.stringify({ratio: ratio, heading_id: headingID, auto: isAuto})
       }).then(function(response){
         if (!response.ok) {
           return response.text().then(function(text){
@@ -450,7 +459,20 @@
       }).then(function(data){
         var saved = data && data.progress ? data.progress.ratio : ratio;
         var savedHeading = data && data.progress ? data.progress.heading_id : headingID;
+        var savedPart = data && data.progress ? data.progress.part : part;
         lastSavedRatio = saved;
+
+        // Keep the saved-part-number data attribute in sync so the
+        // client-side cross-part guard stays accurate after a manual save
+        // that moves to a different part.
+        var totalParts = parseInt(progress.getAttribute('data-total-parts'), 10) || 0;
+        if (totalParts > 0 && savedPart) {
+          // part-NN.md → NN
+          var match = savedPart.match(/part-(\d+)\.md/);
+          if (match) {
+            progress.setAttribute('data-saved-part-number', match[1].replace(/^0+/, ''));
+          }
+        }
         
         var reader = window.latheReadingProgress;
         if (reader && reader.setSavedProgress) {

--- a/internal/serve/progress.go
+++ b/internal/serve/progress.go
@@ -38,6 +38,7 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 	var payload struct {
 		Ratio     *float64 `json:"ratio"`
 		HeadingID string   `json:"heading_id"`
+		Auto      bool     `json:"auto"`
 	}
 	if !readJSONBody(w, r, maxProgressBytes, &payload) {
 		return
@@ -47,13 +48,42 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	progress := &store.Progress{
+	incoming := &store.Progress{
 		Part:      part,
 		Ratio:     clampRatio(*payload.Ratio),
 		HeadingID: strings.TrimSpace(payload.HeadingID),
 		UpdatedAt: time.Now().UTC(),
 	}
-	if err := store.WriteProgress(tutDir, progress); err != nil {
+
+	// Cross-part monotonic guard: only auto-saves are prevented from
+	// regressing progress. Manual saves (payload.Auto == false) are an
+	// explicit user action and always write through.
+	if payload.Auto {
+		if existing, err := store.ReadProgress(tutDir); err == nil && existing != nil {
+			existingIdx := partIndex(tut, existing.Part)
+			incomingIdx := partIndex(tut, incoming.Part)
+			if existingIdx >= 0 && incomingIdx >= 0 {
+				if incomingIdx < existingIdx {
+					// Viewing an earlier part — don't regress.
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(struct {
+						Progress *store.Progress `json:"progress"`
+					}{Progress: existing})
+					return
+				}
+				if incomingIdx == existingIdx && incoming.Ratio <= existing.Ratio {
+					// Same part but not advancing — don't regress.
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(struct {
+						Progress *store.Progress `json:"progress"`
+					}{Progress: existing})
+					return
+				}
+			}
+		}
+	}
+
+	if err := store.WriteProgress(tutDir, incoming); err != nil {
 		http.Error(w, "write progress", http.StatusInternalServerError)
 		return
 	}
@@ -61,5 +91,5 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(struct {
 		Progress *store.Progress `json:"progress"`
-	}{Progress: progress})
+	}{Progress: incoming})
 }

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -264,6 +264,18 @@ func isKnownPart(tut *store.Tutorial, part string) bool {
 	return false
 }
 
+// partIndex returns the 0-based position of part in tut.Parts, or -1 when the
+// part is not found. Used by the cross-part monotonic guard to compare part
+// ordering (lower index = earlier in the series).
+func partIndex(tut *store.Tutorial, part string) int {
+	for i, p := range tut.Parts {
+		if p == part {
+			return i
+		}
+	}
+	return -1
+}
+
 // sameOrigin reports whether a state-changing request originated from a page
 // served by this server. It rejects a *present* Origin or Referer that points
 // elsewhere — the defense against CSRF, where another site (or a LAN device)
@@ -410,6 +422,17 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 
 	currentProgress := currentPartProgress(tut, part)
 
+	// Compute the 1-based part number of the globally saved progress so the
+	// client can perform a cheap cross-part monotonic check and avoid
+	// unnecessary API calls when re-visiting an earlier part.
+	savedPartNumber := 0
+	if tut.Progress != nil {
+		idx := partIndex(tut, tut.Progress.Part)
+		if idx >= 0 {
+			savedPartNumber = idx + 1
+		}
+	}
+
 	var buf bytes.Buffer
 	if err := s.layoutTmpl.Execute(&buf, map[string]any{
 		"Title":             tut.Title,
@@ -421,6 +444,8 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"CurrentPart":       part,
 		"CurrentProgress":   currentProgress,
 		"CurrentPartNumber": currentNumber,
+		"SavedPartNumber":   savedPartNumber,
+		"TotalParts":        len(tut.Parts),
 		"Content":           template.HTML(content),
 		"CSS":               s.designCSS,
 		"HighlightCSS":      s.highlightCSS,

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1442,6 +1442,198 @@ func TestProgressEndpointRejectsOversizeBody(t *testing.T) {
 	}
 }
 
+func TestProgressEndpointAutoSaveRejectsCrossPartRegression(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	// Pre-set progress at part-02 with ratio 0.6
+	err := store.WriteProgress(tutDir, &store.Progress{
+		Part:      "part-02.md",
+		Ratio:     0.6,
+		HeadingID: "later-section",
+		UpdatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("WriteProgress: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	// Auto-save to part-01 (an earlier part) — should be rejected
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{"ratio":0.9,"heading_id":"intro","auto":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("cross-part regression = %d, want %d", w.Code, http.StatusOK)
+	}
+	var response struct {
+		Progress *store.Progress `json:"progress"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	// The response should return the existing (later) progress, not the
+	// incoming request
+	if response.Progress.Part != "part-02.md" {
+		t.Errorf("response part = %q, want part-02.md (existing)", response.Progress.Part)
+	}
+	if response.Progress.Ratio != 0.6 {
+		t.Errorf("response ratio = %v, want 0.6 (existing)", response.Progress.Ratio)
+	}
+
+	// Verify the file on disk was not changed
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Progress.Part != "part-02.md" {
+		t.Errorf("on-disk part = %q, want part-02.md", tut.Progress.Part)
+	}
+}
+
+func TestProgressEndpointAutoSaveRejectsSamePartRatioRegression(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	// Pre-set progress at part-01 with ratio 0.7
+	err := store.WriteProgress(tutDir, &store.Progress{
+		Part:      "part-01.md",
+		Ratio:     0.7,
+		HeadingID: "deep-section",
+		UpdatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("WriteProgress: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	// Auto-save same part with lower ratio — should be rejected
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{"ratio":0.3,"heading_id":"intro","auto":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("same-part ratio regression = %d, want %d", w.Code, http.StatusOK)
+	}
+	var response struct {
+		Progress *store.Progress `json:"progress"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Progress.Ratio != 0.7 {
+		t.Errorf("response ratio = %v, want 0.7 (existing)", response.Progress.Ratio)
+	}
+}
+
+func TestProgressEndpointAutoSaveAllowsForwardProgress(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	// Pre-set progress at part-01 with ratio 0.5
+	err := store.WriteProgress(tutDir, &store.Progress{
+		Part:      "part-01.md",
+		Ratio:     0.5,
+		HeadingID: "intro",
+		UpdatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("WriteProgress: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	// Auto-save to part-02 (a later part) — should succeed
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-02.md", bytes.NewBufferString(`{"ratio":0.3,"heading_id":"new-section","auto":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("forward progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var response struct {
+		Progress *store.Progress `json:"progress"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Progress.Part != "part-02.md" {
+		t.Errorf("response part = %q, want part-02.md", response.Progress.Part)
+	}
+	if response.Progress.Ratio != 0.3 {
+		t.Errorf("response ratio = %v, want 0.3", response.Progress.Ratio)
+	}
+
+	// Verify the file on disk was updated
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Progress.Part != "part-02.md" {
+		t.Errorf("on-disk part = %q, want part-02.md", tut.Progress.Part)
+	}
+}
+
+func TestProgressEndpointManualSaveAlwaysWritesThrough(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+
+	// Pre-set progress at part-02 with ratio 0.8
+	err := store.WriteProgress(tutDir, &store.Progress{
+		Part:      "part-02.md",
+		Ratio:     0.8,
+		HeadingID: "late-section",
+		UpdatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("WriteProgress: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	// Manual save (auto omitted, defaults false) to an earlier part with
+	// lower ratio — the user explicitly chose to resume here, so it must
+	// write through.
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/test-series/part-01.md", bytes.NewBufferString(`{"ratio":0.2,"heading_id":"intro"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("manual save = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var response struct {
+		Progress *store.Progress `json:"progress"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	// Manual save must write to the requested part, not the existing one
+	if response.Progress.Part != "part-01.md" {
+		t.Errorf("response part = %q, want part-01.md", response.Progress.Part)
+	}
+	if response.Progress.Ratio != 0.2 {
+		t.Errorf("response ratio = %v, want 0.2", response.Progress.Ratio)
+	}
+
+	// Verify the file on disk was overwritten
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if tut.Progress.Part != "part-01.md" {
+		t.Errorf("on-disk part = %q, want part-01.md", tut.Progress.Part)
+	}
+	if tut.Progress.Ratio != 0.2 {
+		t.Errorf("on-disk ratio = %v, want 0.2", tut.Progress.Ratio)
+	}
+}
+
 func TestPathTraversalBlocked(t *testing.T) {
 	dir := t.TempDir()
 	makeTestTutorial(t, dir, "test-tutorial", false)


### PR DESCRIPTION
## Summary

Sorry if you are confused, the hyphen in my old username (vipin-si) was creating some problems so I removed it. 

This is a follow-up to PR #55 (dwell-time monotonic auto-saving). The monotonic guard in #55 only prevented progress regression **within** a single part. This PR extends it to work **across** parts — auto-save on an earlier part (e.g., the user revisiting Part 1 after reaching Part 3) no longer overwrites the tutorial's overall progress.

Manual "Save progress" button clicks always write through regardless of position. The user explicitly choosing to bookmark a spot is the highest-priority signal. Let me know if you disagree.

## Problem

With #55 merged, auto-save correctly prevented scroll-up regression within a single part. But in a multi-part series:

1. User reads Part 1 → Part 2 → Part 3 (auto-saved at Part 3, 50%)
2. User clicks back to Part 1 to re-read something
3. After 3 seconds of dwell time, auto-save fires and writes `{part: "part-01.md", ratio: 0.8}`
4. Tutorial progress regresses from Part 3 back to Part 1

The progress bar on the card list page would show regression, and the next time the user opens the tutorial, they'd be redirected to Part 1 instead of Part 3.

## Solution 

### 1. Server-side guard (`progress.go`)

The `handleProgress` endpoint now reads an `auto` boolean from the request body. When `auto: true`:

- **Cross-part check**: Compares the incoming part's index in `tut.Parts` against the existing saved part's index. If the incoming part is earlier → reject, return existing progress unchanged.
- **Same-part ratio check**: If same part but incoming ratio ≤ existing ratio → reject.
- **Forward progress**: Otherwise → write normally.

When `auto: false` (manual save button), **no guard is applied** — the save always writes through. The user explicitly clicking "Save progress" is an intentional bookmark and should override any automatic behavior.

### 2. Client-side guard (`layout.html`)

New data attributes on the `#progressBar` element:
- `data-current-part-number` — 1-based index of the part being viewed
- `data-saved-part-number` — 1-based index of the globally saved progress part
- `data-total-parts` — total number of parts in the series

The JavaScript `triggerSave()` function reads these before firing an auto-save request. When `currentPartNumber < savedPartNumber`, the fetch is skipped entirely — no unnecessary network request.

The fetch body now includes `auto: true` for dwell-time saves and omits it (defaults `false`) for manual button clicks, so the server can distinguish the two.

### 3. Template data (`server.go`)

- Added `partIndex()` helper that returns a part's 0-based position in `tut.Parts` (used by both the server guard and template rendering)
- Added `SavedPartNumber` (1-based index of the globally saved progress part) and `TotalParts` to the template context

## Behavior Matrix

| Scenario | Auto-save | Manual save |
|----------|-----------|-------------|
| Earlier part | ❌ Blocked | ✅ Writes through |
| Same part, scroll up (lower ratio) | ❌ Blocked | ✅ Writes through |
| Same part, scroll down (higher ratio) | ✅ Saves | ✅ Saves |
| Later part | ✅ Saves | ✅ Saves |

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `internal/serve/progress.go` | +36 | Server-side auto-only monotonic guard with `auto` flag |
| `internal/serve/server.go` | +25 | `partIndex()` helper, `SavedPartNumber` + `TotalParts` template data |
| `internal/serve/layout.html` | +28 | Data attributes, client-side cross-part guard, `auto` flag in fetch body, saved-part-number sync |
| `internal/serve/server_test.go` | +192 | 4 new tests covering all guard scenarios |

## Tests

### New tests (all pass)

- `TestProgressEndpointAutoSaveRejectsCrossPartRegression` — auto-save to earlier part blocked, returns existing progress
- `TestProgressEndpointAutoSaveRejectsSamePartRatioRegression` — auto-save with lower ratio on same part blocked
- `TestProgressEndpointAutoSaveAllowsForwardProgress` — auto-save to later part succeeds
- `TestProgressEndpointManualSaveAlwaysWritesThrough` — manual save to earlier part with lower ratio writes through

### Existing tests

All existing tests continue to pass (`go test ./...` — 10 packages, 0 failures). The existing `TestProgressEndpointSavesProgress` still works because it omits the `auto` field (defaults to `false`, which is manual save behavior — always writes through).

## Manual Verification

Manually tested against a local server with a 3-part series tutorial (`cross-part-test`) with progress pre-set at Part 3:
- Part 1: `current=1, saved=3` → JS skips auto-save (1 < 3)
- Part 2: `current=2, saved=3` → JS skips auto-save (2 < 3)  
- Part 3: `current=3, saved=3` → JS runs auto-save (checks ratio)
