### PR TITLE
feat: convert exercises into saved-state checkboxes

### DIFF
--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -116,9 +116,9 @@ One paragraph naming the unanswered question a future part will answer. Include 
 
 ## Exercises
 
-1. <specific>
-2. <specific>
-3. <specific>
+- [ ] 1. <specific>
+- [ ] 2. <specific>
+- [ ] 3. <specific>
 
 ## Sources
 

--- a/.claude/skills/lathe/SKILL.md
+++ b/.claude/skills/lathe/SKILL.md
@@ -116,9 +116,9 @@ One paragraph naming the unanswered question a future part will answer. Include 
 
 ## Exercises
 
-- [ ] 1. <specific>
-- [ ] 2. <specific>
-- [ ] 3. <specific>
+- [ ] <specific>
+- [ ] <specific>
+- [ ] <specific>
 
 ## Sources
 
@@ -310,7 +310,7 @@ Every part ends with **four** things:
 
 1. **A send-off (or forward hook).** For the final part: one short paragraph inviting the reader to leave the path you took. For non-final parts: a single forward-pointing sentence naming the question the next part will answer — lean into the cliffhanger.
 2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in this part and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
-3. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
+3. **`## Exercises`**, Markdown task-list checkboxes (- [ ]), 3-5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
 4. **`## Sources`**, numbered, one entry per source used inline in *this part*. Format: `[Title](url) — one sentence on why this source matters`. Group by primary docs / papers / deep-dives if more than ~5 entries.
 
 ## Output files

--- a/internal/serve/layout.html
+++ b/internal/serve/layout.html
@@ -22,7 +22,7 @@
 </head>
 <body>
 <div id="statusPoll" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-status="{{.Tutorial.Status}}" hidden></div>
-<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}" data-saved-heading-id="{{if .CurrentProgress}}{{.CurrentProgress.HeadingID}}{{end}}" data-current-part-number="{{.CurrentPartNumber}}" data-saved-part-number="{{.SavedPartNumber}}" data-total-parts="{{.TotalParts}}"><div></div><span id="savedProgressMarker" hidden></span></div>
+<div id="progressBar" aria-hidden="true" data-slug="{{.Tutorial.Slug}}" data-part="{{.CurrentPart}}" data-saved-progress="{{if .CurrentProgress}}{{.CurrentProgress.Ratio}}{{end}}" data-saved-heading-id="{{if .CurrentProgress}}{{.CurrentProgress.HeadingID}}{{end}}" data-current-part-number="{{.CurrentPartNumber}}" data-saved-part-number="{{.SavedPartNumber}}" data-total-parts="{{.TotalParts}}" data-saved-exercises="{{range $i, $e := .CheckedExercises}}{{if $i}},{{end}}{{$e}}{{end}}"><div></div><span id="savedProgressMarker" hidden></span></div>
 <header id="topBar">
   <button type="button" id="hamburger" aria-label="Toggle navigation" aria-controls="sidebar" aria-expanded="false">≡</button>
   <a href="/" class="back-link">← All tutorials</a>
@@ -386,6 +386,22 @@
       buttons.forEach(function(button){ button.disabled = busy; });
     }
 
+    // Exercises are persisted separately from the monotonic progress ratio.
+    // Returns null when the page has no exercise checkboxes at all, so the save
+    // omits the field and exercise-less parts never create a sidecar; otherwise
+    // returns the (possibly empty) checked set, so unchecking the last box still
+    // persists.
+    function collectExercises() {
+      var boxes = document.querySelectorAll('.exercise-check');
+      if (!boxes.length) return null;
+      var checked = [];
+      boxes.forEach(function (cb) {
+        var i = parseInt(cb.getAttribute('data-exercise-index'), 10);
+        if (cb.checked && !isNaN(i)) checked.push(i);
+      });
+      return checked;
+    }
+
     function triggerSave(ratio, headingID, isAuto) {
       var slug = progress.getAttribute('data-slug') || '';
       var part = progress.getAttribute('data-part') || '';
@@ -412,10 +428,13 @@
         setStatus('Auto-saving...', false);
       }
 
+      var body = {ratio: ratio, heading_id: headingID, auto: isAuto};
+      if (exercises !== null) body.exercises = collectExercises();
+
       fetch('/-/progress/' + encodeURIComponent(slug) + '/' + encodeURIComponent(part), {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ratio: ratio, heading_id: headingID, auto: isAuto})
