### PR TITLE
feat: add anchored code excerpts and pure-Go drift checking

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/devenjarvis/lathe/internal/anchor"
+	"github.com/devenjarvis/lathe/internal/config"
+	"github.com/devenjarvis/lathe/internal/drift"
+	"github.com/devenjarvis/lathe/internal/gitrepo"
+	"github.com/devenjarvis/lathe/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	driftRepoPath string
+	driftJSON     bool
+)
+
+// driftCmd checks whether an onboarding guide still describes its repository.
+//
+// This is the one verification signal the binary produces by itself, and it does
+// not violate the no-model-in-Go rule: drift is a git computation (diff the
+// pinned commit against HEAD, map anchored line ranges through the hunks), not a
+// judgement. Interpreting what the drift *means* for the prose is still the
+// /lathe-verify skill's job in the user's interactive session.
+var driftCmd = &cobra.Command{
+	Use:   "drift <slug>",
+	Short: "Check whether an onboarding guide still matches its repository",
+	Long: `Diff the commit an onboarding guide is pinned to against HEAD and classify
+every anchored code excerpt as ok, moved, changed, renamed, or broken.
+
+A changed or broken anchor sets the guide's status to stale; a later clean check
+returns a stale guide to unverified. Moved and renamed anchors are not drift —
+the guide still describes the code, it just lives at a different line or path.
+
+When the pinned commit is not in the repository (a shallow clone, a rebase, a
+GC), the result is unknown: drift exits non-zero and leaves status untouched
+rather than reporting drift it cannot actually see.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slug := args[0]
+		if err := validateSlug(slug); err != nil {
+			return err
+		}
+		tutorialsDir, err := config.TutorialsDir()
+		if err != nil {
+			return err
+		}
+		tutDir := filepath.Join(tutorialsDir, slug)
+		tut, err := store.ReadMetadata(tutDir)
+		if err != nil {
+			return fmt.Errorf("read metadata for %q: %w", slug, err)
+		}
+		if !tut.IsOnboarding() || tut.RepoCommit == "" {
+			return fmt.Errorf("%q is not an onboarding guide with a pinned commit; drift only applies to guides stored with --kind onboarding --repo-commit", slug)
+		}
+
+		repo, err := resolveDriftRepo(tut, driftRepoPath)
+		if err != nil {
+			return err
+		}
+
+		parts, err := driftParts(tutDir, tut)
+		if err != nil {
+			return err
+		}
+
+		result, err := drift.CheckParts(repo, tut.RepoCommit, parts)
+		if err != nil {
+			if errors.Is(err, drift.ErrUnknownPin) || errors.Is(err, drift.ErrNoCommonHistory) {
+				// Degrade to unknown rather than to stale: reporting drift we
+				// cannot actually see is worse than reporting nothing. Status and
+				// drift.json are both left exactly as they were.
+				return fmt.Errorf("drift is unknown for %q: %w", slug, err)
+			}
+			return err
+		}
+
+		if err := store.WriteDrift(tutDir, &result); err != nil {
+			return fmt.Errorf("write drift result: %w", err)
+		}
+
+		transition := applyDriftStatus(tut, &result)
+		if transition != "" {
+			if err := store.WriteMetadata(tutDir, tut); err != nil {
+				return fmt.Errorf("write metadata: %w", err)
+			}
+		}
+
+		out := cmd.OutOrStdout()
+		if driftJSON {
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
+		}
+		printDriftReport(out, slug, tut, &result, transition)
+		return nil
+	},
+}
+
+// applyDriftStatus mutates tut's status for a completed drift check and returns
+// a human-readable description of what it did (empty when nothing changed).
+//
+// Two guards matter here. A guide that is mid-verify or mid-extend is left
+// alone entirely — those statuses are in-flight markers owned by the skills, and
+// stomping one would strand a spinner in the web UI. And a guide only leaves
+// stale when a later check comes back clean, so stale never sticks after the
+// code is fixed.
+func applyDriftStatus(tut *store.Tutorial, result *drift.Result) string {
+	if tut.Status == store.StatusVerifying || tut.Status == store.StatusExtending {
+		return ""
+	}
+	switch {
+	case result.Stale() && tut.Status != store.StatusStale:
+		tut.Status = store.StatusStale
+		return "status set to stale"
+	case !result.Stale() && tut.Status == store.StatusStale:
+		tut.Status = store.StatusUnverified
+		return "status returned to unverified"
+	}
+	return ""
+}
+
+// resolveDriftRepo finds the working copy to check against, in priority order:
+// an explicit --repo-path, then the current directory when its origin matches
+// the guide's recorded repo, and only then the RepoPath recorded at store time.
+//
+// The recorded path is last on purpose: it is machine-local, so it is wrong the
+// moment ~/.lathe is copied to another machine or the repo is re-cloned
+// elsewhere. Running from inside a checkout has to be the path that always
+// works.
+func resolveDriftRepo(tut *store.Tutorial, flagPath string) (*gitrepo.Repo, error) {
+	if flagPath != "" {
+		repo, err := gitrepo.Open(flagPath)
+		if err != nil {
+			return nil, fmt.Errorf("--repo-path %s: %w", flagPath, err)
+		}
+		return repo, nil
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		if repo, err := gitrepo.Open(cwd); err == nil {
+			if origin, err := repo.OriginURL(); err == nil {
+				if store.NormalizeRepo(origin) == tut.Repo {
+					return repo, nil
+				}
+			}
+		}
+	}
+
+	if tut.RepoPath != "" {
+		if repo, err := gitrepo.Open(tut.RepoPath); err == nil {
+			return repo, nil
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"cannot find a checkout of %s for %q — run this from inside the repository, or point at it:\n\n  lathe drift %s --repo-path /path/to/repo",
+		tut.Repo, tut.Slug, tut.Slug)
+}
+
+// driftParts reads every part of the guide and parses its anchored blocks.
+func driftParts(tutDir string, tut *store.Tutorial) ([]drift.Part, error) {
+	names := tut.Parts
+	if len(names) == 0 {
+		// Legacy single-part tutorials still store index.md.
+		names = []string{"index.md"}
+	}
+	var parts []drift.Part
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(tutDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		parts = append(parts, drift.Part{Name: name, Anchors: anchor.Parse(data)})
+	}
+	return parts, nil
+}
+
+func printDriftReport(w io.Writer, slug string, tut *store.Tutorial, result *drift.Result, transition string) {
+	_, _ = fmt.Fprintf(w, "%s — pinned %s, HEAD %s\n", slug, short(result.PinnedCommit), short(result.HeadCommit))
+	_, _ = fmt.Fprintf(w, "%s\n", result.SummaryLine())
+	if result.Dirty {
+		_, _ = fmt.Fprintln(w, "note: the working tree has uncommitted changes; drift is measured against HEAD")
+	}
+
+	// List everything worth a reader's attention — the problems, plus anything
+	// that moved, since a moved anchor's printed line number is now wrong.
+	var noteworthy []drift.AnchorResult
+	for _, a := range result.Anchors {
+		if a.Verdict != drift.VerdictOK {
+			noteworthy = append(noteworthy, a)
+		}
+	}
+	if len(noteworthy) > 0 {
+		_, _ = fmt.Fprintln(w)
+		part := ""
+		for _, a := range noteworthy {
+			if a.Part != part {
+				part = a.Part
+				_, _ = fmt.Fprintf(w, "%s\n", part)
+			}
+			_, _ = fmt.Fprintf(w, "  %s — %s%s\n", anchorLocation(a), a.Verdict, driftDetail(a))
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	if result.Stale() {
+		_, _ = fmt.Fprintf(w, "drift detected")
+	} else {
+		_, _ = fmt.Fprintf(w, "clean — no drift detected")
+	}
+	if transition != "" {
+		_, _ = fmt.Fprintf(w, "; %s", transition)
+	} else {
+		_, _ = fmt.Fprintf(w, "; status unchanged (%s)", tut.Status)
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// anchorLocation renders the anchor as the guide wrote it (path:line).
+func anchorLocation(a drift.AnchorResult) string {
+	if a.Start == 0 {
+		return a.Path
+	}
+	if a.Start == a.End {
+		return fmt.Sprintf("%s:%d", a.Path, a.Start)
+	}
+	return fmt.Sprintf("%s:%d-%d", a.Path, a.Start, a.End)
+}
+
+// driftDetail adds the "where it is now" half of a verdict.
+func driftDetail(a drift.AnchorResult) string {
+	switch a.Verdict {
+	case drift.VerdictMoved:
+		return fmt.Sprintf(" (now at line %d)", a.CurrentStart)
+	case drift.VerdictRenamed:
+		return fmt.Sprintf(" (now %s)", a.NewPath)
+	case drift.VerdictBroken:
+		if a.Detail != "" {
+			return fmt.Sprintf(" (%s)", a.Detail)
+		}
+	case drift.VerdictChanged:
+		if a.NewPath != "" {
+			return fmt.Sprintf(" (now %s:%d)", a.NewPath, a.CurrentStart)
+		}
+	}
+	return ""
+}
+
+func short(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+func init() {
+	driftCmd.Flags().StringVar(&driftRepoPath, "repo-path", "", "path to the repository checkout to check against (defaults to the current directory, then the path recorded at store time)")
+	driftCmd.Flags().BoolVar(&driftJSON, "json", false, "print the raw drift result as JSON")
+	rootCmd.AddCommand(driftCmd)
+}

--- a/cmd/drift_test.go
+++ b/cmd/drift_test.go
@@ -1,0 +1,346 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/drift"
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func resetDriftFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		driftRepoPath = ""
+		driftJSON = false
+		driftCmd.SetOut(nil)
+	})
+}
+
+func driftGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+const driftSource = "package app\n\nfunc One() {}\n\nfunc Two() {}\n\nfunc Three() {}\n"
+
+// newDriftRepo builds a git repo with a single source file and returns its dir
+// plus the SHA of the initial commit.
+func newDriftRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	driftGit(t, dir, "init", "-b", "main")
+	driftGit(t, dir, "config", "user.email", "test@example.com")
+	driftGit(t, dir, "config", "user.name", "Test")
+	driftGit(t, dir, "config", "commit.gpgsign", "false")
+	driftGit(t, dir, "remote", "add", "origin", "git@github.com:devenjarvis/example.git")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte(driftSource), 0644); err != nil {
+		t.Fatal(err)
+	}
+	driftGit(t, dir, "add", "-A")
+	driftGit(t, dir, "commit", "-m", "init")
+	return dir, driftGit(t, dir, "rev-parse", "HEAD")
+}
+
+// writeOnboarding stores an onboarding guide whose single part anchors lines
+// 3-3 of app.go (the `func One() {}` line).
+func writeOnboarding(t *testing.T, homeDir, slug, repoDir, sha string, status store.Status) string {
+	t.Helper()
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", slug)
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	part := "# Guide\n\nHere is the entry point.\n\n```go path=app.go lines=3-3\nfunc One() {}\n```\n"
+	if err := os.WriteFile(filepath.Join(tutDir, "part-01.md"), []byte(part), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tut := &store.Tutorial{
+		Slug:       slug,
+		Title:      store.SlugToTitle(slug),
+		Status:     status,
+		Parts:      []string{"part-01.md"},
+		Kind:       store.KindOnboarding,
+		Repo:       "github.com/devenjarvis/example",
+		RepoBranch: "main",
+		RepoCommit: sha,
+		RepoPath:   repoDir,
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	return tutDir
+}
+
+func runDrift(t *testing.T, slug string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	driftCmd.SetOut(&out)
+	err := driftCmd.RunE(driftCmd, []string{slug})
+	return out.String(), err
+}
+
+func TestDriftCleanLeavesStatusAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusVerified)
+	resetDriftFlags(t)
+
+	out, err := runDrift(t, "example-onboarding")
+	if err != nil {
+		t.Fatalf("drift: %v\n%s", err, out)
+	}
+
+	tut, err := store.ReadMetadata(tutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tut.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified (a clean check must not touch status)", tut.Status)
+	}
+	res, err := store.ReadDrift(tutDir)
+	if err != nil {
+		t.Fatalf("ReadDrift: %v", err)
+	}
+	if res.PinnedCommit != sha || res.HeadCommit != sha {
+		t.Errorf("drift.json commits = %q/%q, want %q", res.PinnedCommit, res.HeadCommit, sha)
+	}
+	if res.Summary[drift.VerdictOK] != 1 {
+		t.Errorf("Summary = %#v, want one ok", res.Summary)
+	}
+	if !strings.Contains(out, "no drift") {
+		t.Errorf("output should report no drift:\n%s", out)
+	}
+}
+
+func TestDriftChangedFlipsToStale(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusVerified)
+	resetDriftFlags(t)
+
+	edited := strings.Replace(driftSource, "func One() {}", "func One(ctx context.Context) {}", 1)
+	if err := os.WriteFile(filepath.Join(repoDir, "app.go"), []byte(edited), 0644); err != nil {
+		t.Fatal(err)
+	}
+	driftGit(t, repoDir, "commit", "-am", "change One")
+
+	out, err := runDrift(t, "example-onboarding")
+	if err != nil {
+		t.Fatalf("drift: %v\n%s", err, out)
+	}
+
+	tut, _ := store.ReadMetadata(tutDir)
+	if tut.Status != store.StatusStale {
+		t.Errorf("Status = %q, want stale", tut.Status)
+	}
+	res, err := store.ReadDrift(tutDir)
+	if err != nil {
+		t.Fatalf("ReadDrift: %v", err)
+	}
+	if res.Summary[drift.VerdictChanged] != 1 {
+		t.Errorf("Summary = %#v, want one changed", res.Summary)
+	}
+	if res.Anchors[0].Part != "part-01.md" {
+		t.Errorf("anchor Part = %q, want part-01.md", res.Anchors[0].Part)
+	}
+	if !strings.Contains(out, "changed") || !strings.Contains(out, "app.go") {
+		t.Errorf("output should name the changed anchor:\n%s", out)
+	}
+}
+
+func TestDriftInsertionAboveIsMovedNotStale(t *testing.T) {
+	// The false-positive test: a blank line inserted above the anchored range
+	// must report moved and leave status alone.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusVerified)
+	resetDriftFlags(t)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "app.go"), []byte("// added\n"+driftSource), 0644); err != nil {
+		t.Fatal(err)
+	}
+	driftGit(t, repoDir, "commit", "-am", "add a comment at the top")
+
+	if _, err := runDrift(t, "example-onboarding"); err != nil {
+		t.Fatalf("drift: %v", err)
+	}
+
+	tut, _ := store.ReadMetadata(tutDir)
+	if tut.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified — a moved anchor is not drift", tut.Status)
+	}
+	res, _ := store.ReadDrift(tutDir)
+	if res.Anchors[0].Verdict != drift.VerdictMoved {
+		t.Fatalf("Verdict = %q, want moved", res.Anchors[0].Verdict)
+	}
+	if res.Anchors[0].CurrentStart != 4 {
+		t.Errorf("CurrentStart = %d, want 4", res.Anchors[0].CurrentStart)
+	}
+}
+
+func TestDriftRevertReturnsStaleToUnverified(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusVerified)
+	resetDriftFlags(t)
+
+	edited := strings.Replace(driftSource, "func One() {}", "func One(ctx context.Context) {}", 1)
+	if err := os.WriteFile(filepath.Join(repoDir, "app.go"), []byte(edited), 0644); err != nil {
+		t.Fatal(err)
+	}
+	driftGit(t, repoDir, "commit", "-am", "change One")
+	if _, err := runDrift(t, "example-onboarding"); err != nil {
+		t.Fatal(err)
+	}
+	if tut, _ := store.ReadMetadata(tutDir); tut.Status != store.StatusStale {
+		t.Fatalf("setup: Status = %q, want stale", tut.Status)
+	}
+
+	driftGit(t, repoDir, "revert", "--no-edit", "HEAD")
+	if _, err := runDrift(t, "example-onboarding"); err != nil {
+		t.Fatal(err)
+	}
+	if tut, _ := store.ReadMetadata(tutDir); tut.Status != store.StatusUnverified {
+		t.Errorf("Status = %q, want unverified after a clean re-check", tut.Status)
+	}
+}
+
+func TestDriftUnknownPinExitsNonZeroAndLeavesStatus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, _ := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir,
+		"0000000000000000000000000000000000000000", store.StatusVerified)
+	resetDriftFlags(t)
+
+	out, err := runDrift(t, "example-onboarding")
+	if err == nil {
+		t.Fatal("drift with an unknown pinned commit should return an error")
+	}
+	if tut, _ := store.ReadMetadata(tutDir); tut.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified — an unknown pin must not change status", tut.Status)
+	}
+	if _, err := store.ReadDrift(tutDir); !os.IsNotExist(err) {
+		t.Errorf("an unknown pin must not write drift.json: err=%v", err)
+	}
+	if !strings.Contains(out+err.Error(), "unknown") {
+		t.Errorf("output/error should say the result is unknown:\nout=%s\nerr=%v", out, err)
+	}
+}
+
+func TestDriftSkipsInFlightStatuses(t *testing.T) {
+	for _, status := range []store.Status{store.StatusVerifying, store.StatusExtending} {
+		t.Run(string(status), func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			repoDir, sha := newDriftRepo(t)
+			tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, status)
+			resetDriftFlags(t)
+
+			edited := strings.Replace(driftSource, "func One() {}", "func One(ctx context.Context) {}", 1)
+			if err := os.WriteFile(filepath.Join(repoDir, "app.go"), []byte(edited), 0644); err != nil {
+				t.Fatal(err)
+			}
+			driftGit(t, repoDir, "commit", "-am", "change One")
+
+			if _, err := runDrift(t, "example-onboarding"); err != nil {
+				t.Fatal(err)
+			}
+			if tut, _ := store.ReadMetadata(tutDir); tut.Status != status {
+				t.Errorf("Status = %q, want %q — drift must not disturb in-flight work", tut.Status, status)
+			}
+		})
+	}
+}
+
+func TestDriftJSONOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusUnverified)
+	resetDriftFlags(t)
+	driftJSON = true
+
+	out, err := runDrift(t, "example-onboarding")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res drift.Result
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out)
+	}
+	if res.PinnedCommit != sha {
+		t.Errorf("PinnedCommit = %q, want %q", res.PinnedCommit, sha)
+	}
+}
+
+func TestDriftRejectsNonOnboardingTutorial(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTutorial(t, home, "plain-tutorial", store.StatusUnverified, []string{"part-01.md"})
+	resetDriftFlags(t)
+
+	if _, err := runDrift(t, "plain-tutorial"); err == nil {
+		t.Fatal("drift on a plain tutorial should error")
+	}
+}
+
+func TestDriftRepoPathFlagWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoDir, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", repoDir, sha, store.StatusUnverified)
+	// Point the recorded path somewhere useless, the way a copied ~/.lathe would.
+	tut, _ := store.ReadMetadata(tutDir)
+	tut.RepoPath = filepath.Join(home, "does-not-exist")
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+	resetDriftFlags(t)
+	driftRepoPath = repoDir
+
+	if _, err := runDrift(t, "example-onboarding"); err != nil {
+		t.Fatalf("--repo-path should resolve the repo: %v", err)
+	}
+}
+
+func TestDriftUnresolvableRepoNamesTheCommandToRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, sha := newDriftRepo(t)
+	tutDir := writeOnboarding(t, home, "example-onboarding", filepath.Join(home, "gone"), sha, store.StatusVerified)
+	resetDriftFlags(t)
+
+	_, err := runDrift(t, "example-onboarding")
+	if err == nil {
+		t.Fatal("drift with no resolvable repo should error")
+	}
+	if !strings.Contains(err.Error(), "--repo-path") {
+		t.Errorf("error should name the command to run, got: %v", err)
+	}
+	if tut, _ := store.ReadMetadata(tutDir); tut.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified", tut.Status)
+	}
+}
+
+func TestDriftInvalidSlug(t *testing.T) {
+	resetDriftFlags(t)
+	if _, err := runDrift(t, "../escape"); err == nil {
+		t.Fatal("drift should reject a traversal slug")
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -63,6 +63,8 @@ func statusBadge(s store.Status) string {
 		return "⚠️ skipped"
 	case store.StatusExtending:
 		return "⏳ extending"
+	case store.StatusStale:
+		return "🕰️ stale"
 	default:
 		return string(s)
 	}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/store"
+)
+
+func TestStatusBadge(t *testing.T) {
+	tests := []struct {
+		status store.Status
+		want   string
+	}{
+		{store.StatusUnverified, ""}, // calm default — no badge, matching the web UI
+		{store.StatusVerified, "verified"},
+		{store.StatusVerifying, "verifying"},
+		{store.StatusFailed, "failed"},
+		{store.StatusSkipped, "skipped"},
+		{store.StatusExtending, "extending"},
+		{store.StatusStale, "stale"},
+	}
+	for _, tt := range tests {
+		got := statusBadge(tt.status)
+		if tt.want == "" {
+			if got != "" {
+				t.Errorf("statusBadge(%q) = %q, want empty", tt.status, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, tt.want) {
+			t.Errorf("statusBadge(%q) = %q, want it to contain %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -9,15 +9,18 @@ import (
 )
 
 var (
-	withVerify    bool
-	storeTags     []string
-	storeTagsList []string
-	storeSources  []string
-	storeRepo     string
-	storeBranch   string
-	storeTools    []string
-	storeVoice    string
-	storeModel    string
+	withVerify      bool
+	storeTags       []string
+	storeTagsList   []string
+	storeSources    []string
+	storeRepo       string
+	storeBranch     string
+	storeRepoCommit string
+	storeRepoPath   string
+	storeKind       string
+	storeTools      []string
+	storeVoice      string
+	storeModel      string
 )
 
 var storeCmd = &cobra.Command{
@@ -25,14 +28,21 @@ var storeCmd = &cobra.Command{
 	Short: "Save a tutorial directory to ~/.lathe/tutorials/",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		kind, err := store.NormalizeKind(storeKind)
+		if err != nil {
+			return err
+		}
 		tut, err := store.Store(args[0], store.StoreOptions{
-			Tags:    splitTags(append(storeTags, storeTagsList...)),
-			Sources: storeSources,
-			Repo:    storeRepo,
-			Branch:  storeBranch,
-			Tools:   parseTools(storeTools),
-			Voice:   storeVoice,
-			Model:   storeModel,
+			Tags:       splitTags(append(storeTags, storeTagsList...)),
+			Sources:    storeSources,
+			Repo:       storeRepo,
+			Branch:     storeBranch,
+			Kind:       kind,
+			RepoCommit: storeRepoCommit,
+			RepoPath:   storeRepoPath,
+			Tools:      parseTools(storeTools),
+			Voice:      storeVoice,
+			Model:      storeModel,
 		})
 		if err != nil {
 			return err
@@ -44,6 +54,10 @@ var storeCmd = &cobra.Command{
 				fmt.Printf(" (%s)", tut.RepoBranch)
 			}
 			fmt.Println()
+		}
+		if tut.IsOnboarding() {
+			fmt.Printf("Pinned at: %s\n", tut.RepoCommit)
+			fmt.Printf("\nTo check it against the repo later, run:\n\n  lathe drift %s\n", tut.Slug)
 		}
 		// Verification runs in the user's interactive coding-agent session via
 		// the /lathe-verify skill (the binary never drives a model), so --verify
@@ -86,6 +100,9 @@ func init() {
 	storeCmd.Flags().StringArrayVar(&storeSources, "source", nil, "URL consulted while researching the tutorial (repeatable; the research trail surfaced as provenance)")
 	storeCmd.Flags().StringVar(&storeRepo, "repo", "", "git remote the tutorial was written for (canonicalized to host/org/repo for grouping)")
 	storeCmd.Flags().StringVar(&storeBranch, "repo-branch", "", "branch the tutorial targets (only recorded when --repo is set)")
+	storeCmd.Flags().StringVar(&storeKind, "kind", "", "tutorial (default) or onboarding — an onboarding guide to an existing codebase")
+	storeCmd.Flags().StringVar(&storeRepoCommit, "repo-commit", "", "commit SHA the guide's anchored excerpts are pinned to (required with --kind onboarding)")
+	storeCmd.Flags().StringVar(&storeRepoPath, "repo-path", "", "local checkout the guide was written against (required with --kind onboarding; a hint only — drift prefers the current directory)")
 	storeCmd.Flags().StringArrayVar(&storeTools, "tool", nil, "language/tool and version the tutorial targets, as name:version (repeatable)")
 	storeCmd.Flags().StringVar(&storeVoice, "voice", "", "writing voice the tutorial was generated in (built-in preset or custom voice name)")
 	storeCmd.Flags().StringVar(&storeModel, "model", "", "LLM that authored the tutorial, as a display label (e.g. \"Claude Opus 4.8\"); shown in the reading-page byline")

--- a/cmd/store_test.go
+++ b/cmd/store_test.go
@@ -56,3 +56,77 @@ func TestStoreCmdRecordsModel(t *testing.T) {
 		t.Errorf("Model = %q, want %q", got.Model, "Claude Opus 4.8")
 	}
 }
+
+func resetOnboardingStoreFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		storeKind = ""
+		storeRepo = ""
+		storeBranch = ""
+		storeRepoCommit = ""
+		storeRepoPath = ""
+	})
+}
+
+func TestStoreCmdOnboardingRequiresTheRepoTriple(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	resetOnboardingStoreFlags(t)
+
+	storeKind = "onboarding"
+	storeRepo = "git@github.com:devenjarvis/lathe.git"
+	// No --repo-commit and no --repo-path.
+	if err := storeCmd.RunE(storeCmd, []string{src}); err == nil {
+		t.Fatal("store --kind onboarding without --repo-commit should error")
+	}
+}
+
+func TestStoreCmdRejectsUnknownKind(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	resetOnboardingStoreFlags(t)
+
+	storeKind = "guide"
+	if err := storeCmd.RunE(storeCmd, []string{src}); err == nil {
+		t.Fatal("store --kind guide should error")
+	}
+}
+
+func TestStoreCmdRecordsOnboardingPin(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetOnboardingStoreFlags(t)
+
+	storeKind = "onboarding"
+	storeRepo = "git@github.com:devenjarvis/lathe.git"
+	storeBranch = "main"
+	storeRepoCommit = "1e7c9f6aaaabbbbccccddddeeeeffff0000111122"
+	storeRepoPath = "/Users/x/Code/lathe"
+
+	if err := storeCmd.RunE(storeCmd, []string{src}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	got, err := store.ReadMetadata(filepath.Join(home, ".lathe", "tutorials", filepath.Base(src)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsOnboarding() {
+		t.Error("IsOnboarding() = false")
+	}
+	if got.RepoCommit != storeRepoCommit {
+		t.Errorf("RepoCommit = %q, want %q", got.RepoCommit, storeRepoCommit)
+	}
+	if got.RepoPath != "/Users/x/Code/lathe" {
+		t.Errorf("RepoPath = %q", got.RepoPath)
+	}
+}

--- a/cmd/verify-result.go
+++ b/cmd/verify-result.go
@@ -17,6 +17,7 @@ var (
 	verifyResultFailedStep int
 	verifyResultError      string
 	verifyResultCheckedAt  string
+	verifyResultRepoCommit string
 )
 
 // verifyResultCmd is how the /lathe-verify skill records the outcome of a
@@ -76,6 +77,15 @@ var verifyResultCmd = &cobra.Command{
 		if err := store.WriteVerifyResult(tutDir, result); err != nil {
 			return fmt.Errorf("write verify result: %w", err)
 		}
+		// Re-pinning an onboarding guide has exactly two owners: `lathe store`
+		// (initial) and this flag, set by /lathe-verify after a confirming
+		// re-verify at HEAD. Notably NOT `lathe extend-commit` — a new part
+		// written at a newer HEAD alongside older parts pinned at an older commit
+		// is the ambiguity this design exists to avoid, which is why the extend
+		// skill refuses to run against a drifted guide instead.
+		if sha := store.NormalizeCommit(verifyResultRepoCommit); sha != "" {
+			tut.RepoCommit = sha
+		}
 		tut.Status = status
 		if err := store.WriteMetadata(tutDir, tut); err != nil {
 			return fmt.Errorf("write metadata: %w", err)
@@ -100,6 +110,7 @@ func init() {
 	verifyResultCmd.Flags().IntVar(&verifyResultFailedStep, "failed-step", 0, "1-indexed step number that failed")
 	verifyResultCmd.Flags().StringVar(&verifyResultError, "error", "", "error message or output to record")
 	verifyResultCmd.Flags().StringVar(&verifyResultCheckedAt, "checked-at", "", "RFC3339 timestamp (defaults to now)")
+	verifyResultCmd.Flags().StringVar(&verifyResultRepoCommit, "repo-commit", "", "re-pin an onboarding guide to this commit (the SHA the guide was just re-verified against)")
 	verifyResultCmd.MarkFlagRequired("status") //nolint:errcheck
 	rootCmd.AddCommand(verifyResultCmd)
 }

--- a/cmd/verify-result_test.go
+++ b/cmd/verify-result_test.go
@@ -18,6 +18,7 @@ func resetVerifyResultFlags(t *testing.T) {
 		verifyResultFailedStep = 0
 		verifyResultError = ""
 		verifyResultCheckedAt = ""
+		verifyResultRepoCommit = ""
 	})
 }
 
@@ -121,5 +122,68 @@ func TestVerifyResultRejectsBadStatus(t *testing.T) {
 	verifyResultStatus = "bogus"
 	if err := verifyResultCmd.RunE(verifyResultCmd, []string{"test-slug"}); err == nil {
 		t.Error("verify-result should reject an unknown --status")
+	}
+}
+
+func TestVerifyResultRePinsRepoCommit(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", "onboard")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	old := "1111111111111111111111111111111111111111"
+	tut := &store.Tutorial{
+		Slug:       "onboard",
+		Status:     store.StatusStale,
+		Kind:       store.KindOnboarding,
+		Repo:       "github.com/devenjarvis/lathe",
+		RepoCommit: old,
+		RepoPath:   "/tmp/lathe",
+	}
+	if err := store.WriteMetadata(tutDir, tut); err != nil {
+		t.Fatal(err)
+	}
+
+	resetVerifyResultFlags(t)
+	verifyResultStatus = "verified"
+	verifyResultRepoCommit = "  2222222222222222222222222222222222222222 "
+	if err := verifyResultCmd.RunE(verifyResultCmd, []string{"onboard"}); err != nil {
+		t.Fatalf("verify-result: %v", err)
+	}
+
+	got, _ := store.ReadMetadata(tutDir)
+	if got.RepoCommit != "2222222222222222222222222222222222222222" {
+		t.Errorf("RepoCommit = %q, want the re-pinned SHA", got.RepoCommit)
+	}
+	if got.Status != store.StatusVerified {
+		t.Errorf("Status = %q, want verified", got.Status)
+	}
+}
+
+func TestVerifyResultLeavesRepoCommitAloneWithoutTheFlag(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	tutDir := filepath.Join(homeDir, ".lathe", "tutorials", "onboard")
+	if err := os.MkdirAll(tutDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	old := "1111111111111111111111111111111111111111"
+	if err := store.WriteMetadata(tutDir, &store.Tutorial{
+		Slug: "onboard", Status: store.StatusUnverified,
+		Kind: store.KindOnboarding, Repo: "github.com/devenjarvis/lathe",
+		RepoCommit: old, RepoPath: "/tmp/lathe",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resetVerifyResultFlags(t)
+	verifyResultStatus = "verified"
+	if err := verifyResultCmd.RunE(verifyResultCmd, []string{"onboard"}); err != nil {
+		t.Fatalf("verify-result: %v", err)
+	}
+	got, _ := store.ReadMetadata(tutDir)
+	if got.RepoCommit != old {
+		t.Errorf("RepoCommit = %q, want it unchanged at %q", got.RepoCommit, old)
 	}
 }

--- a/internal/anchor/anchor.go
+++ b/internal/anchor/anchor.go
@@ -1,0 +1,181 @@
+// Package anchor parses and rewrites "anchored" fenced code blocks — blocks
+// whose info string names the repository file the excerpt was taken from:
+//
+//	```go path=internal/serve/renderer.go lines=264-286
+//	…
+//	```
+//
+// An anchor is the durable link between a sentence of prose and the code it
+// describes. `lathe drift` reads those links back out of a stored part and asks
+// git whether the code still looks the way the guide says it does.
+//
+// The package is deliberately pure text in, text out: no git, no filesystem, no
+// goldmark. Rewrite runs as a renderer preprocess step alongside
+// preprocessCallouts/preprocessMermaid, because putting `path=` on the info
+// string and letting it reach goldmark-highlighting would collide with that
+// extension's own info-string attribute parsing.
+package anchor
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Anchor is one anchored code block: the repo-relative file it came from, the
+// 1-indexed line range it covers (zero when the block declared no lines=), the
+// fence language, and the block body verbatim.
+type Anchor struct {
+	Path  string
+	Start int
+	End   int
+	Lang  string
+	Body  string
+}
+
+// HasRange reports whether the anchor declared a lines= range. A path-only
+// anchor can only ever be ok, renamed, or broken — there is no range to move.
+func (a Anchor) HasRange() bool {
+	return a.Start > 0 && a.End >= a.Start
+}
+
+// Label is the human-facing "path:line" header text for the anchor.
+func (a Anchor) Label() string {
+	switch {
+	case !a.HasRange():
+		return a.Path
+	case a.Start == a.End:
+		return fmt.Sprintf("%s:%d", a.Path, a.Start)
+	default:
+		return fmt.Sprintf("%s:%d-%d", a.Path, a.Start, a.End)
+	}
+}
+
+// fencedBlock matches a fenced code block, capturing its indentation (group 1),
+// info string (group 2), and body (group 3). Up to three leading spaces of
+// indentation are allowed per CommonMark, mirroring mermaidBlock/calloutBlock in
+// internal/serve/renderer.go. Every fenced block matches; the `path=` filter
+// lives in parseInfo so a plain block is still consumed here (and therefore can
+// never be mis-paired with a later anchored block's closing fence).
+var fencedBlock = regexp.MustCompile("(?ms)^([ \t]{0,3})```([^\r\n`]*)\r?\n(.*?)\r?\n[ \t]{0,3}```[ \t]*$")
+
+// Parse returns every anchored block in src, in document order. Blocks with no
+// `path=` in their info string are not anchors and are skipped.
+func Parse(src []byte) []Anchor {
+	var out []Anchor
+	for _, m := range fencedBlock.FindAllSubmatch(src, -1) {
+		a, ok := parseInfo(string(m[2]))
+		if !ok {
+			continue
+		}
+		a.Body = string(dedent(m[3], len(m[1])))
+		out = append(out, a)
+	}
+	return out
+}
+
+// dedent strips up to n leading spaces/tabs from each line, undoing the
+// indentation a fence's own opening line carried. CommonMark says the content of
+// an indented fence is dedented by the fence's indentation; Rewrite re-emits the
+// body inside a zero-indent fence, so without this every line of an indented
+// anchored block would render with that indentation baked in.
+func dedent(body []byte, n int) []byte {
+	if n == 0 {
+		return body
+	}
+	lines := bytes.Split(body, []byte("\n"))
+	for i, line := range lines {
+		trimmed := 0
+		for trimmed < n && trimmed < len(line) && (line[trimmed] == ' ' || line[trimmed] == '\t') {
+			trimmed++
+		}
+		lines[i] = line[trimmed:]
+	}
+	return bytes.Join(lines, []byte("\n"))
+}
+
+// Rewrite replaces every anchored block with a raw-HTML container carrying the
+// anchor metadata as data attributes plus a visible path:line header, wrapping a
+// plain ```<lang> fence so goldmark-highlighting still highlights the body. The
+// container and the fence are blank-line separated so CommonMark's
+// HTML-block-type-6 rules re-enable markdown rendering inside the div.
+//
+// A block with no `path=` is returned byte-for-byte unchanged.
+func Rewrite(src []byte) []byte {
+	return fencedBlock.ReplaceAllFunc(src, func(match []byte) []byte {
+		sub := fencedBlock.FindSubmatch(match)
+		if len(sub) < 4 {
+			return match
+		}
+		a, ok := parseInfo(string(sub[2]))
+		if !ok {
+			return match
+		}
+		body := dedent(sub[3], len(sub[1]))
+
+		var b bytes.Buffer
+		b.WriteString("\n<div class=\"anchor\" data-path=\"")
+		b.WriteString(html.EscapeString(a.Path))
+		b.WriteString("\"")
+		if a.HasRange() {
+			fmt.Fprintf(&b, " data-lines=\"%d-%d\"", a.Start, a.End)
+		}
+		b.WriteString(">\n<p class=\"anchor-path\">")
+		b.WriteString(html.EscapeString(a.Label()))
+		b.WriteString("</p>\n\n```")
+		b.WriteString(a.Lang)
+		b.WriteByte('\n')
+		b.Write(body)
+		if !bytes.HasSuffix(body, []byte("\n")) {
+			b.WriteByte('\n')
+		}
+		b.WriteString("```\n\n</div>\n\n")
+		return b.Bytes()
+	})
+}
+
+// parseInfo pulls the anchor out of a fence info string. The shape is
+// "<lang> path=<repo-relative-path> [lines=<start>[-<end>]]"; a leading bare
+// word is the language. A malformed lines= value degrades to a path-only anchor
+// rather than dropping the anchor entirely — the file link is still useful, and
+// silently discarding it would hide the block from drift checking.
+func parseInfo(info string) (Anchor, bool) {
+	var a Anchor
+	for i, f := range strings.Fields(info) {
+		switch {
+		case i == 0 && !strings.Contains(f, "="):
+			a.Lang = f
+		case strings.HasPrefix(f, "path="):
+			a.Path = strings.TrimPrefix(f, "path=")
+		case strings.HasPrefix(f, "lines="):
+			if start, end, ok := parseLines(strings.TrimPrefix(f, "lines=")); ok {
+				a.Start, a.End = start, end
+			}
+		}
+	}
+	if a.Path == "" {
+		return Anchor{}, false
+	}
+	return a, true
+}
+
+// parseLines accepts "12" (a single line) or "12-30" (an inclusive range).
+// Anything else — non-numeric, zero or negative, or reversed — is rejected.
+func parseLines(raw string) (start, end int, ok bool) {
+	lo, hi, hasRange := strings.Cut(raw, "-")
+	start, err := strconv.Atoi(lo)
+	if err != nil || start < 1 {
+		return 0, 0, false
+	}
+	if !hasRange {
+		return start, start, true
+	}
+	end, err = strconv.Atoi(hi)
+	if err != nil || end < start {
+		return 0, 0, false
+	}
+	return start, end, true
+}

--- a/internal/anchor/anchor_test.go
+++ b/internal/anchor/anchor_test.go
@@ -1,0 +1,200 @@
+package anchor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []Anchor
+	}{
+		{
+			name: "path and lines",
+			src:  "```go path=internal/serve/renderer.go lines=264-286\nfunc preprocessCallouts() {}\n```\n",
+			want: []Anchor{{Path: "internal/serve/renderer.go", Start: 264, End: 286, Lang: "go", Body: "func preprocessCallouts() {}"}},
+		},
+		{
+			name: "path only",
+			src:  "```go path=cmd/store.go\nvar storeCmd = 1\n```\n",
+			want: []Anchor{{Path: "cmd/store.go", Lang: "go", Body: "var storeCmd = 1"}},
+		},
+		{
+			name: "single line range",
+			src:  "```go path=cmd/store.go lines=12\nvar withVerify bool\n```\n",
+			want: []Anchor{{Path: "cmd/store.go", Start: 12, End: 12, Lang: "go", Body: "var withVerify bool"}},
+		},
+		{
+			name: "malformed lines falls back to path only",
+			src:  "```go path=cmd/store.go lines=abc\nvar withVerify bool\n```\n",
+			want: []Anchor{{Path: "cmd/store.go", Lang: "go", Body: "var withVerify bool"}},
+		},
+		{
+			name: "reversed range falls back to path only",
+			src:  "```go path=cmd/store.go lines=30-10\nvar withVerify bool\n```\n",
+			want: []Anchor{{Path: "cmd/store.go", Lang: "go", Body: "var withVerify bool"}},
+		},
+		{
+			name: "zero start falls back to path only",
+			src:  "```go path=cmd/store.go lines=0-10\nvar withVerify bool\n```\n",
+			want: []Anchor{{Path: "cmd/store.go", Lang: "go", Body: "var withVerify bool"}},
+		},
+		{
+			name: "no lang",
+			src:  "``` path=Makefile lines=3-4\nall:\n\tgo build\n```\n",
+			want: []Anchor{{Path: "Makefile", Start: 3, End: 4, Body: "all:\n\tgo build"}},
+		},
+		{
+			name: "plain fence yields no anchor",
+			src:  "```go\nfmt.Println(\"hi\")\n```\n",
+			want: nil,
+		},
+		{
+			name: "multiple blocks, only anchored ones counted",
+			src: "```go\nplain()\n```\n\ntext\n\n```go path=a.go lines=1-2\nanchored()\n```\n\n" +
+				"```sh path=b.sh\nrun\n```\n",
+			want: []Anchor{
+				{Path: "a.go", Start: 1, End: 2, Lang: "go", Body: "anchored()"},
+				{Path: "b.sh", Lang: "sh", Body: "run"},
+			},
+		},
+		{
+			name: "four-space indented fence is not an anchor",
+			src:  "text\n\n    ```go path=a.go lines=1-2\n    nope()\n    ```\n",
+			want: nil,
+		},
+		{
+			// CommonMark dedents an indented fence's content by the fence's own
+			// indentation. Rewrite re-emits the body in a zero-indent fence, so
+			// the body must arrive already dedented or the rendered block gains
+			// leading whitespace on every line.
+			name: "three-space indented fence is an anchor, dedented",
+			src:  "   ```go path=a.go lines=1-2\n   yes()\n     nested()\n   ```\n",
+			want: []Anchor{{Path: "a.go", Start: 1, End: 2, Lang: "go", Body: "yes()\n  nested()"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse([]byte(tt.src))
+			if len(got) != len(tt.want) {
+				t.Fatalf("Parse() returned %d anchors, want %d: %#v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("anchor %d = %#v, want %#v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRewritePreservesPlainBlocks(t *testing.T) {
+	tests := []string{
+		"```go\nfmt.Println(\"hi\")\n```\n",
+		"Some prose.\n\n```\nno lang here\n```\n\nMore prose.\n",
+		"```bash\ncurl -sSfL https://example.com | sh\n```\n",
+		"text with no code at all\n",
+		"    ```go path=a.go\n    indented\n    ```\n",
+	}
+	for _, src := range tests {
+		got := string(Rewrite([]byte(src)))
+		if got != src {
+			t.Errorf("Rewrite() modified a plain block.\n got: %q\nwant: %q", got, src)
+		}
+	}
+}
+
+func TestRewriteAnchoredBlock(t *testing.T) {
+	src := "```go path=internal/serve/renderer.go lines=264-266\nfunc preprocessCallouts() {}\n```\n"
+	got := string(Rewrite([]byte(src)))
+
+	for _, want := range []string{
+		`<div class="anchor"`,
+		`data-path="internal/serve/renderer.go"`,
+		`data-lines="264-266"`,
+		`<p class="anchor-path">internal/serve/renderer.go:264-266</p>`,
+		"```go\nfunc preprocessCallouts() {}\n```",
+		"</div>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Rewrite() output missing %q\ngot:\n%s", want, got)
+		}
+	}
+	// The fence must be blank-line separated from the surrounding raw HTML so
+	// CommonMark HTML-block-type-6 re-enables markdown inside the div.
+	if !strings.Contains(got, "</p>\n\n```go") {
+		t.Errorf("Rewrite() must leave a blank line before the fence\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, "```\n\n</div>") {
+		t.Errorf("Rewrite() must leave a blank line after the fence\ngot:\n%s", got)
+	}
+	// The info string must not leak the path= attribute to goldmark-highlighting.
+	if strings.Contains(got, "```go path=") {
+		t.Errorf("Rewrite() leaked path= onto the fence info string\ngot:\n%s", got)
+	}
+}
+
+func TestRewritePathOnlyBlock(t *testing.T) {
+	src := "```go path=cmd/store.go\nvar x = 1\n```\n"
+	got := string(Rewrite([]byte(src)))
+
+	if strings.Contains(got, "data-lines") {
+		t.Errorf("path-only anchor must emit no data-lines attribute\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `<p class="anchor-path">cmd/store.go</p>`) {
+		t.Errorf("path-only anchor header should be the bare path\ngot:\n%s", got)
+	}
+}
+
+func TestRewriteEscapesPath(t *testing.T) {
+	src := "```go path=a\"<b>.go lines=1-2\nx()\n```\n"
+	got := string(Rewrite([]byte(src)))
+	if strings.Contains(got, `<b>`) {
+		t.Errorf("Rewrite() must HTML-escape the path\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, "&lt;b&gt;") {
+		t.Errorf("Rewrite() should escape angle brackets in the path\ngot:\n%s", got)
+	}
+}
+
+func TestParseSingleLineHeader(t *testing.T) {
+	got := string(Rewrite([]byte("```go path=a.go lines=7\nx()\n```\n")))
+	if !strings.Contains(got, `<p class="anchor-path">a.go:7</p>`) {
+		t.Errorf("single-line anchor header should be path:line\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `data-lines="7-7"`) {
+		t.Errorf("single-line anchor should record a normalized range\ngot:\n%s", got)
+	}
+}
+
+func TestRewriteDedentsIndentedFence(t *testing.T) {
+	// An anchored fence nested in a list item must not render its body with the
+	// list indentation baked into every line.
+	src := "- item\n\n   ```go path=a.go lines=1-2\n   func x() {}\n   ```\n"
+	got := string(Rewrite([]byte(src)))
+	if !strings.Contains(got, "```go\nfunc x() {}\n```") {
+		t.Errorf("indented fence body was not dedented, got:\n%s", got)
+	}
+}
+
+func TestDedentStopsAtContentAndHandlesShortLines(t *testing.T) {
+	tests := []struct {
+		body string
+		n    int
+		want string
+	}{
+		{"   a\n   b", 3, "a\nb"},
+		{" a\n   b", 3, "a\nb"},       // less indentation than the fence: strip what's there
+		{"   a\n\n   b", 3, "a\n\nb"}, // a blank line has nothing to strip
+		{"\ta\n\tb", 1, "a\nb"},       // tabs count as one indentation char each
+		{"xy\nzw", 3, "xy\nzw"},       // never eats non-whitespace
+	}
+	for _, tt := range tests {
+		if got := string(dedent([]byte(tt.body), tt.n)); got != tt.want {
+			t.Errorf("dedent(%q, %d) = %q, want %q", tt.body, tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -1,0 +1,279 @@
+// Package drift answers one question about an onboarding guide: does it still
+// describe the code?
+//
+// It diffs the commit the guide was pinned to against HEAD and classifies every
+// anchored code excerpt (see internal/anchor) as ok, moved, changed, renamed, or
+// broken. This is a pure git computation — no model is involved anywhere — which
+// is why it can live in the Go binary without crossing the "skills generate
+// content, the CLI owns durable state" boundary.
+//
+// The design bias throughout is against false positives: a guide wrongly marked
+// stale destroys trust faster than no drift check at all. Anything genuinely
+// unknowable (a pinned commit that is not in the repo, an orphaned history)
+// returns an error so callers can report "unknown" and leave status alone,
+// rather than guessing.
+package drift
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/devenjarvis/lathe/internal/anchor"
+	"github.com/devenjarvis/lathe/internal/gitrepo"
+)
+
+// Verdict is the classification of a single anchor.
+type Verdict string
+
+const (
+	// VerdictOK — the anchored range is byte-identical and in the same place.
+	VerdictOK Verdict = "ok"
+	// VerdictMoved — the range is intact but sits at a different line number.
+	VerdictMoved Verdict = "moved"
+	// VerdictChanged — a diff hunk overlaps the anchored range.
+	VerdictChanged Verdict = "changed"
+	// VerdictRenamed — the file moved; the anchored range itself is intact.
+	VerdictRenamed Verdict = "renamed"
+	// VerdictBroken — the file is gone at HEAD, or was never at the pin.
+	VerdictBroken Verdict = "broken"
+)
+
+var (
+	// ErrUnknownPin means the pinned commit is not in this repository — a
+	// shallow clone, a rebased branch, or a GC'd commit. Drift is unknowable.
+	ErrUnknownPin = errors.New("pinned commit is not present in this repository")
+	// ErrNoCommonHistory means the pinned commit exists but shares no ancestor
+	// with HEAD, so a diff between them says nothing about drift.
+	ErrNoCommonHistory = errors.New("pinned commit shares no history with HEAD")
+)
+
+// AnchorResult is the verdict for one anchored excerpt. Path/Start/End are as
+// the guide wrote them; NewPath and CurrentStart are where that code lives at
+// HEAD. CurrentStart is 0 for a path-only anchor (nothing to map) and for a
+// broken one (nowhere to map to).
+type AnchorResult struct {
+	Part         string  `json:"part,omitempty"`
+	Path         string  `json:"path"`
+	NewPath      string  `json:"new_path,omitempty"`
+	Start        int     `json:"start,omitempty"`
+	End          int     `json:"end,omitempty"`
+	CurrentStart int     `json:"current_start,omitempty"`
+	Verdict      Verdict `json:"verdict"`
+	// Detail carries the reason a broken anchor is broken, for the CLI and the
+	// warning panel. Empty for every other verdict.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Part pairs a part filename with the anchors parsed out of it, so results can
+// name the part a reader needs to look at.
+type Part struct {
+	Name    string
+	Anchors []anchor.Anchor
+}
+
+// Result is a whole drift run, persisted verbatim as the drift.json sidecar.
+type Result struct {
+	PinnedCommit string          `json:"pinned_commit"`
+	HeadCommit   string          `json:"head_commit"`
+	CheckedAt    string          `json:"checked_at"`
+	Dirty        bool            `json:"dirty,omitempty"`
+	Anchors      []AnchorResult  `json:"anchors"`
+	Summary      map[Verdict]int `json:"summary"`
+}
+
+// Stale reports whether this result should flip the tutorial to stale. Only
+// changed and broken count: a moved or renamed anchor still describes the code
+// correctly, it just lives somewhere else.
+func (r *Result) Stale() bool {
+	return r.Summary[VerdictChanged] > 0 || r.Summary[VerdictBroken] > 0
+}
+
+// StalePartsList returns the parts containing at least one changed or broken
+// anchor, in first-seen order — what the reading page's warning panel names.
+func (r *Result) StalePartsList() []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, a := range r.Anchors {
+		if a.Verdict != VerdictChanged && a.Verdict != VerdictBroken {
+			continue
+		}
+		if a.Part == "" || seen[a.Part] {
+			continue
+		}
+		seen[a.Part] = true
+		out = append(out, a.Part)
+	}
+	return out
+}
+
+// Check classifies a flat list of anchors with no part attribution. It is the
+// convenience form of CheckParts.
+func Check(repo *gitrepo.Repo, pinned string, anchors []anchor.Anchor) (Result, error) {
+	return CheckParts(repo, pinned, []Part{{Anchors: anchors}})
+}
+
+// CheckParts classifies every anchor in every part against the diff from pinned
+// to HEAD.
+func CheckParts(repo *gitrepo.Repo, pinned string, parts []Part) (Result, error) {
+	if !repo.HasCommit(pinned) {
+		return Result{}, fmt.Errorf("%w: %s", ErrUnknownPin, pinned)
+	}
+	head, err := repo.HeadSHA()
+	if err != nil {
+		return Result{}, err
+	}
+	if _, err := repo.MergeBase(pinned, head); err != nil {
+		return Result{}, fmt.Errorf("%w: %s", ErrNoCommonHistory, pinned)
+	}
+	dirty, err := repo.IsDirty()
+	if err != nil {
+		return Result{}, err
+	}
+
+	res := Result{
+		PinnedCommit: pinned,
+		HeadCommit:   head,
+		CheckedAt:    time.Now().UTC().Format(time.RFC3339),
+		Dirty:        dirty,
+		Summary:      map[Verdict]int{},
+	}
+
+	// One FileDiff per distinct path, not per anchor — a part typically quotes
+	// the same file several times.
+	diffs := map[string]gitrepo.FileDiff{}
+	diffErrs := map[string]error{}
+
+	for _, part := range parts {
+		for _, a := range part.Anchors {
+			if _, done := diffs[a.Path]; !done {
+				if _, failed := diffErrs[a.Path]; !failed {
+					fd, err := repo.FileDiff(pinned, a.Path)
+					if err != nil {
+						if !errors.Is(err, gitrepo.ErrPathNotAtCommit) {
+							return Result{}, err
+						}
+						diffErrs[a.Path] = err
+					} else {
+						diffs[a.Path] = fd
+					}
+				}
+			}
+			ar := AnchorResult{Part: part.Name, Path: a.Path, Start: a.Start, End: a.End}
+			if err, failed := diffErrs[a.Path]; failed {
+				ar.Verdict = VerdictBroken
+				ar.Detail = fmt.Sprintf("no such file at the pinned commit (%v)", err)
+			} else {
+				classify(&ar, a, diffs[a.Path])
+			}
+			res.Anchors = append(res.Anchors, ar)
+			res.Summary[ar.Verdict]++
+		}
+	}
+	return res, nil
+}
+
+// classify turns one file's diff into a verdict for one anchor.
+func classify(ar *AnchorResult, a anchor.Anchor, fd gitrepo.FileDiff) {
+	if fd.Status == gitrepo.FileDeleted {
+		ar.Verdict = VerdictBroken
+		ar.Detail = "file deleted at HEAD"
+		return
+	}
+	if fd.NewPath != "" && fd.NewPath != a.Path {
+		ar.NewPath = fd.NewPath
+	}
+
+	// A path-only anchor names a file, not a range. It can only be ok, renamed,
+	// or broken — there is nothing to move or overlap.
+	if !a.HasRange() {
+		if fd.Status == gitrepo.FileRenamed {
+			ar.Verdict = VerdictRenamed
+		} else {
+			ar.Verdict = VerdictOK
+		}
+		return
+	}
+
+	if rangeTouched(a.Start, a.End, fd.Hunks) {
+		ar.Verdict = VerdictChanged
+		ar.CurrentStart, _ = MapLine(a.Start, fd.Hunks)
+		return
+	}
+
+	current, _ := MapLine(a.Start, fd.Hunks)
+	ar.CurrentStart = current
+	switch {
+	case fd.Status == gitrepo.FileRenamed:
+		ar.Verdict = VerdictRenamed
+	case current != a.Start:
+		ar.Verdict = VerdictMoved
+	default:
+		ar.Verdict = VerdictOK
+	}
+}
+
+// MapLine maps a 1-indexed line number from the pinned commit to its line number
+// at HEAD, and reports whether the line itself falls inside a changed hunk.
+//
+// The arithmetic that matters: a hunk with OldCount == 0 is a pure *insertion*
+// after old line OldStart (git writes OldStart == 0 for an insertion before the
+// first line). It has no width on the old side, so it can never contain a line —
+// treating it as a zero-width range that intersects would misreport every nearby
+// insertion as a change. It only shifts lines strictly below the insertion
+// point.
+func MapLine(old int, hunks []gitrepo.Hunk) (newLine int, touched bool) {
+	offset := 0
+	for _, h := range hunks {
+		if h.OldCount == 0 {
+			// Pure insertion after old line h.OldStart.
+			if old > h.OldStart {
+				offset += h.NewCount
+			}
+			continue
+		}
+		oldEnd := h.OldStart + h.OldCount - 1
+		switch {
+		case old > oldEnd:
+			offset += h.NewCount - h.OldCount
+		case old >= h.OldStart:
+			touched = true
+		}
+	}
+	return old + offset, touched
+}
+
+// rangeTouched reports whether any hunk overlaps the inclusive old-line range
+// [start, end]. Pure insertions (OldCount == 0) never overlap — see MapLine.
+func rangeTouched(start, end int, hunks []gitrepo.Hunk) bool {
+	for _, h := range hunks {
+		if h.OldCount == 0 {
+			continue
+		}
+		oldEnd := h.OldStart + h.OldCount - 1
+		if h.OldStart <= end && oldEnd >= start {
+			return true
+		}
+	}
+	return false
+}
+
+// Verdicts is the display order for summary output — worst first, so a reader
+// scanning a terminal or a warning panel sees the problems before the noise.
+var Verdicts = []Verdict{VerdictBroken, VerdictChanged, VerdictRenamed, VerdictMoved, VerdictOK}
+
+// SummaryLine renders the verdict counts in Verdicts order, e.g.
+// "12 ok, 2 moved, 1 changed". Verdicts with a zero count are omitted.
+func (r *Result) SummaryLine() string {
+	var parts []string
+	for _, v := range Verdicts {
+		if n := r.Summary[v]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, v))
+		}
+	}
+	if len(parts) == 0 {
+		return "no anchors"
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -1,0 +1,448 @@
+package drift
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/lathe/internal/anchor"
+	"github.com/devenjarvis/lathe/internal/gitrepo"
+)
+
+func TestMapLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		old       int
+		hunks     []gitrepo.Hunk
+		wantLine  int
+		wantTouch bool
+	}{
+		{
+			name:     "no hunks",
+			old:      10,
+			hunks:    nil,
+			wantLine: 10,
+		},
+		{
+			// The pure-insertion case named in the plan's risks: OldCount == 0 is
+			// an insertion *after* old line OldStart, never an overlap.
+			name:     "insertion at top of file shifts everything down",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 0, OldCount: 0, NewStart: 1, NewCount: 2}},
+			wantLine: 12,
+		},
+		{
+			name:     "insertion strictly before the line",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 4, OldCount: 0, NewStart: 5, NewCount: 3}},
+			wantLine: 13,
+		},
+		{
+			name:     "insertion after the line does not shift it",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 50, OldCount: 0, NewStart: 51, NewCount: 3}},
+			wantLine: 10,
+		},
+		{
+			// "after old line 10" is below line 10, so line 10 itself is unmoved
+			// and untouched.
+			name:     "insertion immediately after the line",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 10, OldCount: 0, NewStart: 11, NewCount: 4}},
+			wantLine: 10,
+		},
+		{
+			name:      "modification on exactly the line",
+			old:       10,
+			hunks:     []gitrepo.Hunk{{OldStart: 10, OldCount: 1, NewStart: 10, NewCount: 1}},
+			wantLine:  10,
+			wantTouch: true,
+		},
+		{
+			name:      "modification spanning the line",
+			old:       10,
+			hunks:     []gitrepo.Hunk{{OldStart: 5, OldCount: 20, NewStart: 5, NewCount: 20}},
+			wantLine:  10,
+			wantTouch: true,
+		},
+		{
+			name:      "modification ending on the line",
+			old:       10,
+			hunks:     []gitrepo.Hunk{{OldStart: 8, OldCount: 3, NewStart: 8, NewCount: 3}},
+			wantLine:  10,
+			wantTouch: true,
+		},
+		{
+			name:     "modification entirely before, net growth",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 1, OldCount: 2, NewStart: 1, NewCount: 5}},
+			wantLine: 13,
+		},
+		{
+			name:     "deletion entirely before",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 1, OldCount: 3, NewStart: 0, NewCount: 0}},
+			wantLine: 7,
+		},
+		{
+			name:     "modification entirely after has no effect",
+			old:      10,
+			hunks:    []gitrepo.Hunk{{OldStart: 40, OldCount: 3, NewStart: 40, NewCount: 9}},
+			wantLine: 10,
+		},
+		{
+			name: "offsets accumulate across hunks",
+			old:  100,
+			hunks: []gitrepo.Hunk{
+				{OldStart: 0, OldCount: 0, NewStart: 1, NewCount: 2},   // +2
+				{OldStart: 10, OldCount: 5, NewStart: 12, NewCount: 1}, // -4
+				{OldStart: 90, OldCount: 0, NewStart: 89, NewCount: 7}, // +7
+			},
+			wantLine: 105,
+		},
+		{
+			name: "touched wins even when other hunks shift",
+			old:  20,
+			hunks: []gitrepo.Hunk{
+				{OldStart: 0, OldCount: 0, NewStart: 1, NewCount: 3},
+				{OldStart: 19, OldCount: 4, NewStart: 22, NewCount: 4},
+			},
+			wantLine:  23,
+			wantTouch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line, touched := MapLine(tt.old, tt.hunks)
+			if line != tt.wantLine {
+				t.Errorf("MapLine() line = %d, want %d", line, tt.wantLine)
+			}
+			if touched != tt.wantTouch {
+				t.Errorf("MapLine() touched = %v, want %v", touched, tt.wantTouch)
+			}
+		})
+	}
+}
+
+func TestRangeTouched(t *testing.T) {
+	tests := []struct {
+		name  string
+		s, e  int
+		hunks []gitrepo.Hunk
+		want  bool
+	}{
+		{"hunk on first line", 10, 20, []gitrepo.Hunk{{OldStart: 10, OldCount: 1, NewStart: 10, NewCount: 1}}, true},
+		{"hunk on last line", 10, 20, []gitrepo.Hunk{{OldStart: 20, OldCount: 1, NewStart: 20, NewCount: 1}}, true},
+		{"hunk containing the range", 10, 20, []gitrepo.Hunk{{OldStart: 1, OldCount: 100, NewStart: 1, NewCount: 100}}, true},
+		{"hunk just above", 10, 20, []gitrepo.Hunk{{OldStart: 8, OldCount: 2, NewStart: 8, NewCount: 2}}, false},
+		{"hunk just below", 10, 20, []gitrepo.Hunk{{OldStart: 21, OldCount: 1, NewStart: 21, NewCount: 1}}, false},
+		{"insertion inside the range is not a touch", 10, 20, []gitrepo.Hunk{{OldStart: 15, OldCount: 0, NewStart: 16, NewCount: 3}}, false},
+		{"insertion above the range is not a touch", 10, 20, []gitrepo.Hunk{{OldStart: 5, OldCount: 0, NewStart: 6, NewCount: 3}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rangeTouched(tt.s, tt.e, tt.hunks); got != tt.want {
+				t.Errorf("rangeTouched(%d,%d) = %v, want %v", tt.s, tt.e, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- integration against real git repos ---
+
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	git(t, dir, "init", "-b", "main")
+	git(t, dir, "config", "user.email", "test@example.com")
+	git(t, dir, "config", "user.name", "Test")
+	git(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func commitAll(t *testing.T, dir, msg string) string {
+	t.Helper()
+	git(t, dir, "add", "-A")
+	git(t, dir, "commit", "-m", msg)
+	return git(t, dir, "rev-parse", "HEAD")
+}
+
+const twelveLines = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve\n"
+
+func setup(t *testing.T) (*gitrepo.Repo, string, string) {
+	t.Helper()
+	dir := newTestRepo(t)
+	write(t, dir, "src/app.go", twelveLines)
+	sha := commitAll(t, dir, "init")
+	r, err := gitrepo.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, dir, sha
+}
+
+func anchors(a ...anchor.Anchor) []anchor.Anchor { return a }
+
+func ranged(path string, start, end int) anchor.Anchor {
+	return anchor.Anchor{Path: path, Start: start, End: end, Lang: "go"}
+}
+
+func TestCheckClean(t *testing.T) {
+	r, _, sha := setup(t)
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Anchors) != 1 || res.Anchors[0].Verdict != VerdictOK {
+		t.Fatalf("Anchors = %#v, want one ok", res.Anchors)
+	}
+	if res.Anchors[0].CurrentStart != 4 {
+		t.Errorf("CurrentStart = %d, want 4", res.Anchors[0].CurrentStart)
+	}
+	if res.Stale() {
+		t.Error("a clean check must not be stale")
+	}
+	if res.Summary[VerdictOK] != 1 {
+		t.Errorf("Summary = %#v", res.Summary)
+	}
+	if res.PinnedCommit != sha {
+		t.Errorf("PinnedCommit = %q, want %q", res.PinnedCommit, sha)
+	}
+	if res.HeadCommit != sha {
+		t.Errorf("HeadCommit = %q, want %q", res.HeadCommit, sha)
+	}
+	if res.CheckedAt == "" {
+		t.Error("CheckedAt should be set")
+	}
+}
+
+func TestCheckMovedNotChanged(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", "header\nheader\n"+twelveLines)
+	commitAll(t, dir, "insert two lines above")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.Anchors[0]
+	if got.Verdict != VerdictMoved {
+		t.Fatalf("Verdict = %q, want moved", got.Verdict)
+	}
+	if got.CurrentStart != 6 {
+		t.Errorf("CurrentStart = %d, want 6", got.CurrentStart)
+	}
+	if res.Stale() {
+		t.Error("a moved anchor must not make the guide stale")
+	}
+}
+
+func TestCheckChangedInsideRange(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", strings.Replace(twelveLines, "five\n", "FIVE CHANGED\n", 1))
+	commitAll(t, dir, "edit line 5")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Anchors[0].Verdict != VerdictChanged {
+		t.Fatalf("Verdict = %q, want changed", res.Anchors[0].Verdict)
+	}
+	if !res.Stale() {
+		t.Error("a changed anchor must make the guide stale")
+	}
+}
+
+func TestCheckChangeOutsideRangeIsClean(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", strings.Replace(twelveLines, "twelve\n", "TWELVE CHANGED\n", 1))
+	commitAll(t, dir, "edit the last line")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Anchors[0].Verdict != VerdictOK {
+		t.Errorf("Verdict = %q, want ok (the edit is below the anchored range)", res.Anchors[0].Verdict)
+	}
+}
+
+func TestCheckBroken(t *testing.T) {
+	r, dir, sha := setup(t)
+	git(t, dir, "rm", "src/app.go")
+	write(t, dir, "other.txt", "so the tree is not empty\n")
+	commitAll(t, dir, "delete app.go")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Anchors[0].Verdict != VerdictBroken {
+		t.Fatalf("Verdict = %q, want broken", res.Anchors[0].Verdict)
+	}
+	if !res.Stale() {
+		t.Error("a broken anchor must make the guide stale")
+	}
+}
+
+func TestCheckRenamed(t *testing.T) {
+	r, dir, sha := setup(t)
+	if err := os.MkdirAll(filepath.Join(dir, "internal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, dir, "mv", "src/app.go", "internal/app.go")
+	commitAll(t, dir, "move app.go")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.Anchors[0]
+	if got.Verdict != VerdictRenamed {
+		t.Fatalf("Verdict = %q, want renamed", got.Verdict)
+	}
+	if got.NewPath != "internal/app.go" {
+		t.Errorf("NewPath = %q, want internal/app.go", got.NewPath)
+	}
+	if res.Stale() {
+		t.Error("a renamed anchor must not make the guide stale")
+	}
+}
+
+func TestCheckRenamedAndEditedIsChanged(t *testing.T) {
+	r, dir, sha := setup(t)
+	git(t, dir, "mv", "src/app.go", "src/renamed.go")
+	write(t, dir, "src/renamed.go", strings.Replace(twelveLines, "five\n", "FIVE CHANGED\n", 1))
+	commitAll(t, dir, "move and edit")
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.Anchors[0]
+	if got.Verdict != VerdictChanged {
+		t.Fatalf("Verdict = %q, want changed", got.Verdict)
+	}
+	if got.NewPath != "src/renamed.go" {
+		t.Errorf("NewPath = %q, want src/renamed.go", got.NewPath)
+	}
+}
+
+func TestCheckPathOnlyAnchor(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", strings.Replace(twelveLines, "five\n", "FIVE CHANGED\n", 1))
+	commitAll(t, dir, "edit line 5")
+
+	res, err := Check(r, sha, anchors(anchor.Anchor{Path: "src/app.go", Lang: "go"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Anchors[0].Verdict != VerdictOK {
+		t.Errorf("Verdict = %q, want ok — a path-only anchor has no range to drift", res.Anchors[0].Verdict)
+	}
+}
+
+func TestCheckAnchorPathAbsentAtPinIsBroken(t *testing.T) {
+	r, _, sha := setup(t)
+	res, err := Check(r, sha, anchors(ranged("does/not/exist.go", 1, 3)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Anchors[0].Verdict != VerdictBroken {
+		t.Errorf("Verdict = %q, want broken for an anchor path that never existed", res.Anchors[0].Verdict)
+	}
+}
+
+func TestCheckUnknownPin(t *testing.T) {
+	r, _, _ := setup(t)
+	_, err := Check(r, "0000000000000000000000000000000000000000", anchors(ranged("src/app.go", 1, 2)))
+	if !errors.Is(err, ErrUnknownPin) {
+		t.Fatalf("err = %v, want ErrUnknownPin", err)
+	}
+}
+
+func TestCheckNoCommonHistory(t *testing.T) {
+	r, dir, sha := setup(t)
+	git(t, dir, "checkout", "--orphan", "fresh")
+	git(t, dir, "rm", "-rf", ".")
+	write(t, dir, "unrelated.txt", "nothing in common\n")
+	commitAll(t, dir, "orphan root")
+
+	_, err := Check(r, sha, anchors(ranged("src/app.go", 1, 2)))
+	if !errors.Is(err, ErrNoCommonHistory) {
+		t.Fatalf("err = %v, want ErrNoCommonHistory", err)
+	}
+}
+
+func TestCheckPartsAttributesAnchorsToParts(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", strings.Replace(twelveLines, "five\n", "FIVE CHANGED\n", 1))
+	commitAll(t, dir, "edit line 5")
+
+	res, err := CheckParts(r, sha, []Part{
+		{Name: "part-01.md", Anchors: anchors(ranged("src/app.go", 1, 2))},
+		{Name: "part-02.md", Anchors: anchors(ranged("src/app.go", 4, 6))},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Anchors) != 2 {
+		t.Fatalf("Anchors = %#v, want 2", res.Anchors)
+	}
+	if res.Anchors[0].Part != "part-01.md" || res.Anchors[0].Verdict != VerdictOK {
+		t.Errorf("first anchor = %#v", res.Anchors[0])
+	}
+	if res.Anchors[1].Part != "part-02.md" || res.Anchors[1].Verdict != VerdictChanged {
+		t.Errorf("second anchor = %#v", res.Anchors[1])
+	}
+	if res.Summary[VerdictOK] != 1 || res.Summary[VerdictChanged] != 1 {
+		t.Errorf("Summary = %#v", res.Summary)
+	}
+	if got := res.StalePartsList(); len(got) != 1 || got[0] != "part-02.md" {
+		t.Errorf("StalePartsList() = %#v, want [part-02.md]", got)
+	}
+}
+
+func TestCheckRecordsDirtyTree(t *testing.T) {
+	r, dir, sha := setup(t)
+	write(t, dir, "src/app.go", "uncommitted\n"+twelveLines)
+
+	res, err := Check(r, sha, anchors(ranged("src/app.go", 4, 6)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Dirty {
+		t.Error("Dirty should be true when the working tree has uncommitted changes")
+	}
+	// Drift is computed against HEAD, so the uncommitted edit must not register.
+	if res.Anchors[0].Verdict != VerdictOK {
+		t.Errorf("Verdict = %q, want ok — uncommitted work is not drift", res.Anchors[0].Verdict)
+	}
+}

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -1,0 +1,317 @@
+// Package gitrepo is a thin, dependency-free wrapper over the `git` binary.
+//
+// It knows nothing about anchors, tutorials, or ~/.lathe — it answers plain git
+// questions: what is origin, what is HEAD, does this commit exist, and how did a
+// single file change between a commit and HEAD. Everything is shelled out via
+// os/exec rather than a git library, keeping go.mod as small as it already is.
+package gitrepo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// ErrPathNotAtCommit is returned by FileDiff when the requested path does not
+// exist at the pinned commit. That is an authoring error (the anchor names a
+// file the guide's own pin never contained), not drift, so callers surface it
+// distinctly rather than reporting the file as deleted.
+var ErrPathNotAtCommit = errors.New("path does not exist at the given commit")
+
+// FileStatus is how a single file changed between the pinned commit and HEAD.
+type FileStatus string
+
+const (
+	FileUnchanged FileStatus = "unchanged"
+	FileModified  FileStatus = "modified"
+	FileDeleted   FileStatus = "deleted"
+	FileRenamed   FileStatus = "renamed"
+)
+
+// Hunk is one `@@ -OldStart,OldCount +NewStart,NewCount @@` header from a
+// --unified=0 diff. OldCount == 0 means a pure insertion *after* old line
+// OldStart (git writes OldStart == 0 for an insertion before the first line);
+// NewCount == 0 means a pure deletion.
+type Hunk struct {
+	OldStart int
+	OldCount int
+	NewStart int
+	NewCount int
+}
+
+// FileDiff is the change to one file between a pinned commit and HEAD. NewPath
+// is the file's path at HEAD (equal to the requested path unless it was
+// renamed); Hunks is empty for an unchanged file, a deleted file, and a pure
+// rename.
+type FileDiff struct {
+	Status  FileStatus
+	NewPath string
+	Hunks   []Hunk
+}
+
+// Repo is an opened git working tree, identified by its toplevel directory.
+type Repo struct {
+	dir string
+
+	// nameStatus caches the whole-tree name-status diff per pinned commit.
+	// Rename detection needs to see the full change set, so it cannot be run
+	// per-file with a pathspec; caching keeps one `git diff` per drift run
+	// rather than one per anchored file.
+	mu         sync.Mutex
+	nameStatus map[string]map[string]changedFile
+}
+
+type changedFile struct {
+	status  FileStatus
+	newPath string
+}
+
+// Open resolves dir to the toplevel of the git working tree containing it.
+func Open(dir string) (*Repo, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, fmt.Errorf("git binary not found in PATH: %w", err)
+	}
+	out, err := runGit(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, fmt.Errorf("%s is not inside a git repository: %w", dir, err)
+	}
+	return &Repo{dir: out, nameStatus: map[string]map[string]changedFile{}}, nil
+}
+
+// Dir returns the toplevel directory of the working tree.
+func (r *Repo) Dir() string { return r.dir }
+
+// OriginURL returns the URL of the "origin" remote. It errors when the repo has
+// no origin — callers treat that as "cannot match this repo to a tutorial".
+func (r *Repo) OriginURL() (string, error) {
+	out, err := runGit(r.dir, "remote", "get-url", "origin")
+	if err != nil {
+		return "", fmt.Errorf("read origin remote: %w", err)
+	}
+	return out, nil
+}
+
+// HeadSHA returns the full SHA of HEAD.
+func (r *Repo) HeadSHA() (string, error) {
+	out, err := runGit(r.dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolve HEAD: %w", err)
+	}
+	return out, nil
+}
+
+// HasCommit reports whether sha names a commit object present in this repo. It
+// is the guard against reporting false drift in a shallow clone, after a
+// rebase, or after a GC dropped the pinned commit.
+func (r *Repo) HasCommit(sha string) bool {
+	if strings.TrimSpace(sha) == "" {
+		return false
+	}
+	_, err := runGit(r.dir, "cat-file", "-e", sha+"^{commit}")
+	return err == nil
+}
+
+// IsDirty reports whether the working tree has uncommitted changes. Drift is
+// computed against HEAD, so a dirty tree means the answer describes committed
+// state only — recorded on the result so the UI can say so.
+func (r *Repo) IsDirty() (bool, error) {
+	out, err := runGit(r.dir, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("read working tree status: %w", err)
+	}
+	return out != "", nil
+}
+
+// MergeBase returns the best common ancestor of a and b. It errors when the two
+// commits share no history (an orphan branch, an unrelated repo), which is the
+// other case where drift is unknowable rather than clean or stale.
+func (r *Repo) MergeBase(a, b string) (string, error) {
+	out, err := runGit(r.dir, "merge-base", a, b)
+	if err != nil {
+		return "", fmt.Errorf("no common ancestor between %s and %s: %w", a, b, err)
+	}
+	return out, nil
+}
+
+// FileDiff describes how path (as it existed at fromSHA) changed by HEAD.
+func (r *Repo) FileDiff(fromSHA, path string) (FileDiff, error) {
+	if _, err := runGit(r.dir, "cat-file", "-e", fromSHA+":"+path); err != nil {
+		return FileDiff{}, fmt.Errorf("%q at %s: %w", path, shortSHA(fromSHA), ErrPathNotAtCommit)
+	}
+
+	changed, err := r.changedFiles(fromSHA)
+	if err != nil {
+		return FileDiff{}, err
+	}
+
+	entry, ok := changed[path]
+	if !ok {
+		// Absent from the change set means the file is byte-identical at HEAD.
+		return FileDiff{Status: FileUnchanged, NewPath: path}, nil
+	}
+	if entry.status == FileDeleted {
+		return FileDiff{Status: FileDeleted}, nil
+	}
+
+	newPath := entry.newPath
+	if newPath == "" {
+		newPath = path
+	}
+	hunks, err := r.blobHunks(fromSHA, path, newPath)
+	if err != nil {
+		return FileDiff{}, err
+	}
+	return FileDiff{Status: entry.status, NewPath: newPath, Hunks: hunks}, nil
+}
+
+// changedFiles returns the whole-tree name-status diff from fromSHA to HEAD,
+// keyed by the path as it existed at fromSHA. Rename detection runs over the
+// full change set (a pathspec-limited diff can only see the delete half of a
+// rename), so this is computed once per pinned commit and cached.
+func (r *Repo) changedFiles(fromSHA string) (map[string]changedFile, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cached, ok := r.nameStatus[fromSHA]; ok {
+		return cached, nil
+	}
+	// -z keeps paths raw (git otherwise C-quotes anything non-ASCII or with
+	// spaces), so no unquoting step is needed.
+	//
+	// --find-renames uses git's own similarity heuristic at its default 50%
+	// threshold, deliberately un-tuned. A file that moved *and* was edited past
+	// recognition scores below it and comes back as delete+add, which classifies
+	// as `broken` rather than `renamed` — the honest answer, since an excerpt
+	// whose file changed that much is genuinely stale. Lowering the threshold
+	// would trade that for the worse failure: confidently mapping an anchored
+	// range into a file that only vaguely resembles the original.
+	out, err := runGit(r.dir, "diff", "--name-status", "--find-renames", "-z", fromSHA, "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("diff %s..HEAD: %w", shortSHA(fromSHA), err)
+	}
+	changed := parseNameStatus(out)
+	r.nameStatus[fromSHA] = changed
+	return changed, nil
+}
+
+// parseNameStatus decodes NUL-separated `git diff --name-status -z` output.
+// Every record is a status token followed by one path, except renames and
+// copies (R/C), which are followed by the old path and then the new path.
+func parseNameStatus(out string) map[string]changedFile {
+	changed := map[string]changedFile{}
+	fields := strings.Split(out, "\x00")
+	for i := 0; i < len(fields); {
+		code := fields[i]
+		if code == "" {
+			i++
+			continue
+		}
+		switch code[0] {
+		case 'R', 'C':
+			if i+2 >= len(fields) {
+				return changed
+			}
+			changed[fields[i+1]] = changedFile{status: FileRenamed, newPath: fields[i+2]}
+			i += 3
+		case 'D':
+			if i+1 >= len(fields) {
+				return changed
+			}
+			changed[fields[i+1]] = changedFile{status: FileDeleted}
+			i += 2
+		default: // A, M, T, U, X and friends all read as "content differs"
+			if i+1 >= len(fields) {
+				return changed
+			}
+			changed[fields[i+1]] = changedFile{status: FileModified}
+			i += 2
+		}
+	}
+	return changed
+}
+
+// blobHunks diffs the two blobs directly (rev:path form) rather than diffing
+// the commits with a pathspec, so a renamed file's old and new contents are
+// compared even though their paths differ.
+func (r *Repo) blobHunks(fromSHA, oldPath, newPath string) ([]Hunk, error) {
+	out, err := runGit(r.dir, "diff", "--unified=0", fromSHA+":"+oldPath, "HEAD:"+newPath)
+	if err != nil {
+		return nil, fmt.Errorf("diff %s:%s..HEAD:%s: %w", shortSHA(fromSHA), oldPath, newPath, err)
+	}
+	var hunks []Hunk
+	for _, line := range strings.Split(out, "\n") {
+		if h, ok := parseHunkHeader(line); ok {
+			hunks = append(hunks, h)
+		}
+	}
+	return hunks, nil
+}
+
+// parseHunkHeader decodes "@@ -a[,b] +c[,d] @@ [context]". An omitted count
+// means 1, per the unified diff format.
+func parseHunkHeader(line string) (Hunk, bool) {
+	if !strings.HasPrefix(line, "@@ ") {
+		return Hunk{}, false
+	}
+	rest := line[len("@@ "):]
+	end := strings.Index(rest, " @@")
+	if end == -1 {
+		return Hunk{}, false
+	}
+	parts := strings.Fields(rest[:end])
+	if len(parts) != 2 || !strings.HasPrefix(parts[0], "-") || !strings.HasPrefix(parts[1], "+") {
+		return Hunk{}, false
+	}
+	oldStart, oldCount, ok := parseRange(parts[0][1:])
+	if !ok {
+		return Hunk{}, false
+	}
+	newStart, newCount, ok := parseRange(parts[1][1:])
+	if !ok {
+		return Hunk{}, false
+	}
+	return Hunk{OldStart: oldStart, OldCount: oldCount, NewStart: newStart, NewCount: newCount}, true
+}
+
+func parseRange(s string) (start, count int, ok bool) {
+	startStr, countStr, hasCount := strings.Cut(s, ",")
+	start, err := strconv.Atoi(startStr)
+	if err != nil || start < 0 {
+		return 0, 0, false
+	}
+	if !hasCount {
+		return start, 1, true
+	}
+	count, err = strconv.Atoi(countStr)
+	if err != nil || count < 0 {
+		return 0, 0, false
+	}
+	return start, count, true
+}
+
+// runGit executes git in dir and returns trimmed stdout. Stderr is folded into
+// the error so a caller's message names the actual git complaint.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%w: %s", err, msg)
+	}
+	return strings.TrimRight(stdout.String(), "\n"), nil
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/internal/gitrepo/gitrepo_test.go
+++ b/internal/gitrepo/gitrepo_test.go
@@ -1,0 +1,405 @@
+package gitrepo
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestRepo builds a throwaway git repo in t.TempDir() with deterministic
+// identity and no dependence on the developer's global git config.
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	git(t, dir, "init", "-b", "main")
+	git(t, dir, "config", "user.email", "test@example.com")
+	git(t, dir, "config", "user.name", "Test")
+	git(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z",
+		"GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func lines(n int) string {
+	var b strings.Builder
+	for i := 1; i <= n; i++ {
+		b.WriteString("line ")
+		b.WriteString(string(rune('0' + i%10)))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func commitAll(t *testing.T, dir, msg string) string {
+	t.Helper()
+	git(t, dir, "add", "-A")
+	git(t, dir, "commit", "-m", msg)
+	return git(t, dir, "rev-parse", "HEAD")
+}
+
+func TestOpenRejectsNonRepo(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Open(dir); err == nil {
+		t.Fatal("Open() on a non-git dir should error")
+	}
+}
+
+func TestOpenResolvesToToplevel(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "sub/file.txt", "hi\n")
+	commitAll(t, dir, "init")
+
+	r, err := Open(filepath.Join(dir, "sub"))
+	if err != nil {
+		t.Fatalf("Open(subdir): %v", err)
+	}
+	// macOS temp dirs are symlinked (/var -> /private/var), so compare resolved paths.
+	want, _ := filepath.EvalSymlinks(dir)
+	got, _ := filepath.EvalSymlinks(r.Dir())
+	if got != want {
+		t.Errorf("Dir() = %q, want the toplevel %q", got, want)
+	}
+}
+
+func TestOriginURLAndHeadSHA(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	sha := commitAll(t, dir, "init")
+	git(t, dir, "remote", "add", "origin", "git@github.com:devenjarvis/lathe.git")
+
+	r, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origin, err := r.OriginURL()
+	if err != nil {
+		t.Fatalf("OriginURL: %v", err)
+	}
+	if origin != "git@github.com:devenjarvis/lathe.git" {
+		t.Errorf("OriginURL() = %q", origin)
+	}
+	head, err := r.HeadSHA()
+	if err != nil {
+		t.Fatalf("HeadSHA: %v", err)
+	}
+	if head != sha {
+		t.Errorf("HeadSHA() = %q, want %q", head, sha)
+	}
+}
+
+func TestOriginURLMissingRemote(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	commitAll(t, dir, "init")
+	r, _ := Open(dir)
+	if _, err := r.OriginURL(); err == nil {
+		t.Fatal("OriginURL() with no origin should error")
+	}
+}
+
+func TestHasCommit(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	sha := commitAll(t, dir, "init")
+	r, _ := Open(dir)
+
+	if !r.HasCommit(sha) {
+		t.Error("HasCommit(HEAD) = false")
+	}
+	if r.HasCommit("0000000000000000000000000000000000000000") {
+		t.Error("HasCommit(bogus) = true")
+	}
+	if r.HasCommit("") {
+		t.Error("HasCommit(\"\") = true")
+	}
+}
+
+func TestIsDirty(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	commitAll(t, dir, "init")
+	r, _ := Open(dir)
+
+	dirty, err := r.IsDirty()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirty {
+		t.Error("IsDirty() = true on a clean tree")
+	}
+
+	write(t, dir, "a.txt", "changed\n")
+	dirty, err = r.IsDirty()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dirty {
+		t.Error("IsDirty() = false after modifying a tracked file")
+	}
+}
+
+func TestMergeBase(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	base := commitAll(t, dir, "init")
+	write(t, dir, "b.txt", "there\n")
+	commitAll(t, dir, "second")
+
+	r, _ := Open(dir)
+	got, err := r.MergeBase(base, "HEAD")
+	if err != nil {
+		t.Fatalf("MergeBase: %v", err)
+	}
+	if got != base {
+		t.Errorf("MergeBase = %q, want %q", got, base)
+	}
+
+	// An orphan branch shares no history — the pinned commit still exists, but
+	// there is nothing to diff against meaningfully.
+	git(t, dir, "checkout", "--orphan", "fresh")
+	git(t, dir, "rm", "-rf", ".")
+	write(t, dir, "c.txt", "unrelated\n")
+	commitAll(t, dir, "orphan root")
+	if _, err := r.MergeBase(base, "HEAD"); err == nil {
+		t.Error("MergeBase across unrelated histories should error")
+	}
+}
+
+func TestFileDiffUnchanged(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", lines(10))
+	sha := commitAll(t, dir, "init")
+	write(t, dir, "b.txt", "other\n")
+	commitAll(t, dir, "unrelated change")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Status != FileUnchanged {
+		t.Errorf("Status = %q, want unchanged", fd.Status)
+	}
+	if len(fd.Hunks) != 0 {
+		t.Errorf("Hunks = %#v, want none", fd.Hunks)
+	}
+	if fd.NewPath != "a.txt" {
+		t.Errorf("NewPath = %q, want a.txt", fd.NewPath)
+	}
+}
+
+func TestFileDiffInsertionAbove(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", lines(10))
+	sha := commitAll(t, dir, "init")
+	write(t, dir, "a.txt", "new 1\nnew 2\n"+lines(10))
+	commitAll(t, dir, "insert two lines at the top")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Status != FileModified {
+		t.Fatalf("Status = %q, want modified", fd.Status)
+	}
+	if len(fd.Hunks) != 1 {
+		t.Fatalf("Hunks = %#v, want 1", fd.Hunks)
+	}
+	h := fd.Hunks[0]
+	// A pure insertion carries OldCount == 0 — this is the arithmetic the whole
+	// drift classifier hangs on, so pin the exact numbers.
+	if h.OldCount != 0 {
+		t.Errorf("OldCount = %d, want 0 for a pure insertion", h.OldCount)
+	}
+	if h.OldStart != 0 {
+		t.Errorf("OldStart = %d, want 0 (insertion before old line 1)", h.OldStart)
+	}
+	if h.NewStart != 1 || h.NewCount != 2 {
+		t.Errorf("new side = %d,%d want 1,2", h.NewStart, h.NewCount)
+	}
+}
+
+func TestFileDiffInsertionMidFile(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "a\nb\nc\nd\n")
+	sha := commitAll(t, dir, "init")
+	write(t, dir, "a.txt", "a\nb\nINSERTED\nc\nd\n")
+	commitAll(t, dir, "insert after line 2")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fd.Hunks) != 1 {
+		t.Fatalf("Hunks = %#v, want 1", fd.Hunks)
+	}
+	h := fd.Hunks[0]
+	if h.OldStart != 2 || h.OldCount != 0 {
+		t.Errorf("old side = %d,%d want 2,0 (insertion after old line 2)", h.OldStart, h.OldCount)
+	}
+	if h.NewStart != 3 || h.NewCount != 1 {
+		t.Errorf("new side = %d,%d want 3,1", h.NewStart, h.NewCount)
+	}
+}
+
+func TestFileDiffModificationInside(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "a\nb\nc\nd\ne\n")
+	sha := commitAll(t, dir, "init")
+	write(t, dir, "a.txt", "a\nb\nCHANGED\nd\ne\n")
+	commitAll(t, dir, "change line 3")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fd.Hunks) != 1 {
+		t.Fatalf("Hunks = %#v, want 1", fd.Hunks)
+	}
+	h := fd.Hunks[0]
+	if h.OldStart != 3 || h.OldCount != 1 || h.NewStart != 3 || h.NewCount != 1 {
+		t.Errorf("hunk = %#v, want -3,1 +3,1", h)
+	}
+}
+
+func TestFileDiffDeletion(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", lines(5))
+	write(t, dir, "keep.txt", "keep\n")
+	sha := commitAll(t, dir, "init")
+	git(t, dir, "rm", "a.txt")
+	commitAll(t, dir, "delete a.txt")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Status != FileDeleted {
+		t.Errorf("Status = %q, want deleted", fd.Status)
+	}
+}
+
+func TestFileDiffRename(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", lines(20))
+	sha := commitAll(t, dir, "init")
+	if err := os.MkdirAll(filepath.Join(dir, "moved"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, dir, "mv", "a.txt", "moved/b.txt")
+	commitAll(t, dir, "move a.txt")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Status != FileRenamed {
+		t.Fatalf("Status = %q, want renamed", fd.Status)
+	}
+	if fd.NewPath != "moved/b.txt" {
+		t.Errorf("NewPath = %q, want moved/b.txt", fd.NewPath)
+	}
+	if len(fd.Hunks) != 0 {
+		t.Errorf("a pure rename should have no hunks, got %#v", fd.Hunks)
+	}
+}
+
+func TestFileDiffRenameWithEdit(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n")
+	sha := commitAll(t, dir, "init")
+	git(t, dir, "mv", "a.txt", "b.txt")
+	write(t, dir, "b.txt", "a\nb\nCHANGED\nd\ne\nf\ng\nh\ni\nj\nk\nl\n")
+	commitAll(t, dir, "move and edit")
+
+	r, _ := Open(dir)
+	fd, err := r.FileDiff(sha, "a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fd.Status != FileRenamed {
+		t.Fatalf("Status = %q, want renamed", fd.Status)
+	}
+	if fd.NewPath != "b.txt" {
+		t.Errorf("NewPath = %q, want b.txt", fd.NewPath)
+	}
+	if len(fd.Hunks) != 1 {
+		t.Fatalf("Hunks = %#v, want 1", fd.Hunks)
+	}
+	if fd.Hunks[0].OldStart != 3 {
+		t.Errorf("hunk = %#v, want old start 3", fd.Hunks[0])
+	}
+}
+
+func TestFileDiffPathMissingAtPin(t *testing.T) {
+	dir := newTestRepo(t)
+	write(t, dir, "a.txt", "hi\n")
+	sha := commitAll(t, dir, "init")
+	write(t, dir, "later.txt", "added later\n")
+	commitAll(t, dir, "add later.txt")
+
+	r, _ := Open(dir)
+	if _, err := r.FileDiff(sha, "later.txt"); err == nil {
+		t.Fatal("FileDiff on a path absent at the pinned commit should error")
+	}
+	if _, err := r.FileDiff(sha, "never-existed.txt"); err == nil {
+		t.Fatal("FileDiff on a nonexistent path should error")
+	}
+}
+
+func TestParseHunkHeader(t *testing.T) {
+	tests := []struct {
+		line string
+		want Hunk
+		ok   bool
+	}{
+		{"@@ -0,0 +1,2 @@", Hunk{OldStart: 0, OldCount: 0, NewStart: 1, NewCount: 2}, true},
+		{"@@ -3 +3 @@", Hunk{OldStart: 3, OldCount: 1, NewStart: 3, NewCount: 1}, true},
+		{"@@ -10,5 +10,0 @@", Hunk{OldStart: 10, OldCount: 5, NewStart: 10, NewCount: 0}, true},
+		{"@@ -1,2 +3,4 @@ func foo() {", Hunk{OldStart: 1, OldCount: 2, NewStart: 3, NewCount: 4}, true},
+		{"not a hunk", Hunk{}, false},
+		{"@@ bad @@", Hunk{}, false},
+	}
+	for _, tt := range tests {
+		got, ok := parseHunkHeader(tt.line)
+		if ok != tt.ok {
+			t.Errorf("parseHunkHeader(%q) ok = %v, want %v", tt.line, ok, tt.ok)
+			continue
+		}
+		if ok && got != tt.want {
+			t.Errorf("parseHunkHeader(%q) = %#v, want %#v", tt.line, got, tt.want)
+		}
+	}
+}

--- a/internal/serve/renderer.go
+++ b/internal/serve/renderer.go
@@ -10,6 +10,7 @@ import (
 
 	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
 	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/devenjarvis/lathe/internal/anchor"
 	"github.com/gohugoio/hugo-goldmark-extensions/passthrough"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
@@ -68,7 +69,12 @@ func RenderMarkdown(src []byte) ([]byte, error) {
 // headings for the in-page TOC. parser.WithAutoHeadingID assigns each heading
 // a stable id slug; the same slug is captured here for anchor links.
 func RenderMarkdownWithTOC(src []byte) ([]byte, []TOCEntry, error) {
+	// Callouts first, so a fenced block nested in a callout body is un-quoted
+	// and visible to the anchor rewriter. Anchors before mermaid is arbitrary —
+	// a mermaid block carries no path=, so anchor.Rewrite passes it through
+	// untouched.
 	src = preprocessCallouts(src)
+	src = anchor.Rewrite(src)
 	src = preprocessMermaid(src)
 	md := goldmark.New(
 		goldmark.WithExtensions(

--- a/internal/serve/renderer_test.go
+++ b/internal/serve/renderer_test.go
@@ -433,3 +433,98 @@ func TestRenderExerciseHeadingDetection(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderAnchoredCodeBlock(t *testing.T) {
+	src := []byte("Here is the router.\n\n```go path=internal/serve/server.go lines=76-80\nmux.HandleFunc(\"GET /{slug}/\", s.handleTutorial)\n```\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("serve.RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+
+	for _, want := range []string{
+		`class="anchor"`,
+		`data-path="internal/serve/server.go"`,
+		`data-lines="76-80"`,
+		`class="anchor-path"`,
+		"internal/serve/server.go:76-80",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("anchored block output missing %q, got:\n%s", want, html)
+		}
+	}
+	// The body must still be highlighted — the whole point of rewriting to a
+	// plain fence inside the container rather than putting path= on the info
+	// string where goldmark-highlighting would choke on it.
+	if !strings.Contains(html, `class="chroma"`) {
+		t.Errorf("anchored block lost chroma highlighting, got:\n%s", html)
+	}
+	// The info string itself must not survive into the markup — only the data
+	// attributes we emit deliberately.
+	if strings.Contains(html, "go path=") || strings.Contains(html, "lines=76-80") {
+		t.Errorf("the fence info string leaked into the rendered output, got:\n%s", html)
+	}
+}
+
+func TestRenderPlainCodeBlockUnaffectedByAnchors(t *testing.T) {
+	src := []byte("```go\nfmt.Println(\"hi\")\n```\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("serve.RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if strings.Contains(html, "anchor") {
+		t.Errorf("a plain fenced block must not become an anchor, got:\n%s", html)
+	}
+	if !strings.Contains(html, `class="chroma"`) {
+		t.Errorf("plain fenced block lost chroma highlighting, got:\n%s", html)
+	}
+}
+
+func TestRenderAnchoredBlockInsideCallout(t *testing.T) {
+	src := []byte("> [!NOTE]\n> Look at this:\n>\n> ```go path=cmd/root.go lines=10-12\n> var rootCmd = 1\n> ```\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("serve.RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, `class="callout callout-note"`) {
+		t.Errorf("callout wrapper missing, got:\n%s", html)
+	}
+	if !strings.Contains(html, `data-path="cmd/root.go"`) {
+		t.Errorf("anchor inside a callout body was not rewritten, got:\n%s", html)
+	}
+	if !strings.Contains(html, `class="chroma"`) {
+		t.Errorf("anchor inside a callout lost highlighting, got:\n%s", html)
+	}
+}
+
+func TestRenderAnchoredBlockWithoutLines(t *testing.T) {
+	src := []byte("```go path=cmd/root.go\nvar rootCmd = 1\n```\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("serve.RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if strings.Contains(html, "data-lines") {
+		t.Errorf("a path-only anchor must emit no data-lines, got:\n%s", html)
+	}
+	if !strings.Contains(html, "cmd/root.go</p>") {
+		t.Errorf("path-only anchor header should be the bare path, got:\n%s", html)
+	}
+}
+
+func TestRenderMermaidStillWorksAlongsideAnchors(t *testing.T) {
+	src := []byte("```mermaid\ngraph TD;\n  A-->B;\n```\n\n```go path=a.go lines=1-2\nx()\n```\n")
+	out, err := serve.RenderMarkdown(src)
+	if err != nil {
+		t.Fatalf("serve.RenderMarkdown() error = %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, `<div class="mermaid">`) {
+		t.Errorf("mermaid block lost its wrapper, got:\n%s", html)
+	}
+	if !strings.Contains(html, `data-path="a.go"`) {
+		t.Errorf("anchored block after a mermaid block was not rewritten, got:\n%s", html)
+	}
+}

--- a/internal/serve/styles.css
+++ b/internal/serve/styles.css
@@ -44,6 +44,9 @@
   --callout-recall-bg:#F7E7D6; --callout-recall-border:#D17A3F; --callout-recall-label:#A0501F;
   --callout-unverified-bg:#F6E2DA; --callout-unverified-border:#C2603C; --callout-unverified-label:#8A3417;
 
+  /* Anchored code excerpts (light) — the path:line header above a repo excerpt */
+  --anchor-border:#D6C9B4; --anchor-label:#6B5F53;
+
   /* Type */
   --font-display:'Fraunces','Iowan Old Style',Georgia,serif;
   --font-body:'Newsreader','Iowan Old Style',Charter,Georgia,serif;
@@ -84,6 +87,8 @@
   --callout-predict-bg:#2A1E26; --callout-predict-border:#9A6076; --callout-predict-label:#D6A6BC;
   --callout-recall-bg:#2C1E12; --callout-recall-border:#BE7038; --callout-recall-label:#E0A36A;
   --callout-unverified-bg:#2E1810; --callout-unverified-border:#C2603C; --callout-unverified-label:#EC9272;
+
+  --anchor-border:#3D3429; --anchor-label:#9C8F7C;
 
   --shadow-sm:0 1px 2px rgba(0,0,0,.30);
   --shadow-md:0 4px 14px rgba(0,0,0,.45);
@@ -194,6 +199,14 @@ pre[data-overflow="true"]{box-shadow:inset -18px 0 14px -12px rgba(40,30,20,.20)
 .callout-recall .callout-label{color:var(--callout-recall-label)}
 .callout-unverified{background:var(--callout-unverified-bg);border-color:var(--callout-unverified-border)}
 .callout-unverified .callout-label{color:var(--callout-unverified-label)}
+
+/* Anchored code excerpts. An anchor ties a quoted block to a real file in the
+   repo an onboarding guide describes; the header is a copyable path:line and the
+   data-path/data-lines attributes are what `lathe drift` reports against. The
+   container is deliberately quiet — it must not out-shout the code inside it. */
+.anchor{margin:1.4rem 0}
+.anchor pre{margin-top:0;border-top-left-radius:0;border-top-right-radius:0}
+.anchor-path{font-family:var(--font-mono);font-size:.72rem;color:var(--anchor-label);background:var(--surface-sunken);border:1px solid var(--anchor-border);border-bottom:none;border-radius:var(--radius-md) var(--radius-md) 0 0;padding:.35rem .75rem;margin:0;overflow-wrap:anywhere;user-select:all}
 
 /* Mermaid diagrams */
 .mermaid{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:1rem;margin:1.4rem 0;text-align:center;overflow-x:auto;max-width:100%}

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -2,10 +2,13 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/devenjarvis/lathe/internal/drift"
 )
 
 type Status string
@@ -17,7 +20,37 @@ const (
 	StatusFailed     Status = "failed"
 	StatusSkipped    Status = "skipped"
 	StatusExtending  Status = "extending"
+	// StatusStale is set by `lathe drift` on an onboarding guide whose anchored
+	// excerpts no longer match the repository at HEAD. It is not a failure — the
+	// guide was true when written — so it clears back to unverified as soon as a
+	// later drift run comes back clean.
+	StatusStale Status = "stale"
 )
+
+// Kind distinguishes a topic tutorial (the original and default shape) from an
+// onboarding guide written against a specific git repository at a pinned commit.
+// The zero value is deliberately meaningful: every metadata.json written before
+// onboarding guides existed has no "kind" key and reads as KindTutorial.
+type Kind string
+
+const (
+	KindTutorial   Kind = "tutorial"
+	KindOnboarding Kind = "onboarding"
+)
+
+// NormalizeKind canonicalizes a --kind flag value. Empty means "tutorial", the
+// default shape; anything outside the enum is rejected rather than silently
+// stored, because Kind gates the verification path a guide gets.
+func NormalizeKind(raw string) (Kind, error) {
+	switch k := Kind(strings.ToLower(strings.TrimSpace(raw))); k {
+	case "", KindTutorial:
+		return KindTutorial, nil
+	case KindOnboarding:
+		return KindOnboarding, nil
+	default:
+		return "", fmt.Errorf("invalid kind %q (want tutorial or onboarding)", raw)
+	}
+}
 
 type Tutorial struct {
 	Slug        string    `json:"slug"`
@@ -41,6 +74,21 @@ type Tutorial struct {
 	// meaningful when Repo is set).
 	Repo       string `json:"repo,omitempty"`
 	RepoBranch string `json:"repo_branch,omitempty"`
+	// Kind is "onboarding" for a guide to an existing codebase and "" (read as
+	// "tutorial") for everything else. Empty is the back-compat default, so every
+	// metadata.json written before this field existed keeps working untouched.
+	Kind Kind `json:"kind,omitempty"`
+	// RepoCommit is the SHA the guide's anchored excerpts were written against —
+	// the pin `lathe drift` diffs HEAD back to. Required for onboarding guides
+	// and meaningless without one. It has exactly two writers: `lathe store`
+	// (initial) and `lathe verify-result --repo-commit` (re-pin after a
+	// confirming re-verify). Nothing else may re-pin.
+	RepoCommit string `json:"repo_commit,omitempty"`
+	// RepoPath is where the repository was checked out on the authoring machine.
+	// It is a *hint* only — a copied ~/.lathe or a re-cloned repo makes it wrong
+	// — so drift resolution prefers an explicit --repo-path and then the cwd
+	// whose origin matches Repo, falling back to this last.
+	RepoPath string `json:"repo_path,omitempty"`
 	// Tools are the languages/tools and their versions the tutorial is rooted in,
 	// captured up front so an old tutorial (e.g. written against an outdated
 	// toolchain) is identifiable later. Surfaced as version chips and a dedicated
@@ -90,6 +138,22 @@ type Progress struct {
 
 func (t *Tutorial) IsSeries() bool {
 	return len(t.Parts) > 1
+}
+
+// EffectiveKind resolves the stored Kind, treating the empty value written by
+// every pre-feature metadata.json as KindTutorial.
+func (t *Tutorial) EffectiveKind() Kind {
+	if t.Kind == "" {
+		return KindTutorial
+	}
+	return t.Kind
+}
+
+// IsOnboarding reports whether this is a repo onboarding guide — the guides that
+// are verified by drift-checking their anchors rather than by following them in
+// a scratch dir.
+func (t *Tutorial) IsOnboarding() bool {
+	return t.EffectiveKind() == KindOnboarding
 }
 
 // RepoDisplay returns the short, human-facing form of the repo (the last two
@@ -183,6 +247,25 @@ func WriteExercisePart(tutorialDir, part string, checked []int) error {
 		delete(state, part)
 	}
 	return writeJSONFile(filepath.Join(tutorialDir, "exercises.json"), state)
+}
+
+// ReadDrift returns the last recorded drift check for a tutorial. Like
+// verify-result.json it is a sidecar read best-effort at the point of use, and
+// is deliberately NOT surfaced as a json:"-" field on Tutorial — a
+// ReadMetadata→mutate→WriteMetadata round-trip must never be able to snapshot it
+// into metadata.json. A missing drift.json returns an unwrapped os.ErrNotExist
+// so callers can distinguish "never checked" from "unreadable".
+func ReadDrift(tutorialDir string) (*drift.Result, error) {
+	var r drift.Result
+	if err := readJSONFile(filepath.Join(tutorialDir, "drift.json"), &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// WriteDrift persists a drift check as the drift.json sidecar.
+func WriteDrift(tutorialDir string, r *drift.Result) error {
+	return writeJSONFile(filepath.Join(tutorialDir, "drift.json"), r)
 }
 
 func ReadVerifyResult(tutorialDir string) (*VerifyResult, error) {

--- a/internal/store/metadata_test.go
+++ b/internal/store/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devenjarvis/lathe/internal/drift"
 	"github.com/devenjarvis/lathe/internal/store"
 )
 
@@ -632,5 +633,112 @@ func TestReadExercisesCorruptFileErrors(t *testing.T) {
 	}
 	if _, err := store.ReadExercises(dir); err == nil {
 		t.Error("ReadExercises on corrupt file = nil error, want error")
+	}
+}
+
+func TestMetadataWithNoKindReadsAsTutorial(t *testing.T) {
+	// The back-compat guarantee for every tutorial already in the library: a
+	// metadata.json written before onboarding guides existed has no "kind" key
+	// and must keep reading as a plain tutorial.
+	dir := t.TempDir()
+	raw := `{"slug":"old","title":"Old","topic":"old","created":"2026-05-03T00:00:00Z","status":"verified"}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadMetadata() error = %v", err)
+	}
+	if got.Kind != "" {
+		t.Errorf("Kind = %q, want empty", got.Kind)
+	}
+	if got.EffectiveKind() != store.KindTutorial {
+		t.Errorf("EffectiveKind() = %q, want %q", got.EffectiveKind(), store.KindTutorial)
+	}
+	if got.IsOnboarding() {
+		t.Error("IsOnboarding() = true for a pre-feature tutorial")
+	}
+}
+
+func TestMetadataRoundTripOnboardingFields(t *testing.T) {
+	dir := t.TempDir()
+	original := &store.Tutorial{
+		Slug:       "lathe-onboarding",
+		Kind:       store.KindOnboarding,
+		Repo:       "github.com/devenjarvis/lathe",
+		RepoBranch: "main",
+		RepoCommit: "1e7c9f6aaaabbbbccccddddeeeeffff0000111122",
+		RepoPath:   "/Users/x/Code/lathe",
+	}
+	if err := store.WriteMetadata(dir, original); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.ReadMetadata(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsOnboarding() {
+		t.Error("IsOnboarding() = false")
+	}
+	if got.RepoCommit != original.RepoCommit {
+		t.Errorf("RepoCommit = %q, want %q", got.RepoCommit, original.RepoCommit)
+	}
+	if got.RepoPath != original.RepoPath {
+		t.Errorf("RepoPath = %q, want %q", got.RepoPath, original.RepoPath)
+	}
+}
+
+func TestOnboardingFieldsStayOmittedForPlainTutorials(t *testing.T) {
+	dir := t.TempDir()
+	if err := store.WriteMetadata(dir, &store.Tutorial{Slug: "plain", Title: "Plain"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"kind", "repo_commit", "repo_path"} {
+		if strings.Contains(string(data), key) {
+			t.Errorf("metadata.json contains %q for a plain tutorial:\n%s", key, data)
+		}
+	}
+}
+
+func TestReadDriftMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := store.ReadDrift(dir)
+	if !os.IsNotExist(err) {
+		t.Fatalf("ReadDrift() on a missing file = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestWriteReadDrift(t *testing.T) {
+	dir := t.TempDir()
+	original := &drift.Result{
+		PinnedCommit: "abc123",
+		HeadCommit:   "def456",
+		CheckedAt:    "2026-07-27T00:00:00Z",
+		Anchors: []drift.AnchorResult{
+			{Part: "part-01.md", Path: "cmd/store.go", Start: 10, End: 20, CurrentStart: 12, Verdict: drift.VerdictMoved},
+			{Part: "part-01.md", Path: "cmd/gone.go", Verdict: drift.VerdictBroken},
+		},
+		Summary: map[drift.Verdict]int{drift.VerdictMoved: 1, drift.VerdictBroken: 1},
+	}
+	if err := store.WriteDrift(dir, original); err != nil {
+		t.Fatalf("WriteDrift() error = %v", err)
+	}
+	got, err := store.ReadDrift(dir)
+	if err != nil {
+		t.Fatalf("ReadDrift() error = %v", err)
+	}
+	if got.PinnedCommit != original.PinnedCommit || got.HeadCommit != original.HeadCommit {
+		t.Errorf("commits = %q/%q", got.PinnedCommit, got.HeadCommit)
+	}
+	if len(got.Anchors) != 2 || got.Anchors[0].Verdict != drift.VerdictMoved {
+		t.Errorf("Anchors = %#v", got.Anchors)
+	}
+	if !got.Stale() {
+		t.Error("Stale() = false, want true (one broken anchor)")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,7 +25,21 @@ type StoreOptions struct {
 	Tools   []Tool   // languages/tools + versions (NormalizeTools)
 	Voice   string   // writing voice the tutorial was generated in (NormalizeVoice)
 	Model   string   // LLM that authored the tutorial, a display label (NormalizeModel)
+	// Kind selects the guide shape. The zero value stores as KindTutorial.
+	Kind Kind
+	// RepoCommit is the SHA an onboarding guide's anchors are pinned to, and
+	// RepoPath is where the repo was checked out on the authoring machine. Both
+	// are required (alongside Repo) when Kind is KindOnboarding.
+	RepoCommit string
+	RepoPath   string
 }
+
+// ErrOnboardingRepoRequired is returned when an onboarding guide is stored
+// without the full repo/commit/path triple. Drift-checking is the only
+// verification an onboarding guide gets, and it is impossible without a pin, so
+// this is rejected up front rather than producing a guide that can never be
+// checked.
+var ErrOnboardingRepoRequired = errors.New("onboarding guides require --repo, --repo-commit, and --repo-path")
 
 // Store copies a tutorial directory into ~/.lathe/tutorials/ and writes its
 // metadata with status=unverified. Verification is opt-in and never auto-runs
@@ -37,6 +51,19 @@ func Store(srcPath string, opts StoreOptions) (*Tutorial, error) {
 	// namespaces the temp dir). Strip it so the prefix doesn't leak into the
 	// stored slug — and from there into the derived title.
 	slug = strings.TrimPrefix(slug, "lathe-")
+
+	kind := opts.Kind
+	if kind == "" {
+		kind = KindTutorial
+	}
+	repo := NormalizeRepo(opts.Repo)
+	repoCommit := NormalizeCommit(opts.RepoCommit)
+	repoPath := strings.TrimSpace(opts.RepoPath)
+	// Validate before any copying happens, so a rejected store leaves nothing
+	// behind in ~/.lathe/tutorials/.
+	if kind == KindOnboarding && (repo == "" || repoCommit == "" || repoPath == "") {
+		return nil, ErrOnboardingRepoRequired
+	}
 
 	tutorialsDir, err := config.TutorialsDir()
 	if err != nil {
@@ -58,11 +85,20 @@ func Store(srcPath string, opts StoreOptions) (*Tutorial, error) {
 
 	parts := detectParts(destDir)
 
-	repo := NormalizeRepo(opts.Repo)
 	branch := strings.TrimSpace(opts.Branch)
 	if repo == "" {
 		// A branch with no repo is meaningless — don't record a dangling branch.
+		// Same for the pin and the local checkout path.
 		branch = ""
+		repoCommit = ""
+		repoPath = ""
+	}
+
+	// Keep the back-compat guarantee visible: a plain tutorial writes no "kind"
+	// key at all, so its metadata.json is byte-identical to a pre-feature one.
+	storedKind := kind
+	if storedKind == KindTutorial {
+		storedKind = ""
 	}
 
 	t := &Tutorial{
@@ -73,8 +109,11 @@ func Store(srcPath string, opts StoreOptions) (*Tutorial, error) {
 		Status:     StatusUnverified,
 		Tags:       NormalizeTags(opts.Tags),
 		Parts:      parts,
+		Kind:       storedKind,
 		Repo:       repo,
 		RepoBranch: branch,
+		RepoCommit: repoCommit,
+		RepoPath:   repoPath,
 		Tools:      NormalizeTools(opts.Tools),
 		Sources:    NormalizeSources(opts.Sources),
 		Voice:      NormalizeVoice(opts.Voice),
@@ -309,6 +348,14 @@ func NormalizeVoice(voice string) string {
 // reading-page byline).
 func NormalizeModel(model string) string {
 	return strings.TrimSpace(model)
+}
+
+// NormalizeCommit canonicalizes a git SHA: trimmed and lowercased, since git
+// object names are case-insensitive hex but compare byte-wise everywhere we use
+// them. Returns "" for empty input so RepoCommit stays omitempty in
+// metadata.json.
+func NormalizeCommit(sha string) string {
+	return strings.ToLower(strings.TrimSpace(sha))
 }
 
 func SlugToTitle(slug string) string {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -483,3 +483,117 @@ func TestPromoteIndexToPartFailsCleanly(t *testing.T) {
 		t.Error("PromoteIndexToPart() on missing dir should return error")
 	}
 }
+
+func TestStoreOnboardingRequiresTheRepoTriple(t *testing.T) {
+	// An onboarding guide's whole anti-rot mechanism is the commit pin, so the
+	// repo/commit/path triple is not optional — a guide stored without it could
+	// never be drift-checked.
+	full := store.StoreOptions{
+		Kind:       store.KindOnboarding,
+		Repo:       "git@github.com:devenjarvis/lathe.git",
+		RepoCommit: "1e7c9f6aaaabbbbccccddddeeeeffff0000111122",
+		RepoPath:   "/Users/x/Code/lathe",
+	}
+	cases := []struct {
+		name   string
+		mutate func(o *store.StoreOptions)
+	}{
+		{"no repo", func(o *store.StoreOptions) { o.Repo = "" }},
+		{"no commit", func(o *store.StoreOptions) { o.RepoCommit = "" }},
+		{"no path", func(o *store.StoreOptions) { o.RepoPath = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := t.TempDir()
+			if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
+			opts := full
+			tc.mutate(&opts)
+			if _, err := store.Store(src, opts); err == nil {
+				t.Fatal("Store() should reject an onboarding guide missing part of the repo triple")
+			}
+			// Validation must happen before anything is copied.
+			if _, err := os.Stat(filepath.Join(home, ".lathe", "tutorials", filepath.Base(src))); !os.IsNotExist(err) {
+				t.Errorf("a rejected onboarding store left a tutorial dir behind: err=%v", err)
+			}
+		})
+	}
+}
+
+func TestStoreOnboardingHappyPath(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "lathe-lathe-onboarding")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	tut, err := store.Store(src, store.StoreOptions{
+		Kind:       store.KindOnboarding,
+		Repo:       "git@github.com:devenjarvis/lathe.git",
+		Branch:     "main",
+		RepoCommit: "  1E7C9F6AAAABBBBCCCCDDDDEEEEFFFF0000111122 ",
+		RepoPath:   "/Users/x/Code/lathe",
+	})
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if !tut.IsOnboarding() {
+		t.Error("IsOnboarding() = false")
+	}
+	if tut.Repo != "github.com/devenjarvis/lathe" {
+		t.Errorf("Repo = %q, want the normalized form", tut.Repo)
+	}
+	if tut.RepoCommit != "1e7c9f6aaaabbbbccccddddeeeeffff0000111122" {
+		t.Errorf("RepoCommit = %q, want trimmed and lowercased", tut.RepoCommit)
+	}
+	if tut.Status != store.StatusUnverified {
+		t.Errorf("Status = %q, want unverified", tut.Status)
+	}
+}
+
+func TestStorePlainTutorialNeedsNoRepo(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "part-01.md"), []byte("# Hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	tut, err := store.Store(src, store.StoreOptions{Kind: store.KindTutorial})
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if tut.IsOnboarding() {
+		t.Error("IsOnboarding() = true for an explicit tutorial kind")
+	}
+}
+
+func TestNormalizeKind(t *testing.T) {
+	tests := []struct {
+		in   string
+		want store.Kind
+		ok   bool
+	}{
+		{"", store.KindTutorial, true},
+		{"tutorial", store.KindTutorial, true},
+		{"  Onboarding ", store.KindOnboarding, true},
+		{"ONBOARDING", store.KindOnboarding, true},
+		{"guide", "", false},
+	}
+	for _, tt := range tests {
+		got, err := store.NormalizeKind(tt.in)
+		if (err == nil) != tt.ok {
+			t.Errorf("NormalizeKind(%q) err = %v, want ok=%v", tt.in, err, tt.ok)
+			continue
+		}
+		if tt.ok && got != tt.want {
+			t.Errorf("NormalizeKind(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## What & why

**PR 1 of 3** in the repo-onboarding stack. Ships the machinery; nothing authors content for it yet, which is fine — it is fully exercised by tests.

Onboarding guides describe an existing codebase, so "follow it in a fresh `mktemp -d`" says nothing about whether they are still true. Their analogue is **drift**: does the guide still describe the code?

A fenced block whose info string carries `path=<repo-relative-path> [lines=<start>-<end>]` becomes an **anchor** — a durable link from a sentence of prose to the code it describes. `lathe drift <slug>` diffs the guide's pinned commit against `HEAD` and classifies every anchor as `ok`, `moved`, `changed`, `renamed`, or `broken`.

Drift is a *git* computation, not a model one, so it lives entirely in Go without crossing the `AGENTS.md` boundary ("skills generate content; the CLI owns durable state"). This is the first verification signal the binary can legitimately produce by itself.

- `internal/anchor` — parse/rewrite anchored fences; pure text in, text out
- `internal/gitrepo` — `os/exec` wrapper over `git`; no new module dependency
- `internal/drift` — map line numbers through diff hunks and classify
- `internal/store` — `Kind`/`RepoCommit`/`RepoPath`, the `stale` status, the `drift.json` sidecar
- `cmd/drift.go` — repo resolution, status transitions, `--json`
- renderer — anchored blocks get a `path:line` header over a still-highlighted body

**The bias throughout is against false positives.** A pure insertion (`OldCount == 0`) is an insertion *after* a line, never an overlap, so a blank line added above an excerpt reports `moved`, not `changed`. Anything unknowable — a pinned commit absent from the repo, an orphaned history — exits non-zero as `unknown` and leaves status untouched rather than guessing. A guide wrongly marked stale destroys trust faster than no drift check at all.

Two deliberate design points worth reviewing as decisions, not oversights:

- **Re-pinning has exactly two owners**: `lathe store --repo-commit` and `lathe verify-result --repo-commit`. `extend-commit` gains no such flag.
- **Rename detection uses git's default 50% similarity threshold, un-tuned.** A file that moved *and* was edited past recognition scores below it and classifies as `broken`. Lowering the threshold would trade that for the worse failure: confidently mapping an anchored range into a file that only vaguely resembles the original. Commented at `internal/gitrepo/gitrepo.go`.

## How to test

```bash
mage check
go test ./internal/anchor/... ./internal/gitrepo/... ./internal/drift/... -race
```

End to end against any git repo:

1. Write a part with an anchored fence, `lathe store <dir> --kind onboarding --repo <origin> --repo-commit "$(git rev-parse HEAD)" --repo-path <repo>`.
2. `lathe drift <slug>` — every anchor `ok`, status unchanged.
3. Insert a blank line **above** the anchored range, commit, re-run — `moved`, status still unchanged. This is the false-positive test.
4. Edit a line **inside** the range, commit, re-run — `changed`, status `stale`.
5. `git revert` it, re-run — clean, status back to `unverified`.
6. `git checkout --orphan` a branch with no shared history, re-run — `unknown`, non-zero exit, status untouched.

## Checklist

- [x] PR title is in conventional-commit format (`feat:`/`fix:`/`docs:`/`chore:`/`refactor:`)
- [x] `mage check` passes locally
- [x] Updated docs (`AGENTS.md` / `README.md` / `docs/`) if behavior changed — docs land with the skills in PR 2
- [x] Edited `.claude/skills/` (not `internal/skills/data/`) and ran `mage skills`, if skills changed — n/a, no skill changes here

🤖 Generated with [Claude Code](https://claude.com/claude-code)