### PR TITLE
docs: Tweak CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .superpowers/
 /lathe
+/lathe-local
 .claude/
 # GoReleaser build output
 /dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,19 +54,19 @@ wrote it" isn't an answer to review feedback.
 
 ## Getting set up
 
-New to contributing on GitHub? No problem — here's the whole flow, step by step.
-
-**1. Fork the repo.** Click "Fork" at the top-right of the
-[GitHub page](https://github.com/devenjarvis/lathe). This gives you your own
-copy to push to.
-
-**2. Clone your fork and build it.** Replace `YOUR-USERNAME` with your GitHub
-username:
+**1. Fork the repo** and clone your fork. Replace `YOUR-USERNAME` with your
+GitHub username:
 
 ```bash
 git clone https://github.com/YOUR-USERNAME/lathe
 cd lathe
-go build -o lathe        # build the binary (gitignored at the repo root)
+```
+
+**2. Build and test it.** Name the binary something like `lathe-local` so it
+doesn't clash with any `lathe` you already have installed:
+
+```bash
+go build -o lathe-local  # build the binary (gitignored at the repo root)
 go test ./...            # run the tests — make sure they pass before you change anything
 ```
 


### PR DESCRIPTION
<!--
  This repo squash-merges, so your PR TITLE becomes the commit on `main`.
  Please title it in conventional-commit format, e.g.:
    feat: add windsurf to skills install targets
    fix:  prevent path traversal on the static route
    docs: clarify the verify handoff flow
-->

## What & why

Just tweaking the CONTRIBUTING.md per feedback

<!-- What does this change do, and why? Link any related issue with "Closes #123". -->

## How to test

N/A

<!-- Steps a reviewer can follow to see it working. Delete if not applicable. -->

## Checklist

- [x] PR title is in conventional-commit format (`feat:`/`fix:`/`docs:`/`chore:`/`refactor:`)
- [x] `mage check` passes locally
- [ ] ~Updated docs (`AGENTS.md` / `README.md` / `docs/`) if behavior changed~
- [ ] ~Edited `.claude/skills/` (not `internal/skills/data/`) and ran `mage skills`, if skills changed~