+        body: JSON.stringify(body)
       }).then(function(response){
         if (!response.ok) {
           return response.text().then(function(text){
@@ -521,6 +540,18 @@
         handleHeadingChange(reader.currentHeadingID());
       }
     }, 500);
+  })();
+</script>
+<script>
+  (function () {
+    var bar = document.getElementById('progressBar');
+    if (!bar) return;
+    var raw = bar.getAttribute('data-saved-exercises');
+    if (!raw) return;
+    raw.split(',').forEach(function (s) {
+      var cb = document.querySelector('.exercise-check[data-exercise-index="' + s.trim() + '"]');
+      if (cb) cb.checked = true;
+    });
   })();
 </script>
 <script>

--- a/internal/serve/progress.go
+++ b/internal/serve/progress.go
@@ -38,6 +38,7 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 	var payload struct {
 		Ratio     *float64 `json:"ratio"`
 		HeadingID string   `json:"heading_id"`
+		Exercises []int    `json:"exercises"`
 		Auto      bool     `json:"auto"`
 	}
 	if !readJSONBody(w, r, maxProgressBytes, &payload) {
@@ -46,6 +47,20 @@ func (s *Server) handleProgress(w http.ResponseWriter, r *http.Request) {
 	if payload.Ratio == nil {
 		http.Error(w, "ratio is required", http.StatusBadRequest)
 		return
+	}
+
+	// Persist exercise checkbox state independently of the monotonic reading-
+	// progress guard below: exercises.json is keyed by part, so a save while
+	// reviewing an earlier part still records that part's boxes without colliding
+	// with the high-water position. A nil slice means the field was absent (the
+	// page had no exercises) and is skipped, so exercise-less parts never create a
+	// sidecar; a present-but-empty slice means every box was unchecked and writes
+	// through to clear the part's entry.
+	if payload.Exercises != nil {
+		if err := store.WriteExercisePart(tutDir, part, payload.Exercises); err != nil {
+			http.Error(w, "write exercises", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	incoming := &store.Progress{

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -15,9 +15,12 @@ import (
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
+	goldmarkeast "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
 	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // TOCEntry is a single h2 heading collected for the in-page table of contents
@@ -27,6 +30,10 @@ type TOCEntry struct {
 	ID   string
 	Text string
 }
+
+// Specifically for overriding the goldmark renderer for custom input checkboxes
+// within exercise-related output at the bottom of tutorials.
+type exerciseCheckboxRenderer struct{}
 
 // Chroma syntax styles, chosen to harmonize with the warm "paper"/"ember"
 // palette: tango's muted browns/olives in light, gruvbox's warm ambers/oranges
@@ -74,6 +81,8 @@ func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 			// GFM tables — without this, pipe-delimited tables fall through as
 			// literal text. styles.css already styles <table>/<th>/<td>.
 			extension.Table,
+			// SKILL render output format needs to match GitHub Markdown syntax (- [ ])
+			extension.TaskList,
 			// LaTeX math passes through goldmark untouched — without this,
 			// CommonMark backslash-escapes corrupt TeX before it reaches the
 			// browser (`\|` -> `|`, `\;` -> `;`). KaTeX auto-render in
@@ -91,9 +100,22 @@ func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 				},
 			}),
 		),
-		goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+			// Tag exercise-section task-list checkboxes (exerciseChecklist) so the
+			// node renderer below can emit them as interactive inputs.
+			parser.WithASTTransformers(
+				util.Prioritized(exerciseChecklist{}, 100),
+			),
+		),
 		goldmark.WithRendererOptions(
 			goldmarkhtml.WithUnsafe(),
+			// Override the TaskList extension's checkbox renderer (priority 500).
+			// goldmark registers node renderers lowest-number-wins, so 100 takes
+			// precedence (see exerciseCheckboxRenderer).
+			renderer.WithNodeRenderers(
+				util.Prioritized(exerciseCheckboxRenderer{}, 100),
+			),
 		),
 	)
 	doc := md.Parser().Parse(text.NewReader(src))
@@ -103,6 +125,86 @@ func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
 		return nil, nil, err
 	}
 	return buf.Bytes(), toc, nil
