### PR TITLE
feat: added lathe verify-cancel & tests

### DIFF
--- a/cmd/verify-cancel.go
+++ b/cmd/verify-cancel.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/devenjarvis/lathe/internal/config"
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/spf13/cobra"
+)
+
+// verifyCancelCmd recovers a tutorial whose verification was interrupted. The
+// /lathe-verify skill marks the tutorial "verifying" when it starts, but if the
+// session dies before recording a terminal status (token limit, accidental
+// cancellation, or a verify started by mistake), the tutorial is stuck
+// with the badge spinning forever and the web verify endpoint refuses to
+// re-run. This command resets the status without hand-editing metadata.json or
+// manually forcing verify-result to fail to fail with appropriate arguments.
+var verifyCancelCmd = &cobra.Command{
+	Use:   "verify-cancel <slug>",
+	Short: "Cancel an interrupted verification and restore the previous status",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		if err := validateSlug(slug); err != nil {
+			return err
+		}
+		tutorialsDir, err := config.TutorialsDir()
+		if err != nil {
+			return err
+		}
+		tutDir := filepath.Join(tutorialsDir, slug)
+		tut, err := store.ReadMetadata(tutDir)
+		if err != nil {
+			return fmt.Errorf("no stored tutorial %q: %w", slug, err)
+		}
+
+		if tut.Status != store.StatusVerifying {
+			return fmt.Errorf("%q is not verifying (status: %s) — nothing to cancel", slug, tut.Status)
+		}
+
+		// Cancellation is not a result, so verify-result.json is never written
+		// or deleted so the last completed run's record stays intact.
+		tut.Status = store.StatusUnverified
+		if prior, err := store.ReadVerifyResult(tutDir); err == nil {
+			tut.Status = prior.Status
+		}
+		if err := store.WriteMetadata(tutDir, tut); err != nil {
+			return fmt.Errorf("write metadata: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Cancelled verification of %q (status: %s)\n", slug, tut.Status)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(verifyCancelCmd)
+}

--- a/cmd/verify-cancel_test.go
+++ b/cmd/verify-cancel_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func TestVerifyCancelFallsBackToUnverified(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := writeTutorial(t, homeDir, "test-slug", store.StatusVerifying, []string{"part-01.md"})
+
+	if err := verifyCancelCmd.RunE(verifyCancelCmd, []string{"test-slug"}); err != nil {
+		t.Fatalf("verify-cancel: %v", err)
+	}
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != store.StatusUnverified {
+		t.Errorf("Status = %q, want unverified (no prior result to restore)", got.Status)
+	}
+	if _, err := os.Stat(filepath.Join(tutDir, "verify-result.json")); !os.IsNotExist(err) {
+		t.Error("cancel should not create a verify-result.json")
+	}
+}
+
+func TestVerifyCancelRestoresPriorResult(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := writeTutorial(t, homeDir, "test-slug", store.StatusVerifying, []string{"part-01.md"})
+	prior := &store.VerifyResult{Status: store.StatusVerified, CheckedAt: "2026-06-01T00:00:00Z"}
+	if err := store.WriteVerifyResult(tutDir, prior); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyCancelCmd.RunE(verifyCancelCmd, []string{"test-slug"}); err != nil {
+		t.Fatalf("verify-cancel: %v", err)
+	}
+
+	got, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified restored from prior result", got.Status)
+	}
+	vr, err := store.ReadVerifyResult(tutDir)
+	if err != nil {
+		t.Fatalf("ReadVerifyResult: %v", err)
+	}
+	if vr.Status != store.StatusVerified || vr.CheckedAt != prior.CheckedAt {
+		t.Errorf("VerifyResult = %+v, want prior result untouched", vr)
+	}
+}
+
+func TestVerifyCancelRejectsWhenNotVerifying(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	for _, status := range []store.Status{store.StatusUnverified, store.StatusVerified, store.StatusExtending} {
+		slug := "slug-" + string(status)
+		tutDir := writeTutorial(t, homeDir, slug, status, []string{"part-01.md"})
+
+		if err := verifyCancelCmd.RunE(verifyCancelCmd, []string{slug}); err == nil {
+			t.Errorf("verify-cancel should reject a tutorial with status %q", status)
+		}
+
+		got, err := store.ReadMetadata(tutDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != status {
+			t.Errorf("Status = %q, want %q unchanged after rejected cancel", got.Status, status)
+		}
+	}
+}
+
+func TestVerifyCancelRejectsMissingTutorial(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := verifyCancelCmd.RunE(verifyCancelCmd, []string{"no-such-slug"}); err == nil {
+		t.Error("verify-cancel should error on a missing tutorial")
+	}
+}
+
+func TestVerifyCancelRejectsBadSlug(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, slug := range []string{"", ".", "..", "foo/bar", `foo\bar`} {
+		if err := verifyCancelCmd.RunE(verifyCancelCmd, []string{slug}); err == nil {
+			t.Errorf("verify-cancel %q should be rejected as invalid", slug)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Added new command labeled `lathe verify-cancel` to Cobra command list. This cancels the currently "Verifying" status attached to the slug, and will revert back to the previously assigned verification status.

This PR purposefully does not modify UI or web components, nor does it modify `/.claude` SKILL files. If accepted, can easily be extended into a button within the `.verify-section`, at the bottom of the tutorial.

Commits 2 additional files.

## Changes

* Added `cmd/verify-cancel.go`
* Added `cmd/verify-cancel_test.go`
<ul>
Tests Included:
<ul>1. VerifyCancelFallsBackToUnverified</ul>
<ul>2. VerifyCancelRestoresPriorResult</ul>
<ul>3. VerifyCancelRejectsWhenNotVerifying</ul>
<ul>4. VerifyCancelRejectsMissingTutorial</ul>
<ul>5. VerifyCancelRejectsBadSlug</ul>
</ul>

## Reasoning

Really love Lathe, I've been using it almost daily now, but since Fable 5 has dropped (and trying to utilize lathe to learn other systems towards the end of my LLM usage limit), sometimes verifying a tutorial and having the unfortunate timing of either:
* Reaching token limit before verification completes
* Accidentally interrupting/terminating verification mid-process
* Prematurely starting verification (token waste)

Can make progressing or extending tutorial parts a slight issue. Current work around is to malform a `lathe verify-result` with a random status just to clear the verification queue.

## Testing
* `mage check` all pass, `go test -race ./...`, and `go build` pass.
* Works great locally with custom build
* Confirmed `lathe list` outputs correct information pre & post "Verifying", reverts back to previously acquired status.