+}
+
+// exerciseCheckboxRenderer replaces goldmark's default task-list checkbox.
+// Checkboxes the transformer tagged as exercises render *enabled* with a
+// styling/JS hook; every other task checkbox keeps the upstream disabled
+// rendering, so task lists elsewhere in a tutorial are unaffected.
+func (exerciseCheckboxRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(goldmarkeast.KindTaskCheckBox, renderExerciseCheckbox)
+}
+
+func renderExerciseCheckbox(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*goldmarkeast.TaskCheckBox)
+
+	idx, tagged := node.AttributeString("data-exercise-index")
+	if !tagged {
+		// Outside an exercise section: reproduce the upstream default exactly
+		// (disabled, non-XHTML — our renderer config doesn't set XHTML).
+		if n.IsChecked {
+			_, _ = w.WriteString(`<input checked="" disabled="" type="checkbox"> `)
+		} else {
+			_, _ = w.WriteString(`<input disabled="" type="checkbox"> `)
+		}
+		return ast.WalkContinue, nil
+	}
+
+	// Exercise checkbox: interactive, carries a stable index for save/restore.
+	_, _ = fmt.Fprintf(w, `<input type="checkbox" class="exercise-check" data-exercise-index="%d"`, idx.(int))
+	if n.IsChecked {
+		_, _ = w.WriteString(` checked=""`)
+	}
+	_, _ = w.WriteString("> ")
+	return ast.WalkContinue, nil
+}
+
+// exerciseChecklist tags every task-list checkbox that lives inside an exercise
+// section with a stable, part-local index, in document order. The renderer reads
+// that tag to decide which checkboxes become interactive. Detection keys on the
+// heading's auto-generated id slug (assigned during parse, so it's present here).
+type exerciseChecklist struct{}
+
+func (exerciseChecklist) Transform(doc *ast.Document, _ text.Reader, _ parser.Context) {
+	idx := 0
+	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
+		h, ok := n.(*ast.Heading)
+		if !ok || h.Level != 2 {
+			continue
+		}
+		idAttr, ok := h.AttributeString("id") // same pattern as collectH2TOC
+		if !ok {
+			continue
+		}
+		idBytes, _ := idAttr.([]byte)
+		if !isExerciseHeading(string(idBytes)) {
+			continue
+		}
+		// Walk the section body forward until the next h1/h2 boundary.
+		for s := h.NextSibling(); s != nil; s = s.NextSibling() {
+			if hh, ok := s.(*ast.Heading); ok && hh.Level <= 2 {
+				break
+			}
+			_ = ast.Walk(s, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
+				if entering {
+					if cb, ok := c.(*goldmarkeast.TaskCheckBox); ok {
+						cb.SetAttributeString("data-exercise-index", idx)
+						idx++
+					}
+				}
+				return ast.WalkContinue, nil
+			})
+		}
+	}
+}
+
+// isExerciseHeading is the single fragile input, check for them explicitly.
+// This can be extended later to include things like "bonus", "challenges", etc.
+func isExerciseHeading(id string) bool {
+	return strings.Contains(id, "exercise")
 }
 
 // collectH2TOC walks the parsed AST and returns one TOCEntry per <h2>. h1, h3,

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -330,3 +330,106 @@ func TestHighlightCSS(t *testing.T) {
 		t.Error("HighlightCSS() missing expected dark-theme color")
 	}
 }
+
+func TestRenderExerciseChecklistInteractive(t *testing.T) {
+	// Task-list checkboxes inside an exercise section become interactive inputs:
+	// enabled, class="exercise-check", carrying a stable part-local index — and the
+	// checked state survives.
+	src := []byte("# Title\n\n## Exercises\n\n- [ ] Write the parser\n- [x] Wire it up\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, `<input type="checkbox" class="exercise-check" data-exercise-index="0">`) {
+		t.Errorf("first exercise checkbox not rendered interactive, got:\n%s", html)
+	}
+	if !strings.Contains(html, `<input type="checkbox" class="exercise-check" data-exercise-index="1" checked="">`) {
+		t.Errorf("checked exercise checkbox missing checked state/index, got:\n%s", html)
+	}
+	// Interactive exercise inputs are never disabled — no upstream default leaks in.
+	if strings.Contains(html, `<input disabled="" type="checkbox">`) {
+		t.Errorf("exercise checkboxes should be enabled, found a disabled default, got:\n%s", html)
+	}
+}
+
+func TestRenderNonExerciseTaskListStaysDisabled(t *testing.T) {
+	// Task lists outside an exercise section keep goldmark's default disabled
+	// rendering — the feature must not hijack every checklist in a tutorial.
+	src := []byte("# Title\n\n## Setup steps\n\n- [x] Install the toolchain\n- [ ] Clone the repo\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, `<input checked="" disabled="" type="checkbox">`) {
+		t.Errorf("checked non-exercise checkbox lost its disabled default, got:\n%s", html)
+	}
+	if !strings.Contains(html, `<input disabled="" type="checkbox">`) {
+		t.Errorf("unchecked non-exercise checkbox lost its disabled default, got:\n%s", html)
+	}
+	if strings.Contains(html, "exercise-check") {
+		t.Errorf("non-exercise task list was wrongly made interactive, got:\n%s", html)
+	}
+}
+
+func TestRenderExerciseIndicesArePartLocalAndSkipNonExercises(t *testing.T) {
+	// Indices are assigned in document order across *all* exercise sections in the
+	// part, and only to exercise checkboxes — a task list in a non-exercise section
+	// neither becomes interactive nor consumes an index.
+	src := []byte("# Title\n\n" +
+		"## Exercises\n\n- [ ] First\n- [ ] Second\n\n" +
+		"## Notes\n\n- [ ] Not an exercise\n\n" +
+		"## Bonus Exercises\n\n- [ ] Third\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	for _, want := range []string{
+		`class="exercise-check" data-exercise-index="0"`,
+		`class="exercise-check" data-exercise-index="1"`,
+		`class="exercise-check" data-exercise-index="2"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("missing exercise checkbox %q, got:\n%s", want, html)
+		}
+	}
+	// The non-exercise box stays a disabled default and takes no index, so the
+	// third exercise checkbox is index 2 — never 3.
+	if strings.Contains(html, `data-exercise-index="3"`) {
+		t.Errorf("non-exercise checkbox wrongly consumed an exercise index, got:\n%s", html)
+	}
+	if !strings.Contains(html, `<input disabled="" type="checkbox">`) {
+		t.Errorf("non-exercise checkbox should remain a disabled default, got:\n%s", html)
+	}
+}
+
+func TestRenderExerciseHeadingDetection(t *testing.T) {
+	// A heading turns its section's checkboxes interactive iff its slug contains
+	// "exercise" — the single intentional trigger. Verify representative positive
+	// and negative headings.
+	cases := []struct {
+		heading     string
+		interactive bool
+	}{
+		{"Exercises", true},
+		{"Exercise", true},
+		{"Bonus Exercise", true},
+		{"Try It Yourself", false},
+		{"Summary", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.heading, func(t *testing.T) {
+			src := []byte("# Title\n\n## " + tc.heading + "\n\n- [ ] a box\n")
+			out, err := serve.RenderMarkdown(src)
+			if err != nil {
+				t.Fatalf("RenderMarkdown() error = %v", err)
+			}
+			got := strings.Contains(string(out), "exercise-check")
+			if got != tc.interactive {
+				t.Errorf("heading %q: interactive = %v, want %v; got:\n%s", tc.heading, got, tc.interactive, out)
+			}
+		})
+	}
+}

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -455,6 +455,16 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 
 	currentProgress := currentPartProgress(tut, part)
 
+	// Per-part exercise checkbox state lives in its own sidecar (exercises.json),
+	// deliberately outside the monotonic progress record. Best-effort like
+	// progress: a read error just yields no restored checks. Only the current
+	// part's indices are surfaced — they match the data-exercise-index values the
+	// renderer assigned for this part.
+	var checkedExercises []int
+	if state, err := store.ReadExercises(tutDir); err == nil {
+		checkedExercises = state[part]
+	}
+
 	// Compute the 1-based part number of the globally saved progress so the
 	// client can perform a cheap cross-part monotonic check and avoid
 	// unnecessary API calls when re-visiting an earlier part.
@@ -476,6 +486,7 @@ func (s *Server) renderPart(w http.ResponseWriter, tut *store.Tutorial, tutDir, 
 		"VoiceSpec":         voiceSpec,
 		"CurrentPart":       part,
 		"CurrentProgress":   currentProgress,
+		"CheckedExercises":  checkedExercises,
 		"CurrentPartNumber": currentNumber,
 		"SavedPartNumber":   savedPartNumber,
 		"TotalParts":        len(tut.Parts),

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -1951,3 +1951,143 @@ func TestPartPageLoadsKatex(t *testing.T) {
 		t.Error("part page missing the auto-render invocation")
 	}
 }
+
+func sameIntSlice(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func postProgress(t *testing.T, srv *serve.Server, slug, part, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/-/progress/"+slug+"/"+part, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:4242")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestProgressEndpointSavesExercises(t *testing.T) {
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	srv := serve.NewServer(dir)
+
+	w := postProgress(t, srv, "test-series", "part-02.md", `{"ratio":0.42,"exercises":[0,2]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	state, err := store.ReadExercises(tutDir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if !sameIntSlice(state["part-02.md"], []int{0, 2}) {
+		t.Errorf("saved exercises = %v, want [0 2]", state["part-02.md"])
+	}
+}
+
+func TestProgressEndpointOmittedExercisesCreatesNoSidecar(t *testing.T) {
+	// A part with no exercises sends no "exercises" field (nil slice); the handler
+	// must skip the write entirely rather than create an empty exercises.json.
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	srv := serve.NewServer(dir)
+
+	w := postProgress(t, srv, "test-series", "part-02.md", `{"ratio":0.42,"heading_id":"next-step"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(tutDir, "exercises.json")); !os.IsNotExist(err) {
+		t.Errorf("exercises.json should not exist after an exercise-less save, stat err = %v", err)
+	}
+}
+
+func TestProgressEndpointEmptyExercisesClearsEntry(t *testing.T) {
+	// A present-but-empty array means the reader unchecked everything: it writes
+	// through and clears the part's saved entry.
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	srv := serve.NewServer(dir)
+
+	if w := postProgress(t, srv, "test-series", "part-02.md", `{"ratio":0.42,"exercises":[0,1]}`); w.Code != http.StatusOK {
+		t.Fatalf("seed POST progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if w := postProgress(t, srv, "test-series", "part-02.md", `{"ratio":0.5,"exercises":[]}`); w.Code != http.StatusOK {
+		t.Fatalf("clear POST progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	state, err := store.ReadExercises(tutDir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if _, ok := state["part-02.md"]; ok {
+		t.Errorf("part-02 entry should be cleared by an empty array, got %v", state["part-02.md"])
+	}
+}
+
+func TestProgressEndpointSavesExercisesDespiteMonotonicGuard(t *testing.T) {
+	// Headline design point: exercise state persists independently of the monotonic
+	// reading-progress guard. An *auto* save for an earlier part is rejected for
+	// progress (no regression) yet still records that part's boxes.
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	// High-water reading progress sits at the later part-02.
+	if err := store.WriteProgress(tutDir, &store.Progress{Part: "part-02.md", Ratio: 0.8, UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("WriteProgress: %v", err)
+	}
+	srv := serve.NewServer(dir)
+
+	// Auto-save while reviewing the earlier part-01, checking a box there.
+	w := postProgress(t, srv, "test-series", "part-01.md", `{"ratio":0.1,"exercises":[0],"auto":true}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST progress = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Progress must not regress: the response still reports part-02 as the position.
+	var resp struct {
+		Progress *store.Progress `json:"progress"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Progress == nil || resp.Progress.Part != "part-02.md" {
+		t.Errorf("progress regressed: got %+v, want it held at part-02.md", resp.Progress)
+	}
+
+	// ...but the part-01 exercise box must still be recorded.
+	state, err := store.ReadExercises(tutDir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if !sameIntSlice(state["part-01.md"], []int{0}) {
+		t.Errorf("part-01 exercises = %v, want [0] recorded despite the progress guard", state["part-01.md"])
+	}
+}
+
+func TestPartPageRendersSavedExercises(t *testing.T) {
+	// The renderPart read path surfaces the current part's saved boxes to the
+	// template as data-saved-exercises, so the client can restore them on load.
+	dir := t.TempDir()
+	tutDir := makeTestTutorial(t, dir, "test-series", true)
+	if err := store.WriteExercisePart(tutDir, "part-02.md", []int{0, 2}); err != nil {
+		t.Fatalf("WriteExercisePart: %v", err)
+	}
+
+	srv := serve.NewServer(dir)
+	req := httptest.NewRequest(http.MethodGet, "/test-series/part-02.md", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /test-series/part-02.md = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), `data-saved-exercises="0,2"`) {
+		t.Errorf("part page missing restored data-saved-exercises; body excerpt:\n%s", w.Body.String())
+	}
+}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -468,6 +468,24 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 #askInput:focus{outline:2px solid var(--accent);outline-offset:1px}
 .ask-controls{display:flex;gap:.5rem;justify-content:flex-end}
 /* #askSubmit / #askStop are .btn .btn-sm (primary / danger) in the markup. */
+/* List items that contain an exercise checkbox (tight or loose lists). */
+li:has(> .exercise-check),
+li:has(> p > .exercise-check) {
+  list-style: none;
+  position: relative;
+  padding-left: 2rem;
+}
+.exercise-check {
+  position: absolute;
+  left: 0;
+  margin-top: 0.25em;
+  cursor: pointer;
+}
+/* Custom styling once an exercise is checked. */
+li:has(.exercise-check:checked) {
+  opacity: 0.55;
+  text-decoration: line-through;
+}
 
 /* ---- List page (body.list) ---------------------------------------------- */
 body.list{max-width:46rem;margin:clamp(1.5rem,.9rem + 2vw,3rem) auto;padding:0 clamp(.9rem,.4rem + 2vw,1.5rem)}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -468,24 +468,21 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 #askInput:focus{outline:2px solid var(--accent);outline-offset:1px}
 .ask-controls{display:flex;gap:.5rem;justify-content:flex-end}
 /* #askSubmit / #askStop are .btn .btn-sm (primary / danger) in the markup. */
-/* List items that contain an exercise checkbox (tight or loose lists). */
-li:has(> .exercise-check),
-li:has(> p > .exercise-check) {
-  list-style: none;
-  position: relative;
-  padding-left: 2rem;
-}
-.exercise-check {
-  position: absolute;
-  left: 0;
-  margin-top: 0.25em;
-  cursor: pointer;
-}
-/* Custom styling once an exercise is checked. */
-li:has(.exercise-check:checked) {
-  opacity: 0.55;
-  text-decoration: line-through;
-}
+/* List items that contain an exercise checkbox (tight or loose lists).*/
+#exercises + ul{counter-reset:exercise}
+#exercises + ul li:has(>.exercise-check),#exercises + ul li:has(>p>.exercise-check){--ex-pt:.3rem;--ex-lh:1.7;list-style:none;position:relative;counter-increment:exercise;padding:var(--ex-pt) 0 var(--ex-pt) 4.5rem;line-height:var(--ex-lh);text-decoration:line-through;text-decoration-color:transparent;background:transparent;box-shadow:inset 3px 0 0 transparent;transition:color var(--transition),opacity var(--transition),background var(--transition),box-shadow var(--transition),text-decoration-color var(--transition)}
+#exercises + ul li:has(.exercise-check)>p:first-of-type{margin-top:0}
+#exercises + ul li:has(.exercise-check)>p:last-of-type{margin-bottom:0}
+#exercises + ul li:has(>.exercise-check)::before,#exercises + ul li:has(>p>.exercise-check)::before{content:counter(exercise)".";position:absolute;left:.5rem;top:var(--ex-pt);line-height:var(--ex-lh);font-family:var(--font-display);font-weight:700;color:var(--text-subtle);text-decoration:none;transition:color var(--transition)}
+#exercises + ul .exercise-check{-webkit-appearance:none;appearance:none;box-sizing:border-box;font:inherit;width:1.4rem;height:1.4rem;border-radius:8px;border:1.5px solid var(--border);background:var(--surface);position:absolute;left:2.1rem;top:calc(var(--ex-pt) + (var(--ex-lh)*1em - 1.4rem)/2);margin:0;cursor:pointer;transition:background var(--transition),border-color var(--transition),box-shadow var(--transition),transform 120ms ease}
+#exercises + ul .exercise-check:hover{border-color:color-mix(in srgb,var(--accent) 55%,var(--border));background:color-mix(in srgb,var(--accent) 8%,var(--surface))}
+#exercises + ul .exercise-check:active{transform:scale(.9)}
+#exercises + ul .exercise-check:focus-visible{outline:2px solid color-mix(in srgb,var(--accent) 45%,transparent);outline-offset:2px}
+#exercises + ul .exercise-check:checked{background-color:var(--accent);border-color:var(--accent);box-shadow:inset 0 1px 0 rgba(0,0,0,.06);background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 10'><path d='M1 5.2 L4.2 8.4 L11 1.2' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>");background-repeat:no-repeat;background-position:center;background-size:62%;animation:ex-check-pop .26s ease}
+@keyframes ex-check-pop{0%{transform:scale(1)}45%{transform:scale(1.16)}100%{transform:scale(1)}}
+#exercises + ul li:has(.exercise-check:checked){opacity:.85;color:var(--text-faint);text-decoration-color:currentColor;background:color-mix(in srgb,var(--accent-soft) 10%,transparent);box-shadow:inset 3px 0 0 var(--accent)}
+#exercises + ul li:has(.exercise-check:checked)::before{color:var(--accent)}
+@media (prefers-reduced-motion:reduce){#exercises + ul .exercise-check{animation:none;transition:none}}
 
 /* ---- List page (body.list) ---------------------------------------------- */
 body.list{max-width:46rem;margin:clamp(1.5rem,.9rem + 2vw,3rem) auto;padding:0 clamp(.9rem,.4rem + 2vw,1.5rem)}

--- a/internal/skills/data/lathe/SKILL.md
+++ b/internal/skills/data/lathe/SKILL.md
@@ -116,9 +116,9 @@ One paragraph naming the unanswered question a future part will answer. Include 
 
 ## Exercises
 
-1. <specific>
-2. <specific>
-3. <specific>
+- [ ] 1. <specific>
+- [ ] 2. <specific>
+- [ ] 3. <specific>
 
 ## Sources
 

--- a/internal/skills/data/lathe/SKILL.md
+++ b/internal/skills/data/lathe/SKILL.md
@@ -116,9 +116,9 @@ One paragraph naming the unanswered question a future part will answer. Include 
 
 ## Exercises
 
-- [ ] 1. <specific>
-- [ ] 2. <specific>
-- [ ] 3. <specific>
+- [ ] <specific>
+- [ ] <specific>
+- [ ] <specific>
 
 ## Sources
 
@@ -310,7 +310,7 @@ Every part ends with **four** things:
 
 1. **A send-off (or forward hook).** For the final part: one short paragraph inviting the reader to leave the path you took. For non-final parts: a single forward-pointing sentence naming the question the next part will answer — lean into the cliffhanger.
 2. **A closing reflection.** One self-explanation prompt, in plain prose (not a callout): *"Before you move on: in two sentences, why does the ring buffer beat a channel here? Write it in your own words — the answer that satisfies a sceptical colleague."* Pick the single most important design decision in this part and ask the reader to explain the *why*, not the *what*. Don't answer it for them.
-3. **`## Exercises`**, numbered, 3–5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
+3. **`## Exercises`**, Markdown task-list checkboxes (- [ ]), 3-5 of them. Each specific enough that a motivated reader can start it in 30 seconds. *"Add FM modulation between two oscillators. Routing matrix is up to you — at minimum, let oscillator 2 modulate oscillator 1's frequency."* Not *"explore further."*
 4. **`## Sources`**, numbered, one entry per source used inline in *this part*. Format: `[Title](url) — one sentence on why this source matters`. Group by primary docs / papers / deep-dives if more than ~5 entries.
 
 ## Output files

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -145,6 +145,46 @@ func WriteProgress(tutorialDir string, progress *Progress) error {
 	return writeJSONFile(filepath.Join(tutorialDir, "progress.json"), progress)
 }
 
+// ExerciseState maps a part filename (e.g. "part-02.md") to the indices of the
+// exercises a reader has checked off in that part. It lives in an exercises.json
+// sidecar, deliberately separate from progress.json: checkbox state is per-part
+// and bidirectional (unchecking is a normal action), so it must never be folded
+// into the monotonic, single-slot reading-progress record.
+type ExerciseState map[string][]int
+
+// ReadExercises returns the saved exercise checkbox state for a tutorial. A
+// missing exercises.json is not an error — it yields an empty (non-nil) state —
+// so callers can treat "never saved" and "saved nothing" identically. A present
+// but unreadable or corrupt file still surfaces its error.
+func ReadExercises(tutorialDir string) (ExerciseState, error) {
+	state := ExerciseState{}
+	if err := readJSONFile(filepath.Join(tutorialDir, "exercises.json"), &state); err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return state, err
+	}
+	return state, nil
+}
+
+// WriteExercisePart merges one part's checked indices into exercises.json,
+// leaving every other part's entry untouched — so saving part 2 can never
+// clobber or check part 1's boxes. The incoming slice is the part's complete
+// checked set (an unchecked box is simply absent), so an empty set deletes the
+// part's entry entirely rather than storing an empty array.
+func WriteExercisePart(tutorialDir, part string, checked []int) error {
+	state, err := ReadExercises(tutorialDir)
+	if err != nil {
+		return err
+	}
+	if len(checked) > 0 {
+		state[part] = checked
+	} else {
+		delete(state, part)
+	}
+	return writeJSONFile(filepath.Join(tutorialDir, "exercises.json"), state)
+}
+
 func ReadVerifyResult(tutorialDir string) (*VerifyResult, error) {
 	var v VerifyResult
 	if err := readJSONFile(filepath.Join(tutorialDir, "verify-result.json"), &v); err != nil {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -524,3 +524,113 @@ func TestPendingPartOmittedWhenEmpty(t *testing.T) {
 		t.Error("pending_part should be omitted from JSON when empty")
 	}
 }
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestExercisesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := store.WriteExercisePart(dir, "part-02.md", []int{0, 2, 5}); err != nil {
+		t.Fatalf("WriteExercisePart: %v", err)
+	}
+	state, err := store.ReadExercises(dir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if !sameInts(state["part-02.md"], []int{0, 2, 5}) {
+		t.Errorf("exercises = %v, want [0 2 5]", state["part-02.md"])
+	}
+}
+
+func TestReadExercisesMissingFileIsEmptyNotError(t *testing.T) {
+	// A tutorial that never saved a checkbox has no exercises.json; that must read
+	// as an empty (non-nil) state, so callers treat "never saved" like "saved
+	// nothing" without special-casing.
+	state, err := store.ReadExercises(t.TempDir())
+	if err != nil {
+		t.Fatalf("ReadExercises on missing file: %v", err)
+	}
+	if state == nil {
+		t.Fatal("ReadExercises returned nil state, want empty non-nil map")
+	}
+	if len(state) != 0 {
+		t.Errorf("ReadExercises on missing file = %v, want empty", state)
+	}
+}
+
+func TestWriteExercisePartMergesWithoutClobbering(t *testing.T) {
+	// Per-part keying is the whole point of the separate sidecar: saving one part
+	// must never disturb another part's boxes.
+	dir := t.TempDir()
+	if err := store.WriteExercisePart(dir, "part-01.md", []int{1}); err != nil {
+		t.Fatalf("WriteExercisePart part-01: %v", err)
+	}
+	if err := store.WriteExercisePart(dir, "part-02.md", []int{0, 3}); err != nil {
+		t.Fatalf("WriteExercisePart part-02: %v", err)
+	}
+	state, err := store.ReadExercises(dir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if !sameInts(state["part-01.md"], []int{1}) {
+		t.Errorf("part-01 = %v, want [1]", state["part-01.md"])
+	}
+	if !sameInts(state["part-02.md"], []int{0, 3}) {
+		t.Errorf("part-02 = %v, want [0 3]", state["part-02.md"])
+	}
+}
+
+func TestWriteExercisePartEmptyDeletesEntry(t *testing.T) {
+	// An empty checked-set means every box was unchecked: the part's entry is
+	// removed (not stored as an empty array), and sibling parts survive.
+	dir := t.TempDir()
+	if err := store.WriteExercisePart(dir, "part-01.md", []int{0}); err != nil {
+		t.Fatalf("WriteExercisePart part-01: %v", err)
+	}
+	if err := store.WriteExercisePart(dir, "part-02.md", []int{2, 4}); err != nil {
+		t.Fatalf("WriteExercisePart part-02: %v", err)
+	}
+	if err := store.WriteExercisePart(dir, "part-02.md", nil); err != nil {
+		t.Fatalf("WriteExercisePart clear part-02: %v", err)
+	}
+
+	state, err := store.ReadExercises(dir)
+	if err != nil {
+		t.Fatalf("ReadExercises: %v", err)
+	}
+	if _, ok := state["part-02.md"]; ok {
+		t.Errorf("part-02 entry should be deleted after empty save, got %v", state["part-02.md"])
+	}
+	if !sameInts(state["part-01.md"], []int{0}) {
+		t.Errorf("part-01 = %v, want [0] preserved", state["part-01.md"])
+	}
+	// The cleared part must not linger as an empty array in the JSON.
+	data, err := os.ReadFile(filepath.Join(dir, "exercises.json"))
+	if err != nil {
+		t.Fatalf("ReadFile exercises.json: %v", err)
+	}
+	if strings.Contains(string(data), "part-02.md") {
+		t.Errorf("exercises.json still references cleared part-02:\n%s", data)
+	}
+}
+
+func TestReadExercisesCorruptFileErrors(t *testing.T) {
+	// Only a *missing* file is the empty case; a present-but-unreadable sidecar
+	// must surface its error rather than be silently treated as empty.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "exercises.json"), []byte("not json"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := store.ReadExercises(dir); err == nil {
+		t.Error("ReadExercises on corrupt file = nil error, want error")
+	}
+}


### PR DESCRIPTION
## What & why

This PR resolves #64, introduces the ability to have exercises live statefully within `exercises.json` located inside tutorial folders, and looks to change tutorial generation instructions (via LLM agents) to use Markdown Task Lists, instead of using ordered list syntax; data is saved alongside tutorial per-part metadata. The Go renderer and templating engine then categorizes and parses the preferred Exercise Markdown syntax appropriately, stylizing it with nice animated checkboxes.

More overview information about the technical functionality can be found in the issue (#64) or in the original discussion (#62)

I've gone ahead and ensured that extra test coverage is applied (e36e578f0d34f6aefb21d2a3485a2110d6ebdfdf), specifically for this PR, as broken tutorial syntax output can really mess up tutorial-part progress, break portions of the monotonic/progression save, or render parts of the page useless.

## Notes

* No new `SKILL.md` files are introduced, only existing ones were modified.
* Only the section with the CSS ID `#exercise/#exercises` contains these checkbox styling modifications. Checkboxes elsewhere will return native Lathe styling.

## How to test

**This PR only affects newly generated tutorial parts that are created _after_ this merge.** Older tutorials are unaffected, and should be finalized this way.

1. Pull the branch down, and generate a new tutorial from scratch using `/lathe-extend <slug>` and then verifying that the resulting Exercises generated with the appropriate task lists in GitHub Markdown format.

2. You can also manually override tutorials (both new and old) by removing the ordered list within the Exercises section, and replacing them with task list syntax:

```md
1. <EXERCISE>    --{change}->    - [  ] <EXERCISE>
```

## Checklist

- [X] PR title is in conventional-commit format (`feat:`/`fix:`/`docs:`/`chore:`/`refactor:`)
- [X] `mage check` passes locally
- [X] Updated docs (`AGENTS.md` / `README.md` / `docs/`) if behavior changed
- [ ] ~~Edited `.claude/skills/` (not `internal/skills/data/`) and ran `mage skills`, if skills changed~~
     - This PR sadly **does** include direct modifications to `internal/skills/data/lathe/SKILL.md`, but they replicate 1:1 what `./claude/skills` has commited, and `mage skills` on a separate branch produces the same results. This will be noted for future PRs.
     
     (I make these commits before `CONTRIBUTING.md` was published :( ... )
     
     If you would like a cleaner approach, I can close this PR, squash & revert that file modification, then resubmit after running `mage skills` against the repo.
